### PR TITLE
Table overflow mode

### DIFF
--- a/.changeset/wild-cars-fix.md
+++ b/.changeset/wild-cars-fix.md
@@ -1,0 +1,6 @@
+---
+'@voussoir/dialog': patch
+'@voussoir/table': patch
+---
+
+Fix `TableView` overflow mode behaviour.

--- a/design-system/packages/dialog/src/index.ts
+++ b/design-system/packages/dialog/src/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 export { AlertDialog } from './AlertDialog';
 export { Dialog } from './Dialog';
 export { DialogContainer } from './DialogContainer';

--- a/design-system/packages/table/src/TableView.tsx
+++ b/design-system/packages/table/src/TableView.tsx
@@ -79,7 +79,12 @@ export function TableView<T extends object>(props: TableProps<T>) {
               cell.props.isSelectionCell ? (
                 <TableCheckboxCell key={cell.key} cell={cell} state={state} />
               ) : (
-                <TableCell key={cell.key} cell={cell} state={state} />
+                <TableCell
+                  key={cell.key}
+                  cell={cell}
+                  state={state}
+                  overflowMode={props.overflowMode}
+                />
               )
             )}
           </TableRow>
@@ -215,7 +220,15 @@ function TableRow<T>({
   );
 }
 
-function TableCell<T>({ cell, state }: { cell: any; state: TableState<T> }) {
+function TableCell<T>({
+  cell,
+  overflowMode,
+  state,
+}: {
+  cell: any;
+  overflowMode: TableProps<T>['overflowMode'];
+  state: TableState<T>;
+}) {
   let ref = useRef<HTMLDivElement>(null);
   let { gridCellProps } = useTableCell({ node: cell }, state, ref);
   let { isFocusVisible, focusProps } = useFocusRing();
@@ -224,7 +237,7 @@ function TableCell<T>({ cell, state }: { cell: any; state: TableState<T> }) {
   return (
     <div {...mergeProps(gridCellProps, focusProps)} {...styleProps} ref={ref}>
       {isReactText(cell.rendered) ? (
-        <Text truncate>{cell.rendered}</Text>
+        <Text truncate={overflowMode === 'truncate'}>{cell.rendered}</Text>
       ) : (
         cell.rendered
       )}

--- a/design-system/packages/table/src/index.ts
+++ b/design-system/packages/table/src/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Column } from '@react-stately/table';
 import { ColumnProps } from './types';
 

--- a/design-system/packages/table/src/styles.tsx
+++ b/design-system/packages/table/src/styles.tsx
@@ -167,8 +167,9 @@ export function useCellStyleProps(
       },
 
       // wrapping text shouldn't be centered
-      '.ksv-table-view[data-overflow-mode="truncate"] &': {
-        alignItems: 'center',
+      alignItems: 'center',
+      '.ksv-table-view[data-overflow-mode="wrap"] &': {
+        alignItems: 'initial',
       },
 
       // Density


### PR DESCRIPTION
Fix `TableView` overflow mode behaviour. Cell content may "wrap" and will be center-aligned only when `overflowMode` is "truncate". When providing complex children (non-string/number) consumers must implement their own truncation, using the `Text` component.