### PR TITLE
More field validation

### DIFF
--- a/keystatic/local-config.tsx
+++ b/keystatic/local-config.tsx
@@ -215,6 +215,7 @@ export default config({
         favouritePost: fields.relationship({
           label: 'Favourite Post',
           collection: 'posts',
+          validation: { isRequired: true },
         }),
       },
     }),
@@ -229,6 +230,7 @@ export default config({
         someFilepathInPosts: fields.pathReference({
           label: 'Some Filepath in posts',
           pattern: 'posts/**',
+          validation: { isRequired: true },
         }),
       },
     }),

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/date.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/date.tsx
@@ -1,14 +1,57 @@
 import { TextField } from '@voussoir/text-field';
+import { useReducer } from 'react';
 import { BasicFormField } from '../api';
+import { RequiredValidation } from './utils';
 
-export function date({
+function validateDate(
+  validation: { min?: string; max?: string; isRequired?: boolean } | undefined,
+  value: unknown,
+  label: string
+) {
+  if (
+    value !== null &&
+    (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value))
+  ) {
+    return `${label} is not a valid date`;
+  }
+
+  if (validation?.isRequired && value === null) {
+    return `${label} is required`;
+  }
+  if ((validation?.min || validation?.max) && value !== null) {
+    const date = new Date(value);
+    if (validation?.min !== undefined) {
+      const min = new Date(validation.min);
+      if (date < min) {
+        return `${label} must be after ${min.toLocaleDateString()}`;
+      }
+    }
+    if (validation?.max !== undefined) {
+      const max = new Date(validation.max);
+      if (date > max) {
+        return `${label} must be no later than ${max.toLocaleDateString()}`;
+      }
+    }
+  }
+}
+
+export function date<IsRequired extends boolean | undefined>({
   label,
+  defaultValue,
+  validation,
 }: {
   label: string;
-}): BasicFormField<string | null, undefined> {
-  return {
+  defaultValue?: string | { kind: 'today' };
+  validation?: { isRequired?: IsRequired; min?: string; max?: string };
+} & RequiredValidation<IsRequired>): BasicFormField<
+  string | (IsRequired extends true ? never : null),
+  undefined
+> {
+  const field: BasicFormField<string | null, undefined> = {
     kind: 'form',
-    Input({ value, onChange, autoFocus }) {
+    Input({ value, onChange, autoFocus, forceValidation }) {
+      const [blurred, onBlur] = useReducer(() => true, false);
+
       return (
         <TextField
           label={label}
@@ -18,16 +61,32 @@ export function date({
           }}
           autoFocus={autoFocus}
           value={value === null ? '' : value}
+          onBlur={onBlur}
+          errorMessage={
+            blurred || forceValidation
+              ? validateDate(validation, value, label)
+              : undefined
+          }
         />
       );
     },
     options: undefined,
-    defaultValue: null,
+    get defaultValue() {
+      if (defaultValue === undefined) {
+        return null;
+      }
+      if (typeof defaultValue === 'string') {
+        return defaultValue;
+      }
+      const today = new Date();
+      const year = today.getFullYear();
+      const month = String(today.getMonth() + 1).padStart(2, '0');
+      const day = String(today.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    },
     validate(value) {
-      return (
-        value === null ||
-        (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value))
-      );
+      return validateDate(validation, value, label) === undefined;
     },
   };
+  return field as any;
 }

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/integer.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/integer.tsx
@@ -1,46 +1,72 @@
-import { TextField } from '@voussoir/text-field';
-import { useState } from 'react';
+import { useReducer } from 'react';
+import { NumberField } from '@voussoir/number-field';
 import { BasicFormField } from '../api';
+import { RequiredValidation } from './utils';
 
-export function integer({
+function validateInteger(
+  validation: { min?: number; max?: number; isRequired?: boolean } | undefined,
+  value: unknown,
+  label: string
+) {
+  if (
+    value !== null &&
+    (typeof value !== 'number' || !Number.isFinite(value))
+  ) {
+    return `${label} is not a valid whole number`;
+  }
+
+  if (validation?.isRequired && value === null) {
+    return `${label} is required`;
+  }
+  if (value !== null) {
+    if (validation?.min !== undefined && value < validation.min) {
+      return `${label} must be at least ${validation.min}`;
+    }
+    if (validation?.max !== undefined && value > validation.max) {
+      return `${label} must be at most ${validation.max}`;
+    }
+  }
+}
+
+export function integer<IsRequired extends boolean | undefined>({
   label,
-  defaultValue = 0,
+  defaultValue,
+  validation,
 }: {
   label: string;
   defaultValue?: number;
-}): BasicFormField<number, undefined> {
+  validation?: { isRequired?: IsRequired; min: number; max: number };
+} & RequiredValidation<IsRequired>): BasicFormField<
+  number | (IsRequired extends true ? never : null),
+  undefined
+> {
   const validate = (value: unknown) => {
     return typeof value === 'number' && Number.isFinite(value);
   };
   return {
     kind: 'form',
     Input({ value, onChange, autoFocus, forceValidation }) {
-      const [blurred, setBlurred] = useState(false);
-      const [inputValue, setInputValue] = useState(String(value));
-      const showValidation = forceValidation || (blurred && !validate(value));
+      const [blurred, onBlur] = useReducer(() => true, false);
 
       return (
-        <TextField
+        <NumberField
           label={label}
           errorMessage={
-            showValidation ? 'Please specify an integer' : undefined
+            forceValidation || blurred
+              ? validateInteger(validation, value, label)
+              : undefined
           }
-          onBlur={() => setBlurred(true)}
+          onBlur={onBlur}
           autoFocus={autoFocus}
-          value={inputValue}
-          onChange={raw => {
-            setInputValue(raw);
-            if (/^[+-]?\d+$/.test(raw)) {
-              onChange(Number(raw));
-            } else {
-              onChange(NaN);
-            }
+          value={value === null ? undefined : value}
+          onChange={val => {
+            onChange((val === undefined ? null : val) as any);
           }}
         />
       );
     },
     options: undefined,
-    defaultValue,
+    defaultValue: (defaultValue ?? null) as number,
     validate,
   };
 }

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/pathReference.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/pathReference.tsx
@@ -1,7 +1,7 @@
 import { Item } from '@react-stately/collections';
 import { Combobox } from '@voussoir/combobox';
 import { filter } from 'minimatch';
-import { useMemo, useReducer } from 'react';
+import { useEffect, useMemo, useReducer, useState } from 'react';
 import { useTree } from '../../../app/shell/data';
 import { BasicFormField } from '../api';
 import { RequiredValidation } from './utils';
@@ -30,6 +30,20 @@ export function pathReference<IsRequired extends boolean | undefined>({
         return files.filter(val => match(val.path));
       }, [tree]);
 
+      const _errorMessage =
+        (forceValidation || blurred) && validation?.isRequired && value === null
+          ? `${label} is required`
+          : undefined;
+      // this state & effect shouldn't really exist
+      // it's here because react-aria/stately calls onSelectionChange with null
+      // after selecting an item if we immediately remove the error message
+      // so we delay it with an effect
+      const [errorMessage, setErrorMessage] = useState(_errorMessage);
+
+      useEffect(() => {
+        setErrorMessage(_errorMessage);
+      }, [_errorMessage]);
+
       return (
         <Combobox
           label={label}
@@ -40,13 +54,7 @@ export function pathReference<IsRequired extends boolean | undefined>({
             }
           }}
           onBlur={onBlur}
-          errorMessage={
-            (forceValidation || blurred) &&
-            validation?.isRequired &&
-            value === null
-              ? `${label} is required`
-              : undefined
-          }
+          errorMessage={errorMessage}
           autoFocus={autoFocus}
           defaultItems={options}
           width="auto"

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/relationship.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/relationship.tsx
@@ -1,6 +1,6 @@
 import { Item } from '@react-stately/collections';
 import { Combobox } from '@voussoir/combobox';
-import { useMemo, useReducer } from 'react';
+import { useEffect, useMemo, useReducer, useState } from 'react';
 import { useSlugsInCollection } from '../../../app/useSlugsInCollection';
 import { BasicFormField } from '../api';
 import { RequiredValidation } from './utils';
@@ -25,6 +25,20 @@ export function relationship<IsRequired extends boolean | undefined>({
       const options = useMemo(() => {
         return slugs.map(slug => ({ slug }));
       }, [slugs]);
+
+      const _errorMessage =
+        (forceValidation || blurred) && validation?.isRequired && value === null
+          ? `${label} is required`
+          : undefined;
+      // this state & effect shouldn't really exist
+      // it's here because react-aria/stately calls onSelectionChange with null
+      // after selecting an item if we immediately remove the error message
+      // so we delay it with an effect
+      const [errorMessage, setErrorMessage] = useState(_errorMessage);
+      useEffect(() => {
+        setErrorMessage(_errorMessage);
+      }, [_errorMessage]);
+
       return (
         <Combobox
           label={label}
@@ -37,13 +51,7 @@ export function relationship<IsRequired extends boolean | undefined>({
           onBlur={onBlur}
           autoFocus={autoFocus}
           defaultItems={options}
-          errorMessage={
-            (forceValidation || blurred) &&
-            validation?.isRequired &&
-            value === null
-              ? `${label} is required`
-              : undefined
-          }
+          errorMessage={errorMessage}
           width="auto"
         >
           {item => <Item key={item.slug}>{item.slug}</Item>}

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/utils.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/utils.tsx
@@ -1,0 +1,2 @@
+export type RequiredValidation<IsRequired extends boolean | undefined> =
+  IsRequired extends true ? { validation: { isRequired: true } } : unknown;

--- a/packages/keystatic/reader.test.tsx
+++ b/packages/keystatic/reader.test.tsx
@@ -14,7 +14,9 @@ const localConfig = config({
       slugField: 'title',
       schema: {
         title: fields.slug({ name: { label: 'Title' } }),
-        publishDate: fields.date({ label: 'Publish Date' }),
+        publishDate: fields.date({
+          label: 'Publish Date',
+        }),
         heroImage: fields.image({ label: 'Hero Image' }),
         content: fields.document({
           label: 'Content',


### PR DESCRIPTION
This adds `validation.isRequired` to the following fields (all other fields can never be null):
- `relationship`
- `pathReference`
- `integer`
- `date`
- `image`
- `url`

When you specify `validation.isRequired`, the types from the reader API will reflect that they can never be null.
This also adds `validation.min` and `validation.max` to `integer` and `date.
