### PR TITLE
Fix conditional storage

### DIFF
--- a/.changeset/unlucky-jars-divide.md
+++ b/.changeset/unlucky-jars-divide.md
@@ -1,0 +1,6 @@
+---
+'@keystatic/core': patch
+---
+
+Fix conditionally changing the `storage` field in a config creating a TypeScript
+error

--- a/packages/keystatic/app/shell/index.tsx
+++ b/packages/keystatic/app/shell/index.tsx
@@ -19,7 +19,7 @@ import {
   LocalAppShellProvider,
 } from './data';
 import { SidebarProvider, Sidebar, SIDEBAR_WIDTH } from './sidebar';
-import { isGitHubConfig } from '../utils';
+import { isGitHubConfig, isLocalConfig } from '../utils';
 
 const ConfigContext = createContext<Config | null>(null);
 export function useConfig(): Config {
@@ -75,9 +75,14 @@ export const AppShell = (props: {
       </GitHubAppShellProvider>
     );
   }
-  return (
-    <LocalAppShellProvider config={props.config}>{inner}</LocalAppShellProvider>
-  );
+  if (isLocalConfig(props.config)) {
+    return (
+      <LocalAppShellProvider config={props.config}>
+        {inner}
+      </LocalAppShellProvider>
+    );
+  }
+  return null;
 };
 
 // Styled components

--- a/packages/keystatic/app/utils.ts
+++ b/packages/keystatic/app/utils.ts
@@ -1,6 +1,6 @@
 import { isDefined } from 'emery';
 
-import { Config, GitHubConfig } from '../config';
+import { Config, GitHubConfig, LocalConfig } from '../config';
 import { ComponentSchema, fields, SlugFormField } from '../src';
 import {
   getCollectionFormat,
@@ -55,6 +55,10 @@ export function blobSha(contents: Uint8Array) {
 
 export function isGitHubConfig(config: Config): config is GitHubConfig {
   return config.storage.kind === 'github';
+}
+
+export function isLocalConfig(config: Config): config is LocalConfig {
+  return config.storage.kind === 'local';
 }
 
 export function isSlugFormField(

--- a/packages/keystatic/config.tsx
+++ b/packages/keystatic/config.tsx
@@ -74,9 +74,18 @@ export type Config<
   } = {
     [key: string]: Singleton<Record<string, ComponentSchema>>;
   }
-> =
-  | GitHubConfig<Collections, Singletons>
-  | LocalConfig<Collections, Singletons>;
+> = {
+  storage:
+    | {
+        kind: 'local';
+      }
+    | {
+        kind: 'github';
+        repo: { owner: string; name: string };
+      };
+  collections?: Collections;
+  singletons?: Singletons;
+};
 
 export function config<
   Collections extends {


### PR DESCRIPTION
TypeScript doesn't like `{ a: { kind: 'a' } } | { a: { kind: 'b' } }`