### PR TITLE
Editor table RTL

### DIFF
--- a/.changeset/bright-schools-reply.md
+++ b/.changeset/bright-schools-reply.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Cosmetic fixes for the editor table when RTL.

--- a/packages/keystatic/DocumentEditor/table.tsx
+++ b/packages/keystatic/DocumentEditor/table.tsx
@@ -669,7 +669,7 @@ export const TableElement = ({
         <div
           className={css({
             position: 'relative',
-            paddingRight: 10,
+            paddingInlineEnd: 10,
           })}
         >
           <table
@@ -679,7 +679,7 @@ export const TableElement = ({
               position: 'relative',
               borderSpacing: 0,
               marginTop: 10,
-              marginLeft: 10,
+              marginInlineStart: 10,
               '& *::selection': selectedCells?.cells.size
                 ? { backgroundColor: 'transparent' }
                 : undefined,
@@ -740,12 +740,12 @@ export function TableCellElement({
   return (
     <ElementType
       className={css({
-        borderRight: `1px solid ${borderColor}`,
+        borderInlineEnd: `1px solid ${borderColor}`,
         borderBottom: `1px solid ${borderColor}`,
         borderTop: startElements.top.has(element)
           ? `1px solid ${borderColor}`
           : undefined,
-        borderLeft: startElements.left.has(element)
+        borderInlineStart: startElements.left.has(element)
           ? `1px solid ${borderColor}`
           : undefined,
         backgroundColor: selectedCellsContext?.cells.has(element)
@@ -771,7 +771,7 @@ export function TableCellElement({
             className={css({
               position: 'absolute',
               top: -1,
-              left: -1,
+              insetInlineStart: -1,
               background: tokenSchema.color.alias.borderSelected,
               height: size,
               width: 1,
@@ -782,7 +782,7 @@ export function TableCellElement({
             className={css({
               position: 'absolute',
               top: -1,
-              left: -1,
+              insetInlineStart: -1,
               background: tokenSchema.color.alias.borderSelected,
               height: 1,
               width: size,
@@ -867,19 +867,19 @@ export function TableCellElement({
 const styles = {
   top: {
     top: -9,
-    left: -1,
+    insetInlineStart: -1,
     width: 'calc(100% + 2px)',
     height: 8,
   },
   left: {
     top: -1,
-    left: -9,
+    insetInlineStart: -9,
     width: 8,
     height: 'calc(100% + 2px)',
   },
   'top-left': {
     top: -9,
-    left: -9,
+    insetInlineStart: -9,
     width: 8,
     height: 8,
   },
@@ -897,24 +897,22 @@ function CellSelection(props: {
       <button
         tabIndex={-1}
         type="button"
-        className={css(
-          {
-            position: 'absolute',
-            margin: 0,
-            padding: 0,
-            background: props.selected
-              ? tokenSchema.color.scale.indigo8
-              : tokenSchema.color.scale.slate3,
-            border: `1px solid ${
-              props.selected
-                ? tokenSchema.color.alias.borderSelected
-                : tokenSchema.color.alias.borderIdle
-            }`,
-            borderBottom: props.location === 'left' ? undefined : 'none',
-            borderRight: props.location === 'top' ? undefined : 'none',
-          },
-          styles[props.location]
-        )}
+        className={css({
+          position: 'absolute',
+          margin: 0,
+          padding: 0,
+          background: props.selected
+            ? tokenSchema.color.scale.indigo8
+            : tokenSchema.color.scale.slate3,
+          border: `1px solid ${
+            props.selected
+              ? tokenSchema.color.alias.borderSelected
+              : tokenSchema.color.alias.borderIdle
+          }`,
+          borderBottom: props.location === 'left' ? undefined : 'none',
+          borderInlineEnd: props.location === 'top' ? undefined : 'none',
+        })}
+        style={styles[props.location]}
         aria-label={props.label}
         onClick={() => {
           ReactEditor.focus(editor);
@@ -927,7 +925,7 @@ function CellSelection(props: {
             className={css({
               position: 'absolute',
               top: -9,
-              right: -1,
+              insetInlineEnd: -1,
               background: tokenSchema.color.alias.borderSelected,
               height: 8,
               width: 1,
@@ -939,7 +937,7 @@ function CellSelection(props: {
             className={css({
               position: 'absolute',
               bottom: -1,
-              left: -9,
+              insetInlineStart: -9,
               background: tokenSchema.color.alias.borderSelected,
               height: 1,
               width: 8,
@@ -1096,7 +1094,7 @@ function CellMenu(props: {
       contentEditable={false}
       className={css({
         top: 4,
-        right: 4,
+        insetInlineEnd: 4,
         position: 'absolute',
       })}
     >

--- a/packages/keystatic/DocumentEditor/table.tsx
+++ b/packages/keystatic/DocumentEditor/table.tsx
@@ -13,16 +13,17 @@ import {
 import { ReactEditor, RenderElementProps, useSlate } from 'slate-react';
 
 import { ActionButton } from '@voussoir/button';
-import { tableIcon } from '@voussoir/icon/icons/tableIcon';
 import { Icon } from '@voussoir/icon';
+import { chevronDownIcon } from '@voussoir/icon/icons/chevronDownIcon';
+import { tableIcon } from '@voussoir/icon/icons/tableIcon';
+import { Item, Menu, MenuTrigger } from '@voussoir/menu';
+import { css, tokenSchema } from '@voussoir/style';
 import { TooltipTrigger, Tooltip } from '@voussoir/tooltip';
 import { Text } from '@voussoir/typography';
+import { toDataAttributes } from '@voussoir/utils';
 
 import { useToolbarState } from './toolbar-state';
-import { css, tokenSchema } from '@voussoir/style';
 import { moveChildren, nodeTypeMatcher, useStaticEditor } from './utils';
-import { chevronDownIcon } from '@voussoir/icon/icons/chevronDownIcon';
-import { Item, Menu, MenuTrigger } from '@voussoir/menu';
 
 const cell = (header: boolean) => ({
   type: 'table-cell' as const,
@@ -870,23 +871,26 @@ function CellSelection(props: {
       <button
         tabIndex={-1}
         type="button"
-        data-location={props.location}
+        {...toDataAttributes(props, new Set(['location', 'selected']))}
         className={css({
-          position: 'absolute',
+          background: tokenSchema.color.scale.slate3,
+          border: `1px solid ${tokenSchema.color.alias.borderIdle}`,
           margin: 0,
           padding: 0,
-          background: props.selected
-            ? tokenSchema.color.scale.indigo8
-            : tokenSchema.color.scale.slate3,
-          border: `1px solid ${
-            props.selected
-              ? tokenSchema.color.alias.borderSelected
-              : tokenSchema.color.alias.borderIdle
-          }`,
-          borderBottom: props.location === 'left' ? undefined : 'none',
-          borderInlineEnd: props.location === 'top' ? undefined : 'none',
-          visibility: selectedCellsContext?.focus ? 'visible' : 'hidden',
+          position: 'absolute',
 
+          ':hover': {
+            background: tokenSchema.color.scale.slate4,
+          },
+
+          // ever so slightly larger hit area
+          '::before': {
+            content: '""',
+            inset: -1,
+            position: 'absolute',
+          },
+
+          // location
           '&[data-location=top]': {
             top: -9,
             insetInlineStart: -1,
@@ -905,7 +909,18 @@ function CellSelection(props: {
             width: 8,
             height: 8,
           },
+          '&:not([data-location=top])': { borderInlineEnd: 'none' },
+          '&:not([data-location=left])': { borderBottom: 'none' },
+
+          // state
+          '&[data-selected=true]': {
+            background: tokenSchema.color.scale.indigo8,
+            borderColor: tokenSchema.color.alias.borderSelected,
+          },
         })}
+        style={{
+          visibility: selectedCellsContext?.focus ? 'visible' : 'hidden',
+        }}
         aria-label={props.label}
         onClick={() => {
           ReactEditor.focus(editor);

--- a/packages/keystatic/DocumentEditor/table.tsx
+++ b/packages/keystatic/DocumentEditor/table.tsx
@@ -748,11 +748,10 @@ export function TableCellElement({
           : undefined,
         position: 'relative',
         margin: 0,
-        padding: 10,
+        padding: tokenSchema.size.space.regular,
         fontWeight: 'inherit',
         boxSizing: 'border-box',
         textAlign: 'start',
-        height: 42, // ensures room for the context menu button in the focused cell
         verticalAlign: 'top',
       })}
       {...attributes}
@@ -1083,18 +1082,34 @@ function CellMenu(props: {
   table: Element & { type: 'table' };
 }) {
   const editor = useStaticEditor();
+  const gutter = tokenSchema.size.space.small;
   return (
     <div
       contentEditable={false}
       className={css({
-        top: 4,
-        insetInlineEnd: 4,
+        top: gutter,
+        insetInlineEnd: gutter,
         position: 'absolute',
       })}
     >
       <TooltipTrigger>
         <MenuTrigger>
-          <ActionButton prominence="low">
+          <ActionButton
+            prominence="low"
+            UNSAFE_className={css({
+              borderRadius: tokenSchema.size.radius.small,
+              height: 'auto',
+              minWidth: 0,
+              padding: 0,
+
+              // tiny buttons; increase the hit area
+              '&::before': {
+                content: '""',
+                inset: `calc(${gutter} * -1)`,
+                position: 'absolute',
+              },
+            })}
+          >
             <Icon src={chevronDownIcon} />
           </ActionButton>
           <Menu

--- a/packages/keystatic/DocumentEditor/table.tsx
+++ b/packages/keystatic/DocumentEditor/table.tsx
@@ -666,20 +666,13 @@ export const TableElement = ({
   return (
     <StartElementsContext.Provider value={startElements}>
       <SelectedCellsContext.Provider value={selectedCells}>
-        <div
-          className={css({
-            position: 'relative',
-            paddingInlineEnd: 10,
-          })}
-        >
+        <div className={css({ position: 'relative' })}>
           <table
             className={css({
               width: '100%',
               tableLayout: 'fixed',
               position: 'relative',
               borderSpacing: 0,
-              marginTop: 10,
-              marginInlineStart: 10,
               '& *::selection': selectedCells?.cells.size
                 ? { backgroundColor: 'transparent' }
                 : undefined,
@@ -751,7 +744,7 @@ export function TableCellElement({
         backgroundColor: selectedCellsContext?.cells.has(element)
           ? tokenSchema.color.alias.backgroundSelected
           : element.header
-          ? tokenSchema.color.scale.slate4
+          ? tokenSchema.color.scale.slate3
           : undefined,
         position: 'relative',
         margin: 0,
@@ -864,39 +857,21 @@ export function TableCellElement({
   );
 }
 
-const styles = {
-  top: {
-    top: -9,
-    insetInlineStart: -1,
-    width: 'calc(100% + 2px)',
-    height: 8,
-  },
-  left: {
-    top: -1,
-    insetInlineStart: -9,
-    width: 8,
-    height: 'calc(100% + 2px)',
-  },
-  'top-left': {
-    top: -9,
-    insetInlineStart: -9,
-    width: 8,
-    height: 8,
-  },
-};
-
 function CellSelection(props: {
   location: 'top' | 'left' | 'top-left';
   selected: boolean;
   onClick: () => void;
   label: string;
 }) {
+  const selectedCellsContext = useContext(SelectedCellsContext);
   const editor = useStaticEditor();
+
   return (
     <div contentEditable={false}>
       <button
         tabIndex={-1}
         type="button"
+        data-location={props.location}
         className={css({
           position: 'absolute',
           margin: 0,
@@ -911,8 +886,27 @@ function CellSelection(props: {
           }`,
           borderBottom: props.location === 'left' ? undefined : 'none',
           borderInlineEnd: props.location === 'top' ? undefined : 'none',
+          visibility: selectedCellsContext?.focus ? 'visible' : 'hidden',
+
+          '&[data-location=top]': {
+            top: -9,
+            insetInlineStart: -1,
+            width: 'calc(100% + 2px)',
+            height: 8,
+          },
+          '&[data-location=left]': {
+            top: -1,
+            insetInlineStart: -9,
+            width: 8,
+            height: 'calc(100% + 2px)',
+          },
+          '&[data-location=top-left]': {
+            top: -9,
+            insetInlineStart: -9,
+            width: 8,
+            height: 8,
+          },
         })}
-        style={styles[props.location]}
         aria-label={props.label}
         onClick={() => {
           ReactEditor.focus(editor);


### PR DESCRIPTION
Cosmetic fixes for RTL:

| Before | After |
|--------|-------|
| ![before screenshot](https://user-images.githubusercontent.com/2730833/226276097-bfd619da-03e1-4a3f-ba3a-f7302e18be91.png) | ![after screenshot](https://user-images.githubusercontent.com/2730833/226276188-5f1ed144-58c5-4c09-ad9d-6855c25905d1.png) |

Still need to review other things like "Insert columns right" etc.

**Related:**

- hide cell selection buttons unless table selected: some affordance that they're interactive
- smaller cell menu trigger: reduce how frequently they clash with text