### PR TITLE
Allow having data files outside of their entry directories

### DIFF
--- a/.changeset/dry-feet-report.md
+++ b/.changeset/dry-feet-report.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Rename `format.frontmatter` to `format.data` and make it optional

--- a/.changeset/polite-falcons-drum.md
+++ b/.changeset/polite-falcons-drum.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Add `format.location` option

--- a/apps/next-pages-dir/local-config.tsx
+++ b/apps/next-pages-dir/local-config.tsx
@@ -266,7 +266,7 @@ export default config({
       label: 'Single File Posts',
       directory: 'single-file-posts',
       slugField: 'slug',
-      format: { contentField: 'content', frontmatter: 'yaml' },
+      format: { contentField: 'content' },
       schema: {
         title: fields.text({ label: 'Title' }),
         slug: fields.text({ label: 'Slug' }),

--- a/apps/remix/local-config.tsx
+++ b/apps/remix/local-config.tsx
@@ -62,7 +62,7 @@ export default config({
       label: 'Single File Posts',
       directory: 'single-file-posts',
       slugField: 'slug',
-      format: { contentField: 'content', frontmatter: 'yaml' },
+      format: { contentField: 'content' },
       schema: {
         title: fields.text({ label: 'Title' }),
         slug: fields.text({ label: 'Slug' }),

--- a/keystatic/local-config.tsx
+++ b/keystatic/local-config.tsx
@@ -238,7 +238,7 @@ export default config({
       label: 'Single File Posts',
       directory: 'single-file-posts',
       slugField: 'title',
-      format: { contentField: 'content', frontmatter: 'yaml' },
+      format: { contentField: 'content', location: 'outside' },
       schema: {
         title: fields.slug({ name: { label: 'Title' } }),
         content: fields.document({

--- a/packages/keystatic/app/required-files.ts
+++ b/packages/keystatic/app/required-files.ts
@@ -223,21 +223,19 @@ function splitFrontmatter(data: Uint8Array) {
 }
 
 export function loadDataFile(data: Uint8Array, formatInfo: FormatInfo) {
-  if (typeof formatInfo === 'string') {
+  const parse = formatInfo.data === 'json' ? JSON.parse : load;
+  if (!formatInfo.contentField) {
     const dataFile = textDecoder.decode(data);
     return {
-      loaded: formatInfo === 'json' ? JSON.parse(dataFile) : load(dataFile),
+      loaded: parse(dataFile),
     };
   }
   const res = splitFrontmatter(data);
   assert(res !== null, 'frontmatter not found');
   return {
-    loaded:
-      formatInfo.frontmatter === 'json'
-        ? JSON.parse(res.frontmatter)
-        : load(res.frontmatter),
+    loaded: parse(res.frontmatter),
     extraFakeFile: {
-      path: `${formatInfo.contentFieldKey}${formatInfo.contentFieldConfig.serializeToFile.primaryExtension}`,
+      path: `${formatInfo.contentField.key}${formatInfo.contentField.config.serializeToFile.primaryExtension}`,
       contents: res.content,
     },
   };

--- a/packages/keystatic/app/tree-key.tsx
+++ b/packages/keystatic/app/tree-key.tsx
@@ -1,6 +1,6 @@
 import { assertNever } from '../DocumentEditor/component-blocks/utils';
 import { ComponentSchema } from '../src';
-import { fixPath } from './path-utils';
+import { fixPath, FormatInfo, getDataFileExtension } from './path-utils';
 import { getTreeNodeAtPath, TreeNode } from './trees';
 
 function collectDirectoriesUsedInSchemaInner(
@@ -71,9 +71,13 @@ export function collectDirectoriesUsedInSchema(
 export function getDirectoriesForTreeKey(
   schema: ComponentSchema,
   directory: string,
-  slug: string | undefined
+  slug: string | undefined,
+  format: FormatInfo
 ) {
   const directories = [fixPath(directory)];
+  if (format.dataLocation === 'outer') {
+    directories.push(fixPath(directory) + getDataFileExtension(format));
+  }
   const toAdd = slug === undefined ? '' : `/${slug}`;
   for (const directory of collectDirectoriesUsedInSchema(schema)) {
     directories.push(directory + toAdd);

--- a/packages/keystatic/app/useSlugsInCollection.ts
+++ b/packages/keystatic/app/useSlugsInCollection.ts
@@ -1,13 +1,7 @@
 import { useMemo } from 'react';
-import {
-  getCollectionPath,
-  getDataFileExtension,
-  getCollectionFormat,
-} from './path-utils';
 import { useConfig } from './shell';
 import { useTree } from './shell/data';
-import { getTreeNodeAtPath } from './trees';
-import { getTreeNodeForItem } from './utils';
+import { getEntriesInCollectionWithTreeKey } from './utils';
 
 export function useSlugsInCollection(collection: string) {
   const config = useConfig();
@@ -15,20 +9,10 @@ export function useSlugsInCollection(collection: string) {
 
   return useMemo(() => {
     const loadedTree = tree.kind === 'loaded' ? tree.data.tree : new Map();
-    const treeNode = getTreeNodeAtPath(
-      loadedTree,
-      getCollectionPath(config, collection)
-    );
-    if (!treeNode?.children) return [];
-    const extension = getDataFileExtension(
-      getCollectionFormat(config, collection)
-    );
-    return [...treeNode.children].flatMap(([, entry]) =>
-      getTreeNodeForItem(config, collection, entry)?.children?.has(
-        `index${extension}`
-      )
-        ? [entry.entry.path.replace(/^.+\/([^/]+)$/, '$1')]
-        : []
-    );
+    return getEntriesInCollectionWithTreeKey(
+      config,
+      collection,
+      loadedTree
+    ).map(x => x.slug);
   }, [config, tree, collection]);
 }

--- a/packages/keystatic/config.tsx
+++ b/packages/keystatic/config.tsx
@@ -6,7 +6,11 @@ import {
 export type DataFormat = 'json' | 'yaml';
 export type Format =
   | DataFormat
-  | { frontmatter: DataFormat; contentField: string };
+  | {
+      data?: DataFormat;
+      contentField?: string;
+      location?: 'index' | 'outside';
+    };
 
 export type Collection<
   Schema extends Record<string, ComponentSchema>,

--- a/packages/keystatic/src/api/read-local.ts
+++ b/packages/keystatic/src/api/read-local.ts
@@ -1,6 +1,10 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { getCollectionPath, getSingletonPath } from '../../app/path-utils';
+import {
+  getCollectionPath,
+  getSingletonFormat,
+  getSingletonPath,
+} from '../../app/path-utils';
 import { updateTreeWithChanges, blobSha } from './trees-server-side';
 import { Config } from '../../config';
 import { getDirectoriesForTreeKey } from '../../app/tree-key';
@@ -85,7 +89,8 @@ export function getAllowedDirectories(config: Config) {
       ...getDirectoriesForTreeKey(
         fields.object(collectionConfig.schema),
         getCollectionPath(config, collection),
-        undefined
+        undefined,
+        { data: 'yaml', contentField: undefined, dataLocation: 'index' }
       )
     );
   }
@@ -96,7 +101,8 @@ export function getAllowedDirectories(config: Config) {
       ...getDirectoriesForTreeKey(
         fields.object(singletonConfig.schema),
         getSingletonPath(config, singleton),
-        undefined
+        undefined,
+        getSingletonFormat(config, singleton)
       )
     );
   }


### PR DESCRIPTION
This allows having files like  `collection/slug.{yaml,json,mdoc}` instead of `collection/slug/index.{yaml,json,mdoc}` which is especially nice when you don't have any other files which would be in the directory.