### PR TITLE
Path option

### DIFF
--- a/.changeset/eighty-knives-sort.md
+++ b/.changeset/eighty-knives-sort.md
@@ -1,0 +1,6 @@
+---
+'@keystatic/core': patch
+---
+
+Replace `directory`, `directorySuffix` and `format.location` options with `path`
+option

--- a/apps/astro/keystatic.config.tsx
+++ b/apps/astro/keystatic.config.tsx
@@ -34,7 +34,7 @@ export default config({
     }),
     people: collection({
       label: 'People',
-      directory: 'some/directory/people',
+      path: 'some/directory/people/*/',
       slugField: 'username',
       schema: {
         name: fields.text({ label: 'Name' }),
@@ -46,7 +46,7 @@ export default config({
     }),
     packages: collection({
       label: 'Packages',
-      directorySuffix: 'somewhere/else',
+      path: 'packages/*/somewhere/else/',
       slugField: 'name',
       format: 'json',
       schema: {

--- a/apps/localization/src/config.ts
+++ b/apps/localization/src/config.ts
@@ -41,7 +41,7 @@ const localeCollections = Object.fromEntries(
   Object.entries(locales).map(([key, label]) => [
     key,
     collection({
-      directory: `packages/keystatic/app/l10n/${key}`,
+      path: `packages/keystatic/app/l10n/${key}/*/`,
       format: 'json',
       label,
       slugField: 'key',

--- a/apps/next-pages-dir/local-config.tsx
+++ b/apps/next-pages-dir/local-config.tsx
@@ -243,7 +243,7 @@ export default config({
     }),
     people: collection({
       label: 'People',
-      directory: 'some/directory/people',
+      path: 'some/directory/people/*/',
       slugField: 'username',
       schema: {
         name: fields.text({ label: 'Name' }),
@@ -255,7 +255,7 @@ export default config({
     }),
     packages: collection({
       label: 'Packages',
-      directorySuffix: 'somewhere/else',
+      path: 'packages/*/somewhere/else/',
       slugField: 'name',
       format: 'json',
       schema: {
@@ -264,7 +264,7 @@ export default config({
     }),
     singlefileposts: collection({
       label: 'Single File Posts',
-      directory: 'single-file-posts',
+      path: 'single-file-posts/*/',
       slugField: 'slug',
       format: { contentField: 'content' },
       schema: {

--- a/apps/remix/local-config.tsx
+++ b/apps/remix/local-config.tsx
@@ -39,7 +39,7 @@ export default config({
     }),
     people: collection({
       label: 'People',
-      directory: 'some/directory/people',
+      path: 'some/directory/people/*/',
       slugField: 'username',
       schema: {
         name: fields.text({ label: 'Name' }),
@@ -51,7 +51,7 @@ export default config({
     }),
     packages: collection({
       label: 'Packages',
-      directorySuffix: 'somewhere/else',
+      path: 'packages/*/somewhere/else/',
       slugField: 'name',
       format: 'json',
       schema: {
@@ -60,7 +60,7 @@ export default config({
     }),
     singlefileposts: collection({
       label: 'Single File Posts',
-      directory: 'single-file-posts',
+      path: 'single-file-posts/*/',
       slugField: 'slug',
       format: { contentField: 'content' },
       schema: {

--- a/keystatic/local-config.tsx
+++ b/keystatic/local-config.tsx
@@ -204,7 +204,7 @@ export default config({
     }),
     people: collection({
       label: 'People',
-      directory: 'some/directory/people',
+      path: 'some/directory/people/*/',
       slugField: 'username',
       schema: {
         name: fields.text({ label: 'Name' }),
@@ -221,7 +221,7 @@ export default config({
     }),
     packages: collection({
       label: 'Packages',
-      directorySuffix: 'somewhere/else',
+      path: 'packages/*/somewhere/else/',
       slugField: 'name',
       format: 'json',
       schema: {
@@ -236,9 +236,9 @@ export default config({
     }),
     singlefileposts: collection({
       label: 'Single File Posts',
-      directory: 'single-file-posts',
+      path: 'single-file-posts/*/something',
       slugField: 'title',
-      format: { contentField: 'content', location: 'outside' },
+      format: { contentField: 'content' },
       schema: {
         title: fields.slug({ name: { label: 'Title' } }),
         content: fields.document({

--- a/packages/keystatic/config.tsx
+++ b/packages/keystatic/config.tsx
@@ -4,21 +4,14 @@ import {
 } from './DocumentEditor/component-blocks/api';
 
 export type DataFormat = 'json' | 'yaml';
-export type Format =
-  | DataFormat
-  | {
-      data?: DataFormat;
-      contentField?: string;
-      location?: 'index' | 'outside';
-    };
+export type Format = DataFormat | { data?: DataFormat; contentField?: string };
 
 export type Collection<
   Schema extends Record<string, ComponentSchema>,
   SlugField extends string
 > = {
   label: string;
-  directory?: string;
-  directorySuffix?: string;
+  path?: `${string}/*` | `${string}/*/${string}`;
   format?: Format;
   slugField: SlugField;
   schema: Schema;
@@ -26,7 +19,7 @@ export type Collection<
 
 export type Singleton<Schema extends Record<string, ComponentSchema>> = {
   label: string;
-  directory?: string;
+  path?: string;
   format?: Format;
   schema: Schema;
 };


### PR DESCRIPTION
This replaces the `directory`, `directorySuffix` and `format.location` options with a new `path` option that's less confusing.

- In collections, `path` must include a `*` which indicates where in the path the slug should go (the default is `collection-name/*/`)
- in singletons, `path` must not include a `*` (the default is `singleton-name/`)
- if the path ends with a trailing slash, the structure will look like this:
  - `something`
    - `slug`
      - `index.yaml`
      - `other.mdoc`
- if the path doesn't end in a trailing slash, the structure will look like this:
  - `something`
    - `slug.yaml`
    - `slug`
      - `other.mdoc`