### PR TITLE
Little fixes

### DIFF
--- a/.changeset/perfect-flowers-build.md
+++ b/.changeset/perfect-flowers-build.md
@@ -1,0 +1,7 @@
+---
+'@keystatic/core': patch
+---
+
+Add `description` to
+`fields.{array,checkbox,date,document,image,integer,multiselect,select,pathReference,relationship}`.
+(previously it was only on `fields.{text,slug}`)

--- a/.changeset/wet-socks-rest.md
+++ b/.changeset/wet-socks-rest.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fix incorrectly attempting to get a GitHub token when using local mode

--- a/keystatic/local-config.tsx
+++ b/keystatic/local-config.tsx
@@ -26,6 +26,8 @@ const toneToIcon = {
   positive: checkCircle2Icon,
 };
 
+const description = 'Some description';
+
 export default config({
   storage: {
     kind: 'github',
@@ -256,6 +258,60 @@ export default config({
       schema: {
         something: fields.checkbox({ label: 'Something' }),
         logo: fields.image({ label: 'Logo' }),
+      },
+    }),
+    fields: singleton({
+      label: 'All Fields',
+      schema: {
+        text: fields.text({ label: 'Text', description }),
+        title: fields.slug({
+          name: { label: 'Title', description },
+          slug: { description },
+        }),
+        integer: fields.integer({ label: 'Number', description }),
+        checkbox: fields.checkbox({ label: 'Checkbox', description }),
+        select: fields.select({
+          label: 'Select',
+          description,
+          options: [
+            { value: 'one', label: 'One' },
+            { value: 'two', label: 'Two' },
+            { value: 'three', label: 'Three' },
+          ],
+          defaultValue: 'one',
+        }),
+        multiselect: fields.multiselect({
+          label: 'Multiselect',
+          description,
+          options: [
+            { value: 'one', label: 'One' },
+            { value: 'two', label: 'Two' },
+            { value: 'three', label: 'Three' },
+          ],
+          defaultValue: ['one'],
+        }),
+        array: fields.array(fields.text({ label: 'Text', description }), {
+          label: 'Array',
+          description,
+        }),
+        date: fields.date({ label: 'Date', description }),
+        document: fields.document({
+          label: 'Document',
+          description,
+          formatting: true,
+          dividers: true,
+          links: true,
+        }),
+        image: fields.image({ label: 'Image', description }),
+        pathReference: fields.pathReference({
+          label: 'Path Reference',
+          description,
+        }),
+        relationship: fields.relationship({
+          label: 'Relationship',
+          description,
+          collection: 'posts',
+        }),
       },
     }),
   },

--- a/packages/keystatic/DocumentEditor/component-blocks/api.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/api.tsx
@@ -191,6 +191,7 @@ export type ArrayField<ElementField extends ComponentSchema> = {
   kind: 'array';
   element: ElementField;
   label: string;
+  description?: string;
   // this is written with unknown to avoid typescript being annoying about circularity or variance things
   itemLabel?(props: unknown): string;
   asChildTag?: string;
@@ -223,6 +224,7 @@ type ArrayFieldInComponentSchema = {
   kind: 'array';
   element: ComponentSchema;
   label: string;
+  description?: string;
   // this is written with unknown to avoid typescript being annoying about circularity or variance things
   itemLabel?(props: unknown): string;
   asChildTag?: string;

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/array.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/array.tsx
@@ -9,6 +9,7 @@ export function array<ElementField extends ComponentSchema>(
   element: ElementField,
   opts?: {
     label?: string;
+    description?: string;
     itemLabel?: (props: GenericPreviewProps<ElementField, unknown>) => string;
     asChildTag?: string;
     slugField?: ElementField extends { kind: 'object' }
@@ -28,6 +29,7 @@ export function array<ElementField extends ComponentSchema>(
     kind: 'array',
     element,
     label: opts?.label ?? 'Items',
+    description: opts?.description,
     itemLabel: opts?.itemLabel,
     asChildTag: opts?.asChildTag,
     slugField: opts?.slugField as string,

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/checkbox.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/checkbox.tsx
@@ -1,19 +1,23 @@
 import { Checkbox } from '@voussoir/checkbox';
+import { Text } from '@voussoir/typography';
 import { BasicFormField } from '../../../dist/keystatic-core.cjs';
 
 export function checkbox({
   label,
   defaultValue = false,
+  description,
 }: {
   label: string;
   defaultValue?: boolean;
+  description?: string;
 }): BasicFormField<boolean, undefined> {
   return {
     kind: 'form',
     Input({ value, onChange, autoFocus }) {
       return (
         <Checkbox isSelected={value} onChange={onChange} autoFocus={autoFocus}>
-          {label}
+          <Text>{label}</Text>
+          {description && <Text slot="description">{description}</Text>}
         </Checkbox>
       );
     },

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/date.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/date.tsx
@@ -39,10 +39,12 @@ export function date<IsRequired extends boolean | undefined>({
   label,
   defaultValue,
   validation,
+  description,
 }: {
   label: string;
   defaultValue?: string | { kind: 'today' };
   validation?: { isRequired?: IsRequired; min?: string; max?: string };
+  description?: string;
 } & RequiredValidation<IsRequired>): BasicFormField<
   string | (IsRequired extends true ? never : null),
   undefined
@@ -55,6 +57,7 @@ export function date<IsRequired extends boolean | undefined>({
       return (
         <TextField
           label={label}
+          description={description}
           type="date"
           onChange={val => {
             onChange(val === '' ? null : val);

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/document.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/document.tsx
@@ -146,10 +146,12 @@ function normaliseDocumentFeatures(config: DocumentFeaturesConfig) {
 export function document({
   label,
   componentBlocks = {},
+  description,
   ...documentFeaturesConfig
 }: {
   label: string;
   componentBlocks?: Record<string, ComponentBlock>;
+  description?: string;
 } & DocumentFeaturesConfig): FormFieldWithFileRequiringContentsForReader<
   DocumentElement[],
   undefined,
@@ -188,7 +190,7 @@ export function document({
     defaultValue: [{ type: 'paragraph', children: [{ text: '' }] }],
     Input(props) {
       return (
-        <FieldPrimitive label={label}>
+        <FieldPrimitive label={label} description={description}>
           <DocumentEditor
             componentBlocks={componentBlocks}
             documentFeatures={documentFeatures}

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/image.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/image.tsx
@@ -3,6 +3,7 @@ import { FieldLabel, FieldMessage } from '@voussoir/field';
 import { Flex, Box } from '@voussoir/layout';
 import { tokenSchema } from '@voussoir/style';
 import { TextField } from '@voussoir/text-field';
+import { Text } from '@voussoir/typography';
 import { useState, useEffect, useReducer } from 'react';
 import { useIsInDocumentEditor } from '../..';
 import { fixPath } from '../../../app/path-utils';
@@ -67,10 +68,12 @@ export function image<IsRequired extends boolean | undefined>({
   label,
   directory,
   validation,
+  description,
 }: {
   label: string;
   directory?: string;
   validation?: { isRequired?: IsRequired };
+  description?: string;
 } & RequiredValidation<IsRequired>): FormFieldWithFileNotRequiringContentsForReader<
   | {
       kind: 'uploaded';
@@ -93,7 +96,11 @@ export function image<IsRequired extends boolean | undefined>({
       return (
         <Flex direction="column" gap="medium">
           <FieldLabel>{label}</FieldLabel>
-
+          {description && (
+            <Text size="small" color="neutralSecondary">
+              {description}
+            </Text>
+          )}
           <ButtonGroup>
             <ActionButton
               onPress={async () => {
@@ -125,7 +132,6 @@ export function image<IsRequired extends boolean | undefined>({
               </ActionButton>
             )}
           </ButtonGroup>
-
           {objectUrl && (
             <Box
               alignSelf="start"

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/integer.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/integer.tsx
@@ -32,10 +32,12 @@ export function integer<IsRequired extends boolean | undefined>({
   label,
   defaultValue,
   validation,
+  description,
 }: {
   label: string;
   defaultValue?: number;
   validation?: { isRequired?: IsRequired; min: number; max: number };
+  description?: string;
 } & RequiredValidation<IsRequired>): BasicFormField<
   number | (IsRequired extends true ? never : null),
   undefined
@@ -51,6 +53,7 @@ export function integer<IsRequired extends boolean | undefined>({
       return (
         <NumberField
           label={label}
+          description={description}
           errorMessage={
             forceValidation || blurred
               ? validateInteger(validation, value, label)

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/multiselect.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/multiselect.tsx
@@ -1,6 +1,7 @@
 import { Checkbox } from '@voussoir/checkbox';
 import { FieldLabel } from '@voussoir/field';
 import { Flex } from '@voussoir/layout';
+import { Text } from '@voussoir/typography';
 import { useId } from 'react';
 import { BasicFormField } from '../api';
 
@@ -8,26 +9,35 @@ export function multiselect<Option extends { label: string; value: string }>({
   label,
   options,
   defaultValue = [],
+  description,
 }: {
   label: string;
   options: readonly Option[];
   defaultValue?: readonly Option['value'][];
+  description?: string;
 }): BasicFormField<readonly Option['value'][], readonly Option[]> {
   const valuesToOption = new Map(options.map(x => [x.value, x]));
   return {
     kind: 'form',
     Input({ value, onChange }) {
       const labelId = useId();
+      const descriptionId = useId();
       return (
         <Flex
           role="group"
           aria-labelledby={labelId}
+          aria-describedby={description ? descriptionId : undefined}
           direction="column"
           gap="medium"
         >
           <FieldLabel elementType="span" id={labelId}>
             {label}
           </FieldLabel>
+          {description && (
+            <Text id={descriptionId} size="small" color="neutralSecondary">
+              {description}
+            </Text>
+          )}
           {options.map(option => (
             <Checkbox
               isSelected={value.includes(option.value)}

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/pathReference.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/pathReference.tsx
@@ -10,10 +10,12 @@ export function pathReference<IsRequired extends boolean | undefined>({
   label,
   pattern,
   validation,
+  description,
 }: {
   label: string;
   pattern?: string;
   validation?: { isRequired?: IsRequired };
+  description?: string;
 } & RequiredValidation<IsRequired>): BasicFormField<
   string | (IsRequired extends true ? never : null),
   undefined
@@ -47,6 +49,7 @@ export function pathReference<IsRequired extends boolean | undefined>({
       return (
         <Combobox
           label={label}
+          description={description}
           selectedKey={value}
           onSelectionChange={key => {
             if (typeof key === 'string' || key === null) {

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/relationship.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/relationship.tsx
@@ -9,10 +9,12 @@ export function relationship<IsRequired extends boolean | undefined>({
   label,
   collection,
   validation,
+  description,
 }: {
   label: string;
   collection: string;
   validation?: { isRequired?: IsRequired };
+  description?: string;
 } & RequiredValidation<IsRequired>): BasicFormField<
   string | (IsRequired extends true ? never : null),
   undefined
@@ -42,6 +44,7 @@ export function relationship<IsRequired extends boolean | undefined>({
       return (
         <Combobox
           label={label}
+          description={description}
           selectedKey={value}
           onSelectionChange={key => {
             if (typeof key === 'string' || key === null) {

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/select.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/select.tsx
@@ -6,10 +6,12 @@ export function select<Option extends { label: string; value: string }>({
   label,
   options,
   defaultValue,
+  description,
 }: {
   label: string;
   options: readonly Option[];
   defaultValue: Option['value'];
+  description?: string;
 }): BasicFormField<Option['value'], readonly Option[]> {
   const optionValuesSet = new Set(options.map(x => x.value));
   if (!optionValuesSet.has(defaultValue)) {
@@ -23,6 +25,7 @@ export function select<Option extends { label: string; value: string }>({
       return (
         <Picker
           label={label}
+          description={description}
           items={options}
           selectedKey={value}
           onSelectionChange={key => {

--- a/packages/keystatic/DocumentEditor/component-blocks/fields/url.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/url.tsx
@@ -23,10 +23,12 @@ export function url<IsRequired extends boolean | undefined>({
   label,
   defaultValue = '',
   validation,
+  description,
 }: {
   label: string;
   defaultValue?: string;
   validation?: { isRequired?: IsRequired };
+  description?: string;
 } & RequiredValidation<IsRequired>): BasicFormField<
   string | (IsRequired extends true ? never : null),
   undefined
@@ -40,6 +42,7 @@ export function url<IsRequired extends boolean | undefined>({
           width="initial"
           maxWidth={`calc(${tokenSchema.size.alias.singleLineWidth} * 3)`}
           label={label}
+          description={description}
           autoFocus={autoFocus}
           value={value === null ? '' : value}
           onChange={val => {

--- a/packages/keystatic/DocumentEditor/component-blocks/form-from-preview.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/form-from-preview.tsx
@@ -54,6 +54,7 @@ type DefaultFieldProps<Key> = GenericPreviewProps<
 
 function ArrayFieldPreview(props: DefaultFieldProps<'array'>) {
   const labelId = useId();
+  const descriptionId = useId();
   const stringFormatter = useLocalizedStringFormatter(l10nMessages);
 
   let onMove = (keys: Key[], target: ItemDropTarget) => {
@@ -173,11 +174,17 @@ function ArrayFieldPreview(props: DefaultFieldProps<'array'>) {
       gap="medium"
       role="group"
       aria-labelledby={labelId}
+      aria-describedby={props.schema.description ? descriptionId : undefined}
       direction="column"
     >
       <FieldLabel elementType="h3" id={labelId}>
         {props.schema.label}
       </FieldLabel>
+      {props.schema.description && (
+        <Text id={descriptionId} size="small" color="neutralSecondary">
+          {props.schema.description}
+        </Text>
+      )}
       <ActionButton
         autoFocus={props.autoFocus}
         onPress={addItem}

--- a/packages/keystatic/app/provider.tsx
+++ b/packages/keystatic/app/provider.tsx
@@ -175,7 +175,10 @@ export default function Provider({
                         },
                       });
                     },
-                    getAuth,
+                    getAuth: async () => {
+                      if (repo) return getAuth();
+                      return null;
+                    },
                   }),
                   fetchExchange,
                 ],

--- a/packages/keystatic/markdoc/find-children.test.ts
+++ b/packages/keystatic/markdoc/find-children.test.ts
@@ -117,6 +117,7 @@ test('array', () => {
       },
       "field": {
         "asChildTag": "related-link",
+        "description": undefined,
         "element": {
           "fields": {
             "content": {


### PR DESCRIPTION
- Adds `description` to all the other fields
- Skip attempting to get a GitHub auth token when using local mode (note this never caused a redirect or anything previously, it just did an unnecessary request to the API route to try getting a refreshed auth token)