### PR TITLE
Image block schema

### DIFF
--- a/.changeset/popular-actors-deliver.md
+++ b/.changeset/popular-actors-deliver.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Add `images.schema` option to `fields.document` to allow changing the schema for 

--- a/keystatic/local-config.tsx
+++ b/keystatic/local-config.tsx
@@ -54,6 +54,9 @@ export default config({
           images: {
             directory: 'public/images/posts',
             publicPath: '/images/posts/',
+            schema: {
+              title: fields.text({ label: 'Title' }),
+            },
           },
           componentBlocks: {
             blockChild: component({

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@changesets/changelog-github": "^0.4.5",
     "@changesets/cli": "^2.23.0",
     "@manypkg/cli": "^0.19.1",
-    "@preconstruct/cli": "^2.4.1",
+    "@preconstruct/cli": "^2.4.2",
     "@testing-library/dom": "^8.20.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/packages/keystatic/DocumentEditor/Toolbar.tsx
+++ b/packages/keystatic/DocumentEditor/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo, useContext } from 'react';
+import { ReactNode, useMemo } from 'react';
 import { Editor, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 
@@ -27,17 +27,14 @@ import { Tooltip, TooltipTrigger } from '@voussoir/tooltip';
 import { TextAlignMenu } from './alignment';
 import { blockquoteButton } from './blockquote';
 import { codeButton } from './code-block';
-import {
-  ComponentBlockContext,
-  insertComponentBlock,
-} from './component-blocks';
+import { insertComponentBlock } from './component-blocks';
 import { dividerButton } from './divider';
 import { DocumentFeatures } from './document-features';
 import { linkButton } from './link';
 import { LayoutsButton } from './layouts';
 import { ListButtons } from './lists';
 import { ToolbarSeparator } from './primitives';
-import { useToolbarState } from './toolbar-state';
+import { useDocumentEditorConfig, useToolbarState } from './toolbar-state';
 import { clearFormatting, useStaticEditor } from './utils';
 import { Picker } from '@voussoir/picker';
 import { imageButton } from './image';
@@ -50,7 +47,7 @@ export function Toolbar({
   documentFeatures: DocumentFeatures;
   viewState?: { expanded: boolean; toggle: () => void };
 }) {
-  const blockComponent = useContext(ComponentBlockContext);
+  const blockComponent = useDocumentEditorConfig().componentBlocks;
   const hasBlockItems = Object.keys(blockComponent).length;
   const hasMarks = Object.values(documentFeatures.formatting.inlineMarks).some(
     x => x
@@ -265,7 +262,7 @@ const HeadingMenu = ({
 
 function InsertBlockMenu() {
   const editor = useStaticEditor();
-  const componentBlocks = useContext(ComponentBlockContext)!;
+  const componentBlocks = useDocumentEditorConfig().componentBlocks;
 
   return (
     <MenuTrigger align="end">

--- a/packages/keystatic/DocumentEditor/component-blocks/form-from-preview.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/form-from-preview.tsx
@@ -402,7 +402,7 @@ function ObjectFieldPreview({
     ? findFocusableObjectFieldKey(schema)
     : undefined;
   return (
-    <Flex gap="xlarge" direction="column">
+    <Flex gap="large" direction="column">
       {Object.entries(fields).map(
         ([key, propVal]) =>
           isNonChildFieldPreviewProps(propVal) && (
@@ -432,7 +432,7 @@ function ConditionalFieldPreview({
     unknown
   >;
   return (
-    <Flex gap="xlarge" direction="column">
+    <Flex gap="large" direction="column">
       {useMemo(
         () => (
           <AddToPathProvider part="discriminant">

--- a/packages/keystatic/DocumentEditor/component-blocks/index.tsx
+++ b/packages/keystatic/DocumentEditor/component-blocks/index.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { ReactEditor, RenderElementProps } from 'slate-react';
 import { Editor, Transforms } from 'slate';
 
@@ -22,12 +15,9 @@ import { updateComponentBlockElementProps } from './update-element';
 import { ComponentBlockRender } from './component-block-render';
 import { ChromefulComponentBlockElement } from './chromeful-element';
 import { ChromelessComponentBlockElement } from './chromeless-element';
+import { useDocumentEditorConfig } from '../toolbar-state';
 
 export { withComponentBlocks } from './with-component-blocks';
-
-export const ComponentBlockContext = createContext<
-  Record<string, ComponentBlock>
->({});
 
 export function ComponentInlineProp(props: RenderElementProps) {
   return <span {...props.attributes}>{props.children}</span>;
@@ -61,7 +51,7 @@ export const ComponentBlocksElement = ({
     editor,
     __elementToGetPath
   );
-  const blockComponents = useContext(ComponentBlockContext)!;
+  const blockComponents = useDocumentEditorConfig().componentBlocks;
   const componentBlock = blockComponents[currentElement.component] as
     | ComponentBlock
     | undefined;

--- a/packages/keystatic/DocumentEditor/component-blocks/utils.ts
+++ b/packages/keystatic/DocumentEditor/component-blocks/utils.ts
@@ -164,7 +164,8 @@ export function getDocumentFeaturesForChildField(
               },
       },
       links: options.links === 'inherit',
-      images: options.images === 'inherit',
+      images:
+        options.images === 'inherit' ? editorDocumentFeatures.images : false,
       tables: options.tables === 'inherit',
     },
     componentBlocks: options.componentBlocks === 'inherit',

--- a/packages/keystatic/DocumentEditor/document-features.ts
+++ b/packages/keystatic/DocumentEditor/document-features.ts
@@ -1,3 +1,5 @@
+import { BasicStringFormField } from './component-blocks/fields/document';
+
 export type DocumentFeatures = {
   formatting: {
     inlineMarks: {
@@ -26,7 +28,16 @@ export type DocumentFeatures = {
     softBreaks: boolean;
   };
   links: boolean;
-  images: boolean | { directory?: string; publicPath?: string };
+  images:
+    | false
+    | {
+        directory?: string;
+        publicPath?: string;
+        schema: {
+          alt: BasicStringFormField;
+          title: BasicStringFormField;
+        };
+      };
   dividers: boolean;
   layouts: [number, ...number[]][];
   tables: boolean;

--- a/packages/keystatic/DocumentEditor/index.tsx
+++ b/packages/keystatic/DocumentEditor/index.tsx
@@ -37,7 +37,7 @@ import { Toolbar } from './Toolbar';
 import { renderElement } from './render-element';
 import { withHeading } from './heading';
 import { nestList, unnestList, withList } from './lists';
-import { ComponentBlockContext, withComponentBlocks } from './component-blocks';
+import { withComponentBlocks } from './component-blocks';
 import { getPlaceholderTextForPropPath } from './component-blocks/utils';
 import { withBlockquote } from './blockquote';
 import { withDivider } from './divider';
@@ -47,7 +47,7 @@ import { renderLeaf } from './leaf';
 import { withSoftBreaks } from './soft-breaks';
 import { withShortcuts } from './shortcuts';
 import { withDocumentFeaturesNormalization } from './document-features-normalization';
-import { ToolbarStateProvider, useToolbarState } from './toolbar-state';
+import { ToolbarStateProvider, useDocumentEditorConfig } from './toolbar-state';
 import { withInsertMenu } from './insert-menu';
 import { withBlockMarkdownShortcuts } from './block-markdown-shortcuts';
 import { withPasting } from './pasting';
@@ -476,12 +476,11 @@ function getPrismTokenLength(token: Prism.Token | string): number {
 
 export function DocumentEditorEditable(props: EditableProps) {
   const editor = useSlate();
-  const componentBlocks = useContext(ComponentBlockContext);
-  const toolbarState = useToolbarState();
+  const { componentBlocks, documentFeatures } = useDocumentEditorConfig();
 
   const onKeyDown = useMemo(
-    () => getKeyDownHandler(editor, toolbarState.editorDocumentFeatures),
-    [editor, toolbarState.editorDocumentFeatures]
+    () => getKeyDownHandler(editor, documentFeatures),
+    [editor, documentFeatures]
   );
 
   return (

--- a/packages/keystatic/DocumentEditor/insert-menu.tsx
+++ b/packages/keystatic/DocumentEditor/insert-menu.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactNode, useContext, useEffect, useRef } from 'react';
+import { Fragment, ReactNode, useEffect, useRef } from 'react';
 import { Transforms, Text, Editor, Path, Point, Node } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { matchSorter } from 'match-sorter';
@@ -11,13 +11,14 @@ import { Item, ListBoxBase, useListBoxLayout } from '@voussoir/listbox';
 import { Popover } from '@voussoir/overlays';
 import { css, tokenSchema } from '@voussoir/style';
 
-import {
-  ComponentBlockContext,
-  insertComponentBlock,
-} from './component-blocks';
+import { insertComponentBlock } from './component-blocks';
 import { ComponentBlock } from './component-blocks/api';
 import { insertLayout } from './layouts';
-import { ToolbarState, useToolbarState } from './toolbar-state';
+import {
+  ToolbarState,
+  useDocumentEditorConfig,
+  useToolbarState,
+} from './toolbar-state';
 import { insertNodesButReplaceIfSelectionIsAtEmptyParagraphOrHeading } from './utils';
 import { getUploadedImage } from './component-blocks/fields/image';
 import { isBlock } from '.';
@@ -157,7 +158,7 @@ export function InsertMenu({
 }) {
   const toolbarState = useToolbarState();
   const { editor } = toolbarState;
-  const componentBlocks = useContext(ComponentBlockContext);
+  const { componentBlocks } = useDocumentEditorConfig();
   const options = matchSorter(
     getOptions(toolbarState, componentBlocks),
     text.text.slice(1),

--- a/packages/keystatic/DocumentEditor/layouts.tsx
+++ b/packages/keystatic/DocumentEditor/layouts.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo } from 'react';
+import { useMemo } from 'react';
 import { Editor, Element, Node, Transforms, Range, Point } from 'slate';
 import { ReactEditor, RenderElementProps } from 'slate-react';
 
@@ -24,11 +24,7 @@ import {
   moveChildren,
   useStaticEditor,
 } from './utils';
-import { useToolbarState } from './toolbar-state';
-
-const LayoutOptionsContext = createContext<[number, ...number[]][]>([]);
-
-export const LayoutOptionsProvider = LayoutOptionsContext.Provider;
+import { useDocumentEditorConfig, useToolbarState } from './toolbar-state';
 
 // UI Components
 export const LayoutContainer = ({
@@ -39,7 +35,7 @@ export const LayoutContainer = ({
   const editor = useStaticEditor();
 
   const layout = element.layout;
-  const layoutOptions = useContext(LayoutOptionsContext);
+  const layoutOptions = useDocumentEditorConfig().documentFeatures.layouts;
   const currentLayoutIndex = layoutOptions.findIndex(
     x => x.toString() === layout.toString()
   );

--- a/packages/keystatic/DocumentEditor/tests/utils.tsx
+++ b/packages/keystatic/DocumentEditor/tests/utils.tsx
@@ -12,6 +12,7 @@ import { createToolbarState, ToolbarStateProvider } from '../toolbar-state';
 import { validateDocumentStructure } from '../../structure-validation';
 import { validateAndNormalizeDocument } from '../../validation';
 import { VoussoirProvider } from '@voussoir/core';
+import { normaliseDocumentFeatures } from '../component-blocks/fields/document';
 
 export { __jsx as jsx } from './jsx/namespace';
 
@@ -136,30 +137,15 @@ expect.extend({
     return { actual: received, message, pass };
   },
 });
-export const defaultDocumentFeatures: DocumentFeatures = {
-  formatting: {
-    alignment: { center: true, end: true },
-    blockTypes: { blockquote: true, code: true },
-    headingLevels: [1, 2, 3, 4, 5, 6],
-    inlineMarks: {
-      bold: true,
-      code: true,
-      italic: true,
-      keyboard: true,
-      strikethrough: true,
-      subscript: true,
-      superscript: true,
-      underline: true,
-    },
-    listTypes: { ordered: true, unordered: true },
-    softBreaks: true,
-  },
+
+export const defaultDocumentFeatures = normaliseDocumentFeatures({
   dividers: true,
-  links: true,
-  layouts: [[1], [1, 1], [1, 1, 1], [1, 2, 1]],
+  formatting: true,
   images: true,
+  layouts: [[1], [1, 1], [1, 1, 1], [1, 2, 1]],
+  links: true,
   tables: true,
-};
+});
 
 function EditorComp({
   editor,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
       '@changesets/changelog-github': ^0.4.5
       '@changesets/cli': ^2.23.0
       '@manypkg/cli': ^0.19.1
-      '@preconstruct/cli': ^2.4.1
+      '@preconstruct/cli': ^2.4.2
       '@testing-library/dom': ^8.20.0
       '@testing-library/jest-dom': ^5.16.5
       '@testing-library/react': ^13.4.0
@@ -48,7 +48,7 @@ importers:
       '@changesets/changelog-github': 0.4.8
       '@changesets/cli': 2.26.0
       '@manypkg/cli': 0.19.2
-      '@preconstruct/cli': 2.4.1
+      '@preconstruct/cli': 2.4.2
       '@testing-library/dom': 8.20.0
       '@testing-library/jest-dom': 5.16.5
       '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y
@@ -5591,8 +5591,8 @@ packages:
       webpack: 5.75.0_esbuild@0.14.54
     dev: true
 
-  /@preconstruct/cli/2.4.1:
-    resolution: {integrity: sha512-5/UCz6JwFjDpJsZrONsmsD++xIZ0pLYG0heh8DVXs9/F2vxmmZaKwBrswH78+Js5ZHkjDiWNH6vQlWVMxRhYow==}
+  /@preconstruct/cli/2.4.2:
+    resolution: {integrity: sha512-fhdzbDF58Gu+t+CqQedx2J21jhVL7xE9f+RLuOLtS1lJhD8jyDJ+O7ny+6nVSB87NK5FaBM+dDErCcZcWjbJQA==}
     hasBin: true
     dependencies:
       '@babel/code-frame': 7.18.6


### PR DESCRIPTION
This lets you add a title field(serialised to the normal markdown title syntax) to the built-in image block and also customise the alt text field to e.g. have a custom description. If a `title` field isn't provided, there won't be a title field in the UI (though a title written in the markdoc file will be valid and will be kept upon saving). If an `alt` field isn't provided, a default one will be used. Currently this doesn't allow arbitrary fields on images, though that will likely exist in the future.