### PR TITLE
Refactor overlays

### DIFF
--- a/.changeset/sharp-cats-learn.md
+++ b/.changeset/sharp-cats-learn.md
@@ -1,0 +1,6 @@
+---
+'@voussoir/overlays': patch
+'@voussoir/tooltip': patch
+---
+
+Provide `nodeRef` to overlays. Fixes `findDOMNode` errors in StrictMode.

--- a/.changeset/sharp-cats-learn.md
+++ b/.changeset/sharp-cats-learn.md
@@ -3,4 +3,5 @@
 '@voussoir/tooltip': patch
 ---
 
-Provide `nodeRef` to overlays. Fixes `findDOMNode` errors in StrictMode.
+Provide `nodeRef` to overlays (react-transition-group). Fixes `findDOMNode`
+errors in StrictMode.

--- a/design-system/packages/overlays/package.json
+++ b/design-system/packages/overlays/package.json
@@ -36,6 +36,7 @@
     "@types/react-transition-group": "^4.4.5",
     "@voussoir/button": "^0.1.0",
     "@voussoir/storybook": "^0.0.0",
+    "@voussoir/test-utils": "^2.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/design-system/packages/overlays/src/Overlay.tsx
+++ b/design-system/packages/overlays/src/Overlay.tsx
@@ -18,6 +18,7 @@ export const Overlay = forwardRef(function Overlay(
     children,
     isOpen,
     container,
+    nodeRef,
     onEnter,
     onEntering,
     onEntered,
@@ -56,14 +57,15 @@ export const Overlay = forwardRef(function Overlay(
         isDisabled={false}
       >
         <OpenTransition
-          in={isOpen}
           appear
-          onExit={onExit}
-          onExiting={onExiting}
-          onExited={handleExited}
+          in={isOpen}
+          nodeRef={nodeRef}
           onEnter={onEnter}
-          onEntering={onEntering}
           onEntered={handleEntered}
+          onEntering={onEntering}
+          onExit={onExit}
+          onExited={handleExited}
+          onExiting={onExiting}
         >
           {children}
         </OpenTransition>

--- a/design-system/packages/overlays/src/types.ts
+++ b/design-system/packages/overlays/src/types.ts
@@ -31,7 +31,7 @@ export type ModalProps = {
   type?: 'modal' | 'fullscreen';
 } & AriaModalOverlayProps &
   BaseStyleProps &
-  OverlayProps;
+  Omit<OverlayProps, 'nodeRef'>;
 
 // Tray
 // -----------------------------------------------------------------------------
@@ -42,4 +42,4 @@ export type TrayProps = {
   isFixedHeight?: boolean;
 } & AriaModalOverlayProps &
   BaseStyleProps &
-  OverlayProps;
+  Omit<OverlayProps, 'nodeRef'>;

--- a/design-system/packages/overlays/stories/Popover.stories.tsx
+++ b/design-system/packages/overlays/stories/Popover.stories.tsx
@@ -3,7 +3,7 @@ import { useOverlayTrigger } from '@react-aria/overlays';
 import { useOverlayTriggerState } from '@react-stately/overlays';
 import { ArgTypes, storiesOf } from '@voussoir/storybook';
 
-import { Button } from '@voussoir/button';
+import { ActionButton } from '@voussoir/button';
 import { Box, Flex } from '@voussoir/layout';
 import { Text } from '@voussoir/typography';
 
@@ -21,9 +21,9 @@ storiesOf('Components/Popover', module)
 
     return (
       <>
-        <Button {...triggerProps} ref={triggerRef}>
+        <ActionButton {...triggerProps} ref={triggerRef}>
           Always open
-        </Button>
+        </ActionButton>
         <Popover {...overlayProps} triggerRef={triggerRef} state={state}>
           <Box padding="xlarge" width={320} maxWidth="100%">
             <Text>
@@ -51,9 +51,9 @@ storiesOf('Components/Popover', module)
 
       return (
         <Flex direction="column" gap="regular">
-          <Button {...triggerProps} ref={targetRef}>
+          <ActionButton {...triggerProps} ref={targetRef}>
             Toggle
-          </Button>
+          </ActionButton>
           <Popover
             triggerRef={targetRef}
             state={state}

--- a/design-system/packages/overlays/test/Overlay.test.tsx
+++ b/design-system/packages/overlays/test/Overlay.test.tsx
@@ -1,40 +1,26 @@
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
-import { TestProvider } from '@voussoir/core';
-import { createRef } from 'react';
+import { createRef, ForwardedRef, forwardRef, useRef } from 'react';
 
-import { Overlay } from '../src';
+import { renderWithProvider } from '@voussoir/test-utils';
+
+import { Overlay, OverlayProps } from '../src';
 
 describe('overlays/Overlay', () => {
   it('should render nothing if isOpen is not set', () => {
-    const { queryByTestId } = render(
-      <Overlay>
-        <ExampleOverlay />
-      </Overlay>,
-      { wrapper: TestProvider }
-    );
+    const { queryByTestId } = renderWithProvider(<ExampleOverlay />);
 
     expect(queryByTestId(testID)).toBe(null);
   });
 
   it('should render children when isOpen is set', () => {
-    const { getByTestId } = render(
-      <Overlay isOpen>
-        <ExampleOverlay />
-      </Overlay>,
-      { wrapper: TestProvider }
-    );
+    const { getByTestId } = renderWithProvider(<ExampleOverlay isOpen />);
 
     expect(getByTestId(testID)).toBeTruthy();
   });
 
   it('should render into a portal in the body', async () => {
     const overlayRef = createRef<HTMLDivElement>();
-    render(
-      <Overlay isOpen ref={overlayRef}>
-        <ExampleOverlay />
-      </Overlay>
-    );
+    renderWithProvider(<ExampleOverlay isOpen ref={overlayRef} />);
 
     const overlayNode = overlayRef.current;
     expect(overlayNode?.parentNode).toBe(document.body);
@@ -43,6 +29,17 @@ describe('overlays/Overlay', () => {
 
 const testID = 'overlay-content';
 
-function ExampleOverlay() {
-  return <span data-testid={testID}>Overlay content</span>;
-}
+const ExampleOverlay = forwardRef(function ExampleOverlay(
+  props: Partial<OverlayProps>,
+  ref: ForwardedRef<HTMLDivElement>
+) {
+  let nodeRef = useRef<HTMLDivElement>(null);
+  return (
+    /* @ts-expect-error FIXME: resolve ref inconsistencies */
+    <Overlay {...props} ref={ref} nodeRef={nodeRef}>
+      <span data-testid={testID} ref={nodeRef}>
+        Overlay content
+      </span>
+    </Overlay>
+  );
+});

--- a/design-system/packages/tooltip/src/Tooltip.tsx
+++ b/design-system/packages/tooltip/src/Tooltip.tsx
@@ -1,5 +1,5 @@
 import { useTooltip } from '@react-aria/tooltip';
-import { mergeProps, useObjectRef } from '@react-aria/utils';
+import { mergeProps, mergeRefs, useObjectRef } from '@react-aria/utils';
 import {
   ForwardedRef,
   forwardRef,
@@ -42,6 +42,7 @@ export const Tooltip: ForwardRefExoticComponent<
   let {
     state,
     targetRef: triggerRef,
+    overlayRef: tooltipRef,
     crossOffset,
     offset,
     ...contextualProps
@@ -55,7 +56,9 @@ export const Tooltip: ForwardRefExoticComponent<
   let styleProps = useStyleProps(otherProps);
 
   let ref = useRef<HTMLDivElement>(null);
-  let overlayRef = useObjectRef(forwardedRef); // for testing etc. tooltips may be rendered w/o a trigger
+  let overlayRef = useObjectRef(
+    tooltipRef ? mergeRefs(tooltipRef, forwardedRef) : forwardedRef
+  ); // for testing etc. tooltips may be rendered w/o a trigger
   let targetRef = triggerRef ?? ref; // for testing etc. tooltips may be rendered w/o a trigger
 
   let slots = useMemo(

--- a/design-system/packages/tooltip/src/TooltipTrigger.tsx
+++ b/design-system/packages/tooltip/src/TooltipTrigger.tsx
@@ -14,6 +14,8 @@ function TooltipTrigger(props: TooltipTriggerProps) {
   let { children, isDisabled, trigger: triggerMode, ...otherProps } = props;
 
   let targetRef = useRef<HTMLElement>(null);
+  let overlayRef = useRef<HTMLDivElement>(null);
+
   let state = useTooltipTriggerState({
     isDisabled,
     delay: MOUSE_REST_TIMEOUT,
@@ -33,13 +35,17 @@ function TooltipTrigger(props: TooltipTriggerProps) {
       {triggerElement}
       <TooltipContext.Provider
         value={{
+          overlayRef,
           targetRef,
           state,
           ...otherProps,
           ...tooltipProps,
         }}
       >
-        <Overlay isOpen={state.isOpen}>{tooltipElement}</Overlay>
+        {/* @ts-expect-error FIXME: resolve ref inconsistencies */}
+        <Overlay isOpen={state.isOpen} nodeRef={overlayRef}>
+          {tooltipElement}
+        </Overlay>
       </TooltipContext.Provider>
     </FocusableProvider>
   );

--- a/design-system/packages/tooltip/src/context.ts
+++ b/design-system/packages/tooltip/src/context.ts
@@ -6,6 +6,7 @@ import { RootStyleProps } from '@voussoir/style';
 
 type TooltipContextProps = {
   state?: TooltipTriggerState;
+  overlayRef?: RefObject<HTMLDivElement>;
   targetRef?: RefObject<HTMLElement>;
   arrowProps?: HTMLAttributes<HTMLElement>;
 } & PositionProps &

--- a/design-system/packages/tooltip/stories/TooltipTrigger.stories.tsx
+++ b/design-system/packages/tooltip/stories/TooltipTrigger.stories.tsx
@@ -1,6 +1,6 @@
 import { action, ArgTypes, storiesOf } from '@voussoir/storybook';
 
-import { Button } from '@voussoir/button';
+import { Button, ActionButton } from '@voussoir/button';
 import { Flex } from '@voussoir/layout';
 import { TextLink } from '@voussoir/link';
 import { Text } from '@voussoir/typography';
@@ -89,7 +89,7 @@ storiesOf('Components/TooltipTrigger', module)
   })
   .add('trigger disabled', () => (
     <TooltipTrigger>
-      <Button isDisabled>Trigger</Button>
+      <ActionButton isDisabled>Trigger</ActionButton>
       <Tooltip>Tooltip content</Tooltip>
     </TooltipTrigger>
   ))
@@ -114,7 +114,7 @@ storiesOf('Components/TooltipTrigger', module)
     <Flex gap="regular">
       {['one', 'two', 'three'].map(n => (
         <TooltipTrigger key={n}>
-          <Button>{n}</Button>
+          <ActionButton>{n}</ActionButton>
           <Tooltip>Tooltip content</Tooltip>
         </TooltipTrigger>
       ))}
@@ -123,11 +123,11 @@ storiesOf('Components/TooltipTrigger', module)
   .add('collisions', () => (
     <Flex direction="column" gap="large" alignSelf="start">
       <TooltipTrigger placement="start">
-        <Button>Flip</Button>
+        <ActionButton>Flip</ActionButton>
         <Tooltip>Tooltip content</Tooltip>
       </TooltipTrigger>
       <TooltipTrigger>
-        <Button>Offset</Button>
+        <ActionButton>Offset</ActionButton>
         <Tooltip>Tooltip content</Tooltip>
       </TooltipTrigger>
     </Flex>
@@ -141,7 +141,7 @@ function renderTooltip(props: Partial<TooltipTriggerProps> = {}) {
         {...props}
         {...args}
       >
-        <Button>Trigger</Button>
+        <ActionButton>Trigger</ActionButton>
         <Tooltip>Tooltip content</Tooltip>
       </TooltipTrigger>
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1298,6 +1298,7 @@ importers:
       '@voussoir/slots': ^0.1.0
       '@voussoir/storybook': ^0.0.0
       '@voussoir/style': ^0.1.0
+      '@voussoir/test-utils': ^2.0.0
       '@voussoir/types': ^0.1.0
       '@voussoir/typography': ^0.1.0
       '@voussoir/utils': ^2.0.0
@@ -1324,6 +1325,7 @@ importers:
       '@types/react-transition-group': 4.4.5
       '@voussoir/button': link:../button
       '@voussoir/storybook': link:../../docs/storybook
+      '@voussoir/test-utils': link:../test-utils
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1307,10 +1307,10 @@ importers:
     dependencies:
       '@babel/runtime': 7.21.0
       '@react-aria/i18n': 3.6.3_react@18.2.0
-      '@react-aria/overlays': 3.12.1_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/overlays': 3.13.0_biqbaboplfbrettd7655fr4n2y
       '@react-aria/utils': 3.14.2_react@18.2.0
-      '@react-stately/overlays': 3.4.4_react@18.2.0
-      '@react-types/overlays': 3.6.5_react@18.2.0
+      '@react-stately/overlays': 3.5.0_react@18.2.0
+      '@react-types/overlays': 3.7.0_react@18.2.0
       '@voussoir/core': link:../core
       '@voussoir/layout': link:../layout
       '@voussoir/slots': link:../slots
@@ -4763,7 +4763,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.6.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /@graphql-tools/relay-operation-optimizer/6.5.17_graphql@16.6.0:
@@ -4774,7 +4774,7 @@ packages:
       '@ardatan/relay-compiler': 12.0.0_graphql@16.6.0
       '@graphql-tools/utils': 9.2.1_graphql@16.6.0
       graphql: 16.6.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -4786,7 +4786,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.6.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /@graphql-tools/utils/9.2.1_graphql@16.6.0:
@@ -4796,7 +4796,7 @@ packages:
     dependencies:
       '@graphql-typed-document-node/core': 3.1.1_graphql@16.6.0
       graphql: 16.6.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /@graphql-typed-document-node/core/3.1.1_graphql@16.6.0:
@@ -5962,6 +5962,27 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
+  /@react-aria/overlays/3.13.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-hRZyhAYzrlCcEWQ2k2jP24b0wc5/355Xl5w5FZHRmPeU1U4XlFwKX/eFlBs/li9Sprm1bTDXrCY480Kl6UsKDA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-aria/focus': 3.11.0_react@18.2.0
+      '@react-aria/i18n': 3.7.0_react@18.2.0
+      '@react-aria/interactions': 3.14.0_react@18.2.0
+      '@react-aria/ssr': 3.5.0_react@18.2.0
+      '@react-aria/utils': 3.15.0_react@18.2.0
+      '@react-aria/visually-hidden': 3.7.0_react@18.2.0
+      '@react-stately/overlays': 3.5.0_react@18.2.0
+      '@react-types/button': 3.7.1_react@18.2.0
+      '@react-types/overlays': 3.7.0_react@18.2.0
+      '@react-types/shared': 3.17.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
   /@react-aria/progress/3.3.4_react@18.2.0:
     resolution: {integrity: sha512-MVlWdH7L2e0u1SvkVk+C6/onS8opex9rIKUKHM08s++y80Xe3BIAh8jd5tgdlutDtcZ1kKgfb4bet9dvjymo4A==}
     peerDependencies:
@@ -6237,6 +6258,19 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@react-aria/visually-hidden/3.7.0_react@18.2.0:
+    resolution: {integrity: sha512-v/0ujJ67H6LjwY8J7mIGPVB1K8suBArLV+w8UGdX/wFXRL7H4r2fiqlrwAElWSmNbhDQl5BDm/Zh/ub9jB9yzA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-aria/interactions': 3.14.0_react@18.2.0
+      '@react-aria/utils': 3.15.0_react@18.2.0
+      '@react-types/shared': 3.17.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      clsx: 1.2.1
+      react: 18.2.0
+    dev: false
+
   /@react-stately/checkbox/3.3.2_react@18.2.0:
     resolution: {integrity: sha512-eU3zvWgQrcqS8UK8ZVkb3fMP816PeuN9N0/dOJKuOXXhkoLPuxtuja1oEqKU3sFMa5+bx3czZhhNIRpr60NAdw==}
     peerDependencies:
@@ -6371,6 +6405,17 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@react-stately/overlays/3.5.0_react@18.2.0:
+    resolution: {integrity: sha512-r+U/G0Y4tCfI5wyBeIu+hmcZVRN8ChoK2zM1srPH9nDKsijQard2goX+9YmKng2LJ01Re/P6F8S8jYbpfEdLfQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-stately/utils': 3.6.0_react@18.2.0
+      '@react-types/overlays': 3.7.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      react: 18.2.0
+    dev: false
+
   /@react-stately/radio/3.6.2_react@18.2.0:
     resolution: {integrity: sha512-qjbebR0YSkdEocLsPSzNnCsUYllWY938/5Z8mETxk4+74PJLxC3z0qjqVRq+aDO8hOgIfqSgrRRp3cJz9vIsBg==}
     peerDependencies:
@@ -6417,7 +6462,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-stately/collections': 3.5.1_react@18.2.0
-      '@react-stately/utils': 3.5.2_react@18.2.0
+      '@react-stately/utils': 3.6.0_react@18.2.0
       '@react-types/shared': 3.17.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
@@ -6467,7 +6512,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/overlays': 3.4.4_react@18.2.0
+      '@react-stately/overlays': 3.5.0_react@18.2.0
       '@react-stately/utils': 3.5.2_react@18.2.0
       '@react-types/tooltip': 3.2.5_react@18.2.0
       '@swc/helpers': 0.4.14
@@ -6545,6 +6590,15 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@react-types/button/3.7.1_react@18.2.0:
+    resolution: {integrity: sha512-c+8xjmqWSjI5/mEHVLbVSp0eh/z2UU8Ga+wqjbEUZUjm8uopYj1PaCAwZ7YgcAebyQrL/21GyjK6tFHKzuUdJQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.17.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
   /@react-types/checkbox/3.4.1_react@18.2.0:
     resolution: {integrity: sha512-kDMpy9SntjGQ7x00m5zmW8GENPouOtyiDgiEDKsPXUr2iYqHsNtricqVyG9S9+6hqpzuu8BzTcvZamc/xYjzlg==}
     peerDependencies:
@@ -6568,7 +6622,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/overlays': 3.6.5_react@18.2.0
+      '@react-types/overlays': 3.7.0_react@18.2.0
       '@react-types/shared': 3.17.0_react@18.2.0
       react: 18.2.0
     dev: false
@@ -6651,6 +6705,15 @@ packages:
 
   /@react-types/overlays/3.6.5_react@18.2.0:
     resolution: {integrity: sha512-IeWcF+YTucCYYHagNh8fZLH6R4YUONO1VHY57WJyIHwMy0qgEaKSQCwq72VO1fQJ0ySZgOgm31FniOyKkg6+eQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.17.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/overlays/3.7.0_react@18.2.0:
+    resolution: {integrity: sha512-LstucncZ8dM+xJYEijI1V6jGH20w5XO/T60r7JTrgQElMC86phPeoWkMTN4c2lsRikybolDbvXL6XsF76YO56A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -6753,7 +6816,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/overlays': 3.6.5_react@18.2.0
+      '@react-types/overlays': 3.7.0_react@18.2.0
       '@react-types/shared': 3.17.0_react@18.2.0
       react: 18.2.0
     dev: false
@@ -10835,7 +10898,7 @@ packages:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       upper-case-first: 2.0.2
     dev: true
 
@@ -10920,7 +10983,7 @@ packages:
       path-case: 3.0.4
       sentence-case: 3.0.4
       snake-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /char-regex/1.0.2:
@@ -11334,7 +11397,7 @@ packages:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       upper-case: 2.0.2
     dev: true
 
@@ -14705,7 +14768,7 @@ packages:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
     dependencies:
       capital-case: 1.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /history/5.3.0:
@@ -15482,7 +15545,7 @@ packages:
   /is-lower-case/2.0.2:
     resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /is-map/2.0.2:
@@ -15658,7 +15721,7 @@ packages:
   /is-upper-case/2.0.2:
     resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /is-utf8/0.2.1:
@@ -16664,13 +16727,13 @@ packages:
   /lower-case-first/2.0.2:
     resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /lower-case/2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /lowercase-keys/1.0.1:
@@ -17986,7 +18049,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /node-addon-api/1.7.2:
@@ -18714,7 +18777,7 @@ packages:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /path-dirname/1.0.2:
@@ -20546,7 +20609,7 @@ packages:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       upper-case-first: 2.0.2
     dev: true
 
@@ -20788,7 +20851,7 @@ packages:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /snapdragon-node/2.1.1:
@@ -21008,7 +21071,7 @@ packages:
   /sponge-case/1.0.1:
     resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /sprintf-js/1.0.3:
@@ -21447,7 +21510,7 @@ packages:
   /swap-case/2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /symbol-tree/3.2.4:
@@ -21690,7 +21753,7 @@ packages:
   /title-case/3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /tmp/0.0.33:
@@ -22253,13 +22316,13 @@ packages:
   /upper-case-first/2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /upper-case/2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /uri-js/4.4.1:


### PR DESCRIPTION
Resolves #120

Provide `nodeRef` to overlay components. Fixes `findDOMNode` errors in StrictMode.

[Discussion on react-transition-group](https://github.com/reactjs/react-transition-group/issues/668).