### PR TITLE
Ignore changesets with prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -42,6 +42,9 @@ node_modules/
 # Preconstruct build output
 dist
 
+# Changesets
+.changeset
+
 # Docs
 docs/cache
 docs/public/playroom


### PR DESCRIPTION
Otherwise adding a changeset with the changesets bot fails the format test on CI.

Probably not the _best_ solution (ideally the bot would be configurable?) but without this, the GitHub workflow is pretty awkward.

Happy for a different solution if you have one @emmatown 