### PR TITLE
Fix editor table styles

### DIFF
--- a/packages/keystatic/DocumentEditor/table.tsx
+++ b/packages/keystatic/DocumentEditor/table.tsx
@@ -666,22 +666,29 @@ export const TableElement = ({
   return (
     <StartElementsContext.Provider value={startElements}>
       <SelectedCellsContext.Provider value={selectedCells}>
-        <table
+        <div
           className={css({
-            width: '100%',
-            tableLayout: 'fixed',
             position: 'relative',
-            borderSpacing: 0,
-            marginTop: 10,
-            marginLeft: 10,
-            '& *::selection': selectedCells?.cells.size
-              ? { backgroundColor: 'transparent' }
-              : undefined,
+            paddingRight: 10,
           })}
-          {...attributes}
         >
-          {children}
-        </table>
+          <table
+            className={css({
+              width: '100%',
+              tableLayout: 'fixed',
+              position: 'relative',
+              borderSpacing: 0,
+              marginTop: 10,
+              marginLeft: 10,
+              '& *::selection': selectedCells?.cells.size
+                ? { backgroundColor: 'transparent' }
+                : undefined,
+            })}
+            {...attributes}
+          >
+            {children}
+          </table>
+        </div>
       </SelectedCellsContext.Provider>
     </StartElementsContext.Provider>
   );
@@ -748,10 +755,12 @@ export function TableCellElement({
           : undefined,
         position: 'relative',
         margin: 0,
-        padding: 0,
+        padding: 10,
         fontWeight: 'inherit',
+        boxSizing: 'border-box',
         textAlign: 'start',
-        height: 42,
+        height: 42, // ensures room for the context menu button in the focused cell
+        verticalAlign: 'top',
       })}
       {...attributes}
     >


### PR DESCRIPTION
Small tweaks to fix the table layout styles, so that

* The table outline sits nearly within the document margins
* Cell content is vertically-aligned to the top, and doesn't jump the first time you add a second line
* Cells have padding

Some magic numbers in here, but I think it's OK for now.

Screenshot after:

<img width="620" alt="image" src="https://user-images.githubusercontent.com/872310/224623969-b6157a5c-8585-490b-8721-39d66b5b1fbb.png">
