### PR TITLE
Split form between a document and everything else when a `contentField` is set

### DIFF
--- a/packages/keystatic/DocumentEditor/component-blocks/fields/document.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/fields/document.tsx
@@ -145,6 +145,8 @@ function normaliseDocumentFeatures(config: DocumentFeaturesConfig) {
   return documentFeatures;
 }
 
+export const DOCUMENT_FIELD_SYMBOL = Symbol('document field');
+
 export function document({
   label,
   componentBlocks = {},
@@ -276,5 +278,6 @@ export function document({
         parseToReader: parse('read'),
       },
     },
+    ...{ [DOCUMENT_FIELD_SYMBOL]: true },
   };
 }

--- a/packages/keystatic/DocumentEditor/component-blocks/form-from-preview.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/form-from-preview.tsx
@@ -480,7 +480,7 @@ const fieldRenderers = {
   conditional: ConditionalFieldPreview,
 };
 
-const InnerFormValueContentFromPreviewProps: MemoExoticComponent<
+export const InnerFormValueContentFromPreviewProps: MemoExoticComponent<
   (
     props: GenericPreviewProps<NonChildFieldComponentSchema, unknown> & {
       autoFocus?: boolean;

--- a/packages/keystatic/app/ItemPage.tsx
+++ b/packages/keystatic/app/ItemPage.tsx
@@ -320,7 +320,7 @@ function ItemPage(props: ItemPageProps) {
               key={localTreeKey}
               forceValidation={forceValidation}
               slugField={props.slugInfo}
-              contentField={formatInfo.contentField?.key}
+              formatInfo={formatInfo}
               {...previewProps}
             />
           </AppShellBody>

--- a/packages/keystatic/app/ItemPage.tsx
+++ b/packages/keystatic/app/ItemPage.tsx
@@ -27,7 +27,6 @@ import { TextField } from '@voussoir/text-field';
 import { Heading, Text } from '@voussoir/typography';
 
 import { Config } from '../config';
-import { FormValueContentFromPreviewProps } from '../DocumentEditor/component-blocks/form-from-preview';
 import { createGetPreviewProps } from '../DocumentEditor/component-blocks/preview-props';
 import { fields } from '../DocumentEditor/component-blocks/api';
 import { clientSideValidateProp } from '../DocumentEditor/component-blocks/utils';
@@ -59,6 +58,7 @@ import { useItemData } from './useItemData';
 import { useHasChanged } from './useHasChanged';
 import { mergeDataStates } from './useData';
 import { useSlugsInCollection } from './useSlugsInCollection';
+import { FormForEntry } from './form-for-entry';
 
 type ItemPageProps = {
   collection: string;
@@ -316,10 +316,11 @@ function ItemPage(props: ItemPageProps) {
             <Notice tone="critical">{deleteResult.error.message}</Notice>
           )}
           <AppShellBody>
-            <FormValueContentFromPreviewProps
+            <FormForEntry
               key={localTreeKey}
               forceValidation={forceValidation}
               slugField={props.slugInfo}
+              contentField={formatInfo.contentField?.key}
               {...previewProps}
             />
           </AppShellBody>

--- a/packages/keystatic/app/SingletonPage.tsx
+++ b/packages/keystatic/app/SingletonPage.tsx
@@ -10,7 +10,6 @@ import { ProgressCircle } from '@voussoir/progress';
 import { Heading, Text } from '@voussoir/typography';
 
 import { Config } from '../config';
-import { FormValueContentFromPreviewProps } from '../DocumentEditor/component-blocks/form-from-preview';
 import { createGetPreviewProps } from '../DocumentEditor/component-blocks/preview-props';
 import { fields } from '../DocumentEditor/component-blocks/api';
 import { clientSideValidateProp } from '../DocumentEditor/component-blocks/utils';
@@ -30,6 +29,7 @@ import { getSingletonFormat, getSingletonPath, isGitHubConfig } from './utils';
 import { Icon } from '@voussoir/icon';
 import { refreshCwIcon } from '@voussoir/icon/icons/refreshCwIcon';
 import { ForkRepoDialog } from './fork-repo';
+import { FormForEntry } from './form-for-entry';
 
 type SingletonPageProps = {
   singleton: string;
@@ -94,13 +94,15 @@ function SingletonPage({
   )(state as Record<string, unknown>);
 
   const baseCommit = useBaseCommit();
+
+  const format = getSingletonFormat(config, singleton);
   const [updateResult, _update, resetUpdateItem] = useUpsertItem({
     state,
     initialFiles,
     storage: config.storage,
     schema: singletonConfig.schema,
     basePath: singletonPath,
-    format: getSingletonFormat(config, singleton),
+    format,
     currentLocalTreeKey: localTreeKey,
     currentTree,
     slug: undefined,
@@ -167,9 +169,11 @@ function SingletonPage({
             {updateResult.kind === 'error' && (
               <Notice tone="critical">{updateResult.error.message}</Notice>
             )}
-            <FormValueContentFromPreviewProps
+            <FormForEntry
               key={localTreeKey}
               forceValidation={forceValidation}
+              contentField={format.contentField?.key}
+              slugField={undefined}
               {...previewProps}
             />
             <DialogContainer

--- a/packages/keystatic/app/SingletonPage.tsx
+++ b/packages/keystatic/app/SingletonPage.tsx
@@ -172,7 +172,7 @@ function SingletonPage({
             <FormForEntry
               key={localTreeKey}
               forceValidation={forceValidation}
-              contentField={format.contentField?.key}
+              formatInfo={format}
               slugField={undefined}
               {...previewProps}
             />

--- a/packages/keystatic/app/create-item.tsx
+++ b/packages/keystatic/app/create-item.tsx
@@ -11,7 +11,6 @@ import { toastQueue } from '@voussoir/toast';
 
 import { Config } from '../config';
 import { fields } from '../DocumentEditor/component-blocks/api';
-import { FormValueContentFromPreviewProps } from '../DocumentEditor/component-blocks/form-from-preview';
 import { getInitialPropsValue } from '../DocumentEditor/component-blocks/initial-values';
 import { createGetPreviewProps } from '../DocumentEditor/component-blocks/preview-props';
 import { clientSideValidateProp } from '../DocumentEditor/component-blocks/utils';
@@ -33,6 +32,7 @@ import {
 } from './utils';
 import { useSlugsInCollection } from './useSlugsInCollection';
 import { ForkRepoDialog } from './fork-repo';
+import { FormForEntry } from './form-for-entry';
 
 const emptyMap = new Map<string, TreeNode>();
 
@@ -61,13 +61,15 @@ export function CreateItem(props: {
 
   const slug = getSlugFromState(collectionConfig, state);
 
+  const formatInfo = getCollectionFormat(props.config, props.collection);
+
   const [createResult, _createItem, resetCreateItemState] = useUpsertItem({
     state,
     basePath: getCollectionItemPath(props.config, props.collection, slug),
     initialFiles: undefined,
     storage: props.config.storage,
     schema: collectionConfig.schema,
-    format: getCollectionFormat(props.config, props.collection),
+    format: formatInfo,
     currentLocalTreeKey: undefined,
     currentTree:
       tree.current.kind === 'loaded' ? tree.current.data.tree : emptyMap,
@@ -165,9 +167,10 @@ export function CreateItem(props: {
               <Notice tone="critical">{createResult.error.message}</Notice>
             )}
 
-            <FormValueContentFromPreviewProps
+            <FormForEntry
               forceValidation={forceValidation}
               slugField={slugInfo}
+              contentField={formatInfo.contentField?.key}
               {...previewProps}
             />
           </Flex>

--- a/packages/keystatic/app/create-item.tsx
+++ b/packages/keystatic/app/create-item.tsx
@@ -170,7 +170,7 @@ export function CreateItem(props: {
             <FormForEntry
               forceValidation={forceValidation}
               slugField={slugInfo}
-              contentField={formatInfo.contentField?.key}
+              formatInfo={formatInfo}
               {...previewProps}
             />
           </Flex>

--- a/packages/keystatic/app/form-for-entry.tsx
+++ b/packages/keystatic/app/form-for-entry.tsx
@@ -1,4 +1,6 @@
-import { Flex, Grid } from '@voussoir/layout';
+import { Box, Grid } from '@voussoir/layout';
+import { useEffect } from 'react';
+
 import { DOCUMENT_FIELD_SYMBOL } from '../DocumentEditor/component-blocks/fields/document';
 import {
   AddToPathProvider,
@@ -13,6 +15,7 @@ import {
 import { ReadonlyPropPath } from '../DocumentEditor/component-blocks/utils';
 import { ComponentSchema, GenericPreviewProps, ObjectField } from '../src';
 import { FormatInfo } from './path-utils';
+import { useAppShellContext } from './shell';
 
 const emptyArray: ReadonlyPropPath = [];
 
@@ -43,18 +46,19 @@ export function FormForEntry({
     ObjectField<Record<string, NonChildFieldComponentSchema>>,
     unknown
   >;
-  if (hasSplitView(formatInfo, props.schema)) {
+  const { setContainerWidth } = useAppShellContext();
+  const splitView = hasSplitView(formatInfo, props.schema);
+
+  useEffect(() => {
+    setContainerWidth(splitView ? 'large' : 'medium');
+  }, [setContainerWidth, splitView]);
+
+  if (splitView) {
     return (
       <PathContextProvider value={emptyArray}>
         <SlugFieldProvider value={slugField}>
-          <Grid columns={['2fr', '1fr']} gap="large">
-            <AddToPathProvider part={formatInfo.contentField.key}>
-              <InnerFormValueContentFromPreviewProps
-                forceValidation={forceValidation}
-                {...props.fields[formatInfo.contentField.key]}
-              />
-            </AddToPathProvider>
-            <Flex gap="xlarge" direction="column">
+          <Grid columns={{ desktop: ['2fr', '1fr'] }} gap="xlarge">
+            <Grid gap="xlarge" order={{ desktop: 2 }}>
               {Object.entries(props.fields).map(([key, propVal]) =>
                 key === formatInfo.contentField.key ? null : (
                   <AddToPathProvider key={key} part={key}>
@@ -65,7 +69,15 @@ export function FormForEntry({
                   </AddToPathProvider>
                 )
               )}
-            </Flex>
+            </Grid>
+            <Box minWidth={0}>
+              <AddToPathProvider part={formatInfo.contentField.key}>
+                <InnerFormValueContentFromPreviewProps
+                  forceValidation={forceValidation}
+                  {...props.fields[formatInfo.contentField.key]}
+                />
+              </AddToPathProvider>
+            </Box>
           </Grid>
         </SlugFieldProvider>
       </PathContextProvider>

--- a/packages/keystatic/app/form-for-entry.tsx
+++ b/packages/keystatic/app/form-for-entry.tsx
@@ -1,0 +1,70 @@
+import { Flex, Grid } from '@voussoir/layout';
+import {
+  AddToPathProvider,
+  PathContextProvider,
+  SlugFieldProvider,
+} from '../DocumentEditor/component-blocks/fields/text';
+import {
+  FormValueContentFromPreviewProps,
+  InnerFormValueContentFromPreviewProps,
+  NonChildFieldComponentSchema,
+} from '../DocumentEditor/component-blocks/form-from-preview';
+import { ReadonlyPropPath } from '../DocumentEditor/component-blocks/utils';
+import { ComponentSchema, GenericPreviewProps, ObjectField } from '../src';
+
+const emptyArray: ReadonlyPropPath = [];
+
+export function FormForEntry({
+  contentField,
+  forceValidation,
+  slugField,
+  ..._props
+}: GenericPreviewProps<
+  ObjectField<Record<string, ComponentSchema>>,
+  unknown
+> & {
+  contentField: string | undefined;
+  forceValidation: boolean | undefined;
+  slugField: { slugs: Set<string>; field: string } | undefined;
+}) {
+  const props = _props as GenericPreviewProps<
+    ObjectField<Record<string, NonChildFieldComponentSchema>>,
+    unknown
+  >;
+  if (contentField !== undefined) {
+    return (
+      <PathContextProvider value={emptyArray}>
+        <SlugFieldProvider value={slugField}>
+          <Grid columns={['2fr', '1fr']} gap="large">
+            <AddToPathProvider part={contentField}>
+              <InnerFormValueContentFromPreviewProps
+                forceValidation={forceValidation}
+                {...props.fields[contentField]}
+              />
+            </AddToPathProvider>
+            <Flex gap="xlarge" direction="column">
+              {Object.entries(props.fields).map(([key, propVal]) =>
+                key === contentField ? null : (
+                  <AddToPathProvider key={key} part={key}>
+                    <InnerFormValueContentFromPreviewProps
+                      forceValidation={forceValidation}
+                      {...propVal}
+                    />
+                  </AddToPathProvider>
+                )
+              )}
+            </Flex>
+          </Grid>
+        </SlugFieldProvider>
+      </PathContextProvider>
+    );
+  }
+  return (
+    <FormValueContentFromPreviewProps
+      autoFocus
+      forceValidation={forceValidation}
+      slugField={slugField}
+      {...props}
+    />
+  );
+}

--- a/packages/keystatic/app/shell/index.tsx
+++ b/packages/keystatic/app/shell/index.tsx
@@ -4,6 +4,7 @@ import {
   ReactElement,
   ReactNode,
   useContext,
+  useState,
 } from 'react';
 
 import { alertCircleIcon } from '@voussoir/icon/icons/alertCircleIcon';
@@ -132,18 +133,29 @@ export const AppShellBody = ({ children }: PropsWithChildren) => {
   );
 };
 
+type ContainerWidth = keyof VoussoirTheme['size']['container'];
 type AppShellContextValue = {
-  containerWidth: keyof VoussoirTheme['size']['container'];
+  containerWidth: ContainerWidth;
+  setContainerWidth: (containerWidth: ContainerWidth) => void;
 };
 const AppShellContext = createContext<AppShellContextValue>({
   containerWidth: 'medium',
+  setContainerWidth: () => {
+    throw new Error('`AppShellContext.Provider` not found.');
+  },
 });
+export function useAppShellContext() {
+  return useContext(AppShellContext);
+}
+
 export const AppShellRoot = ({
   children,
-  containerWidth = 'medium',
+  containerWidth: initialContainerWidth = 'medium',
 }: PropsWithChildren<Partial<AppShellContextValue>>) => {
+  // TODO: check perf; potentially separate context for set/get.
+  const [containerWidth, setContainerWidth] = useState(initialContainerWidth);
   return (
-    <AppShellContext.Provider value={{ containerWidth }}>
+    <AppShellContext.Provider value={{ containerWidth, setContainerWidth }}>
       <Box
         elementType="main"
         flex


### PR DESCRIPTION
Not totally sure if tying this to `contentField` is the right move but let's try it and see how it goes