### PR TITLE
Use `cache` from `react` in the reader API in server component environments

### DIFF
--- a/.changeset/tender-squids-arrive.md
+++ b/.changeset/tender-squids-arrive.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+`@keystatic/core/reader` now uses React's `cache` function in server component environments

--- a/design-system/packages/action-group/package.json
+++ b/design-system/packages/action-group/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-action-group.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-action-group.cjs.js",
       "module": "./dist/voussoir-action-group.esm.js",
       "default": "./dist/voussoir-action-group.cjs.js"
     },

--- a/design-system/packages/avatar/package.json
+++ b/design-system/packages/avatar/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-avatar.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-avatar.cjs.js",
       "module": "./dist/voussoir-avatar.esm.js",
       "default": "./dist/voussoir-avatar.cjs.js"
     },

--- a/design-system/packages/badge/package.json
+++ b/design-system/packages/badge/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-badge.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-badge.cjs.js",
       "module": "./dist/voussoir-badge.esm.js",
       "default": "./dist/voussoir-badge.cjs.js"
     },

--- a/design-system/packages/breadcrumbs/package.json
+++ b/design-system/packages/breadcrumbs/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-breadcrumbs.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-breadcrumbs.cjs.js",
       "module": "./dist/voussoir-breadcrumbs.esm.js",
       "default": "./dist/voussoir-breadcrumbs.cjs.js"
     },

--- a/design-system/packages/button/package.json
+++ b/design-system/packages/button/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-button.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-button.cjs.js",
       "module": "./dist/voussoir-button.esm.js",
       "default": "./dist/voussoir-button.cjs.js"
     },

--- a/design-system/packages/checkbox/package.json
+++ b/design-system/packages/checkbox/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-checkbox.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-checkbox.cjs.js",
       "module": "./dist/voussoir-checkbox.esm.js",
       "default": "./dist/voussoir-checkbox.cjs.js"
     },

--- a/design-system/packages/combobox/package.json
+++ b/design-system/packages/combobox/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-combobox.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-combobox.cjs.js",
       "module": "./dist/voussoir-combobox.esm.js",
       "default": "./dist/voussoir-combobox.cjs.js"
     },

--- a/design-system/packages/core/package.json
+++ b/design-system/packages/core/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-core.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-core.cjs.js",
       "module": "./dist/voussoir-core.esm.js",
       "default": "./dist/voussoir-core.cjs.js"
     },

--- a/design-system/packages/date-time/package.json
+++ b/design-system/packages/date-time/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-date-time.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-date-time.cjs.js",
       "module": "./dist/voussoir-date-time.esm.js",
       "default": "./dist/voussoir-date-time.cjs.js"
     },

--- a/design-system/packages/dialog/package.json
+++ b/design-system/packages/dialog/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-dialog.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-dialog.cjs.js",
       "module": "./dist/voussoir-dialog.esm.js",
       "default": "./dist/voussoir-dialog.cjs.js"
     },

--- a/design-system/packages/drag-and-drop/package.json
+++ b/design-system/packages/drag-and-drop/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-drag-and-drop.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-drag-and-drop.cjs.js",
       "module": "./dist/voussoir-drag-and-drop.esm.js",
       "default": "./dist/voussoir-drag-and-drop.cjs.js"
     },

--- a/design-system/packages/field/package.json
+++ b/design-system/packages/field/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-field.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-field.cjs.js",
       "module": "./dist/voussoir-field.esm.js",
       "default": "./dist/voussoir-field.cjs.js"
     },

--- a/design-system/packages/icon/package.json
+++ b/design-system/packages/icon/package.json
@@ -7,3646 +7,4557 @@
   "module": "dist/voussoir-icon.esm.js",
   "exports": {
     "./all": {
+      "types": "./all/dist/voussoir-icon-all.cjs.js",
       "module": "./all/dist/voussoir-icon-all.esm.js",
       "default": "./all/dist/voussoir-icon-all.cjs.js"
     },
     ".": {
+      "types": "./dist/voussoir-icon.cjs.js",
       "module": "./dist/voussoir-icon.esm.js",
       "default": "./dist/voussoir-icon.cjs.js"
     },
     "./icons/xIcon": {
+      "types": "./icons/xIcon/dist/voussoir-icon-icons-xIcon.cjs.js",
       "module": "./icons/xIcon/dist/voussoir-icon-icons-xIcon.esm.js",
       "default": "./icons/xIcon/dist/voussoir-icon-icons-xIcon.cjs.js"
     },
     "./icons/tvIcon": {
+      "types": "./icons/tvIcon/dist/voussoir-icon-icons-tvIcon.cjs.js",
       "module": "./icons/tvIcon/dist/voussoir-icon-icons-tvIcon.esm.js",
       "default": "./icons/tvIcon/dist/voussoir-icon-icons-tvIcon.cjs.js"
     },
     "./icons/axeIcon": {
+      "types": "./icons/axeIcon/dist/voussoir-icon-icons-axeIcon.cjs.js",
       "module": "./icons/axeIcon/dist/voussoir-icon-icons-axeIcon.esm.js",
       "default": "./icons/axeIcon/dist/voussoir-icon-icons-axeIcon.cjs.js"
     },
     "./icons/bedIcon": {
+      "types": "./icons/bedIcon/dist/voussoir-icon-icons-bedIcon.cjs.js",
       "module": "./icons/bedIcon/dist/voussoir-icon-icons-bedIcon.esm.js",
       "default": "./icons/bedIcon/dist/voussoir-icon-icons-bedIcon.cjs.js"
     },
     "./icons/botIcon": {
+      "types": "./icons/botIcon/dist/voussoir-icon-icons-botIcon.cjs.js",
       "module": "./icons/botIcon/dist/voussoir-icon-icons-botIcon.esm.js",
       "default": "./icons/botIcon/dist/voussoir-icon-icons-botIcon.cjs.js"
     },
     "./icons/boxIcon": {
+      "types": "./icons/boxIcon/dist/voussoir-icon-icons-boxIcon.cjs.js",
       "module": "./icons/boxIcon/dist/voussoir-icon-icons-boxIcon.esm.js",
       "default": "./icons/boxIcon/dist/voussoir-icon-icons-boxIcon.cjs.js"
     },
     "./icons/bugIcon": {
+      "types": "./icons/bugIcon/dist/voussoir-icon-icons-bugIcon.cjs.js",
       "module": "./icons/bugIcon/dist/voussoir-icon-icons-bugIcon.esm.js",
       "default": "./icons/bugIcon/dist/voussoir-icon-icons-bugIcon.cjs.js"
     },
     "./icons/busIcon": {
+      "types": "./icons/busIcon/dist/voussoir-icon-icons-busIcon.cjs.js",
       "module": "./icons/busIcon/dist/voussoir-icon-icons-busIcon.esm.js",
       "default": "./icons/busIcon/dist/voussoir-icon-icons-busIcon.cjs.js"
     },
     "./icons/carIcon": {
+      "types": "./icons/carIcon/dist/voussoir-icon-icons-carIcon.cjs.js",
       "module": "./icons/carIcon/dist/voussoir-icon-icons-carIcon.esm.js",
       "default": "./icons/carIcon/dist/voussoir-icon-icons-carIcon.cjs.js"
     },
     "./icons/catIcon": {
+      "types": "./icons/catIcon/dist/voussoir-icon-icons-catIcon.cjs.js",
       "module": "./icons/catIcon/dist/voussoir-icon-icons-catIcon.esm.js",
       "default": "./icons/catIcon/dist/voussoir-icon-icons-catIcon.cjs.js"
     },
     "./icons/cogIcon": {
+      "types": "./icons/cogIcon/dist/voussoir-icon-icons-cogIcon.cjs.js",
       "module": "./icons/cogIcon/dist/voussoir-icon-icons-cogIcon.esm.js",
       "default": "./icons/cogIcon/dist/voussoir-icon-icons-cogIcon.cjs.js"
     },
     "./icons/cpuIcon": {
+      "types": "./icons/cpuIcon/dist/voussoir-icon-icons-cpuIcon.cjs.js",
       "module": "./icons/cpuIcon/dist/voussoir-icon-icons-cpuIcon.esm.js",
       "default": "./icons/cpuIcon/dist/voussoir-icon-icons-cpuIcon.cjs.js"
     },
     "./icons/dnaIcon": {
+      "types": "./icons/dnaIcon/dist/voussoir-icon-icons-dnaIcon.cjs.js",
       "module": "./icons/dnaIcon/dist/voussoir-icon-icons-dnaIcon.esm.js",
       "default": "./icons/dnaIcon/dist/voussoir-icon-icons-dnaIcon.cjs.js"
     },
     "./icons/dogIcon": {
+      "types": "./icons/dogIcon/dist/voussoir-icon-icons-dogIcon.cjs.js",
       "module": "./icons/dogIcon/dist/voussoir-icon-icons-dogIcon.esm.js",
       "default": "./icons/dogIcon/dist/voussoir-icon-icons-dogIcon.cjs.js"
     },
     "./icons/earIcon": {
+      "types": "./icons/earIcon/dist/voussoir-icon-icons-earIcon.cjs.js",
       "module": "./icons/earIcon/dist/voussoir-icon-icons-earIcon.esm.js",
       "default": "./icons/earIcon/dist/voussoir-icon-icons-earIcon.cjs.js"
     },
     "./icons/eggIcon": {
+      "types": "./icons/eggIcon/dist/voussoir-icon-icons-eggIcon.cjs.js",
       "module": "./icons/eggIcon/dist/voussoir-icon-icons-eggIcon.esm.js",
       "default": "./icons/eggIcon/dist/voussoir-icon-icons-eggIcon.cjs.js"
     },
     "./icons/eyeIcon": {
+      "types": "./icons/eyeIcon/dist/voussoir-icon-icons-eyeIcon.cjs.js",
       "module": "./icons/eyeIcon/dist/voussoir-icon-icons-eyeIcon.esm.js",
       "default": "./icons/eyeIcon/dist/voussoir-icon-icons-eyeIcon.cjs.js"
     },
     "./icons/fanIcon": {
+      "types": "./icons/fanIcon/dist/voussoir-icon-icons-fanIcon.cjs.js",
       "module": "./icons/fanIcon/dist/voussoir-icon-icons-fanIcon.esm.js",
       "default": "./icons/fanIcon/dist/voussoir-icon-icons-fanIcon.cjs.js"
     },
     "./icons/gemIcon": {
+      "types": "./icons/gemIcon/dist/voussoir-icon-icons-gemIcon.cjs.js",
       "module": "./icons/gemIcon/dist/voussoir-icon-icons-gemIcon.esm.js",
       "default": "./icons/gemIcon/dist/voussoir-icon-icons-gemIcon.cjs.js"
     },
     "./icons/hopIcon": {
+      "types": "./icons/hopIcon/dist/voussoir-icon-icons-hopIcon.cjs.js",
       "module": "./icons/hopIcon/dist/voussoir-icon-icons-hopIcon.esm.js",
       "default": "./icons/hopIcon/dist/voussoir-icon-icons-hopIcon.cjs.js"
     },
     "./icons/keyIcon": {
+      "types": "./icons/keyIcon/dist/voussoir-icon-icons-keyIcon.cjs.js",
       "module": "./icons/keyIcon/dist/voussoir-icon-icons-keyIcon.esm.js",
       "default": "./icons/keyIcon/dist/voussoir-icon-icons-keyIcon.cjs.js"
     },
     "./icons/mapIcon": {
+      "types": "./icons/mapIcon/dist/voussoir-icon-icons-mapIcon.cjs.js",
       "module": "./icons/mapIcon/dist/voussoir-icon-icons-mapIcon.esm.js",
       "default": "./icons/mapIcon/dist/voussoir-icon-icons-mapIcon.cjs.js"
     },
     "./icons/mehIcon": {
+      "types": "./icons/mehIcon/dist/voussoir-icon-icons-mehIcon.cjs.js",
       "module": "./icons/mehIcon/dist/voussoir-icon-icons-mehIcon.esm.js",
       "default": "./icons/mehIcon/dist/voussoir-icon-icons-mehIcon.cjs.js"
     },
     "./icons/micIcon": {
+      "types": "./icons/micIcon/dist/voussoir-icon-icons-micIcon.cjs.js",
       "module": "./icons/micIcon/dist/voussoir-icon-icons-micIcon.esm.js",
       "default": "./icons/micIcon/dist/voussoir-icon-icons-micIcon.cjs.js"
     },
     "./icons/nfcIcon": {
+      "types": "./icons/nfcIcon/dist/voussoir-icon-icons-nfcIcon.cjs.js",
       "module": "./icons/nfcIcon/dist/voussoir-icon-icons-nfcIcon.esm.js",
       "default": "./icons/nfcIcon/dist/voussoir-icon-icons-nfcIcon.cjs.js"
     },
     "./icons/nutIcon": {
+      "types": "./icons/nutIcon/dist/voussoir-icon-icons-nutIcon.cjs.js",
       "module": "./icons/nutIcon/dist/voussoir-icon-icons-nutIcon.esm.js",
       "default": "./icons/nutIcon/dist/voussoir-icon-icons-nutIcon.cjs.js"
     },
     "./icons/pinIcon": {
+      "types": "./icons/pinIcon/dist/voussoir-icon-icons-pinIcon.cjs.js",
       "module": "./icons/pinIcon/dist/voussoir-icon-icons-pinIcon.esm.js",
       "default": "./icons/pinIcon/dist/voussoir-icon-icons-pinIcon.cjs.js"
     },
     "./icons/rssIcon": {
+      "types": "./icons/rssIcon/dist/voussoir-icon-icons-rssIcon.cjs.js",
       "module": "./icons/rssIcon/dist/voussoir-icon-icons-rssIcon.esm.js",
       "default": "./icons/rssIcon/dist/voussoir-icon-icons-rssIcon.cjs.js"
     },
     "./icons/sunIcon": {
+      "types": "./icons/sunIcon/dist/voussoir-icon-icons-sunIcon.cjs.js",
       "module": "./icons/sunIcon/dist/voussoir-icon-icons-sunIcon.esm.js",
       "default": "./icons/sunIcon/dist/voussoir-icon-icons-sunIcon.cjs.js"
     },
     "./icons/tagIcon": {
+      "types": "./icons/tagIcon/dist/voussoir-icon-icons-tagIcon.cjs.js",
       "module": "./icons/tagIcon/dist/voussoir-icon-icons-tagIcon.esm.js",
       "default": "./icons/tagIcon/dist/voussoir-icon-icons-tagIcon.cjs.js"
     },
     "./icons/tv2Icon": {
+      "types": "./icons/tv2Icon/dist/voussoir-icon-icons-tv2Icon.cjs.js",
       "module": "./icons/tv2Icon/dist/voussoir-icon-icons-tv2Icon.esm.js",
       "default": "./icons/tv2Icon/dist/voussoir-icon-icons-tv2Icon.cjs.js"
     },
     "./icons/usbIcon": {
+      "types": "./icons/usbIcon/dist/voussoir-icon-icons-usbIcon.cjs.js",
       "module": "./icons/usbIcon/dist/voussoir-icon-icons-usbIcon.esm.js",
       "default": "./icons/usbIcon/dist/voussoir-icon-icons-usbIcon.cjs.js"
     },
     "./icons/zapIcon": {
+      "types": "./icons/zapIcon/dist/voussoir-icon-icons-zapIcon.cjs.js",
       "module": "./icons/zapIcon/dist/voussoir-icon-icons-zapIcon.esm.js",
       "default": "./icons/zapIcon/dist/voussoir-icon-icons-zapIcon.cjs.js"
     },
     "./icons/babyIcon": {
+      "types": "./icons/babyIcon/dist/voussoir-icon-icons-babyIcon.cjs.js",
       "module": "./icons/babyIcon/dist/voussoir-icon-icons-babyIcon.esm.js",
       "default": "./icons/babyIcon/dist/voussoir-icon-icons-babyIcon.cjs.js"
     },
     "./icons/bathIcon": {
+      "types": "./icons/bathIcon/dist/voussoir-icon-icons-bathIcon.cjs.js",
       "module": "./icons/bathIcon/dist/voussoir-icon-icons-bathIcon.esm.js",
       "default": "./icons/bathIcon/dist/voussoir-icon-icons-bathIcon.cjs.js"
     },
     "./icons/beanIcon": {
+      "types": "./icons/beanIcon/dist/voussoir-icon-icons-beanIcon.cjs.js",
       "module": "./icons/beanIcon/dist/voussoir-icon-icons-beanIcon.esm.js",
       "default": "./icons/beanIcon/dist/voussoir-icon-icons-beanIcon.cjs.js"
     },
     "./icons/beefIcon": {
+      "types": "./icons/beefIcon/dist/voussoir-icon-icons-beefIcon.cjs.js",
       "module": "./icons/beefIcon/dist/voussoir-icon-icons-beefIcon.esm.js",
       "default": "./icons/beefIcon/dist/voussoir-icon-icons-beefIcon.cjs.js"
     },
     "./icons/beerIcon": {
+      "types": "./icons/beerIcon/dist/voussoir-icon-icons-beerIcon.cjs.js",
       "module": "./icons/beerIcon/dist/voussoir-icon-icons-beerIcon.esm.js",
       "default": "./icons/beerIcon/dist/voussoir-icon-icons-beerIcon.cjs.js"
     },
     "./icons/bellIcon": {
+      "types": "./icons/bellIcon/dist/voussoir-icon-icons-bellIcon.cjs.js",
       "module": "./icons/bellIcon/dist/voussoir-icon-icons-bellIcon.esm.js",
       "default": "./icons/bellIcon/dist/voussoir-icon-icons-bellIcon.cjs.js"
     },
     "./icons/bikeIcon": {
+      "types": "./icons/bikeIcon/dist/voussoir-icon-icons-bikeIcon.cjs.js",
       "module": "./icons/bikeIcon/dist/voussoir-icon-icons-bikeIcon.esm.js",
       "default": "./icons/bikeIcon/dist/voussoir-icon-icons-bikeIcon.cjs.js"
     },
     "./icons/birdIcon": {
+      "types": "./icons/birdIcon/dist/voussoir-icon-icons-birdIcon.cjs.js",
       "module": "./icons/birdIcon/dist/voussoir-icon-icons-birdIcon.esm.js",
       "default": "./icons/birdIcon/dist/voussoir-icon-icons-birdIcon.cjs.js"
     },
     "./icons/boldIcon": {
+      "types": "./icons/boldIcon/dist/voussoir-icon-icons-boldIcon.cjs.js",
       "module": "./icons/boldIcon/dist/voussoir-icon-icons-boldIcon.esm.js",
       "default": "./icons/boldIcon/dist/voussoir-icon-icons-boldIcon.cjs.js"
     },
     "./icons/bombIcon": {
+      "types": "./icons/bombIcon/dist/voussoir-icon-icons-bombIcon.cjs.js",
       "module": "./icons/bombIcon/dist/voussoir-icon-icons-bombIcon.esm.js",
       "default": "./icons/bombIcon/dist/voussoir-icon-icons-bombIcon.cjs.js"
     },
     "./icons/boneIcon": {
+      "types": "./icons/boneIcon/dist/voussoir-icon-icons-boneIcon.cjs.js",
       "module": "./icons/boneIcon/dist/voussoir-icon-icons-boneIcon.esm.js",
       "default": "./icons/boneIcon/dist/voussoir-icon-icons-boneIcon.cjs.js"
     },
     "./icons/bookIcon": {
+      "types": "./icons/bookIcon/dist/voussoir-icon-icons-bookIcon.cjs.js",
       "module": "./icons/bookIcon/dist/voussoir-icon-icons-bookIcon.esm.js",
       "default": "./icons/bookIcon/dist/voussoir-icon-icons-bookIcon.cjs.js"
     },
     "./icons/cakeIcon": {
+      "types": "./icons/cakeIcon/dist/voussoir-icon-icons-cakeIcon.cjs.js",
       "module": "./icons/cakeIcon/dist/voussoir-icon-icons-cakeIcon.esm.js",
       "default": "./icons/cakeIcon/dist/voussoir-icon-icons-cakeIcon.cjs.js"
     },
     "./icons/castIcon": {
+      "types": "./icons/castIcon/dist/voussoir-icon-icons-castIcon.cjs.js",
       "module": "./icons/castIcon/dist/voussoir-icon-icons-castIcon.esm.js",
       "default": "./icons/castIcon/dist/voussoir-icon-icons-castIcon.cjs.js"
     },
     "./icons/codeIcon": {
+      "types": "./icons/codeIcon/dist/voussoir-icon-icons-codeIcon.cjs.js",
       "module": "./icons/codeIcon/dist/voussoir-icon-icons-codeIcon.esm.js",
       "default": "./icons/codeIcon/dist/voussoir-icon-icons-codeIcon.cjs.js"
     },
     "./icons/copyIcon": {
+      "types": "./icons/copyIcon/dist/voussoir-icon-icons-copyIcon.cjs.js",
       "module": "./icons/copyIcon/dist/voussoir-icon-icons-copyIcon.esm.js",
       "default": "./icons/copyIcon/dist/voussoir-icon-icons-copyIcon.cjs.js"
     },
     "./icons/cropIcon": {
+      "types": "./icons/cropIcon/dist/voussoir-icon-icons-cropIcon.cjs.js",
       "module": "./icons/cropIcon/dist/voussoir-icon-icons-cropIcon.esm.js",
       "default": "./icons/cropIcon/dist/voussoir-icon-icons-cropIcon.cjs.js"
     },
     "./icons/diffIcon": {
+      "types": "./icons/diffIcon/dist/voussoir-icon-icons-diffIcon.cjs.js",
       "module": "./icons/diffIcon/dist/voussoir-icon-icons-diffIcon.esm.js",
       "default": "./icons/diffIcon/dist/voussoir-icon-icons-diffIcon.cjs.js"
     },
     "./icons/discIcon": {
+      "types": "./icons/discIcon/dist/voussoir-icon-icons-discIcon.cjs.js",
       "module": "./icons/discIcon/dist/voussoir-icon-icons-discIcon.esm.js",
       "default": "./icons/discIcon/dist/voussoir-icon-icons-discIcon.cjs.js"
     },
     "./icons/editIcon": {
+      "types": "./icons/editIcon/dist/voussoir-icon-icons-editIcon.cjs.js",
       "module": "./icons/editIcon/dist/voussoir-icon-icons-editIcon.esm.js",
       "default": "./icons/editIcon/dist/voussoir-icon-icons-editIcon.cjs.js"
     },
     "./icons/euroIcon": {
+      "types": "./icons/euroIcon/dist/voussoir-icon-icons-euroIcon.cjs.js",
       "module": "./icons/euroIcon/dist/voussoir-icon-icons-euroIcon.esm.js",
       "default": "./icons/euroIcon/dist/voussoir-icon-icons-euroIcon.cjs.js"
     },
     "./icons/fileIcon": {
+      "types": "./icons/fileIcon/dist/voussoir-icon-icons-fileIcon.cjs.js",
       "module": "./icons/fileIcon/dist/voussoir-icon-icons-fileIcon.esm.js",
       "default": "./icons/fileIcon/dist/voussoir-icon-icons-fileIcon.cjs.js"
     },
     "./icons/filmIcon": {
+      "types": "./icons/filmIcon/dist/voussoir-icon-icons-filmIcon.cjs.js",
       "module": "./icons/filmIcon/dist/voussoir-icon-icons-filmIcon.esm.js",
       "default": "./icons/filmIcon/dist/voussoir-icon-icons-filmIcon.cjs.js"
     },
     "./icons/fishIcon": {
+      "types": "./icons/fishIcon/dist/voussoir-icon-icons-fishIcon.cjs.js",
       "module": "./icons/fishIcon/dist/voussoir-icon-icons-fishIcon.esm.js",
       "default": "./icons/fishIcon/dist/voussoir-icon-icons-fishIcon.cjs.js"
     },
     "./icons/flagIcon": {
+      "types": "./icons/flagIcon/dist/voussoir-icon-icons-flagIcon.cjs.js",
       "module": "./icons/flagIcon/dist/voussoir-icon-icons-flagIcon.esm.js",
       "default": "./icons/flagIcon/dist/voussoir-icon-icons-flagIcon.cjs.js"
     },
     "./icons/fuelIcon": {
+      "types": "./icons/fuelIcon/dist/voussoir-icon-icons-fuelIcon.cjs.js",
       "module": "./icons/fuelIcon/dist/voussoir-icon-icons-fuelIcon.esm.js",
       "default": "./icons/fuelIcon/dist/voussoir-icon-icons-fuelIcon.cjs.js"
     },
     "./icons/giftIcon": {
+      "types": "./icons/giftIcon/dist/voussoir-icon-icons-giftIcon.cjs.js",
       "module": "./icons/giftIcon/dist/voussoir-icon-icons-giftIcon.esm.js",
       "default": "./icons/giftIcon/dist/voussoir-icon-icons-giftIcon.cjs.js"
     },
     "./icons/grabIcon": {
+      "types": "./icons/grabIcon/dist/voussoir-icon-icons-grabIcon.cjs.js",
       "module": "./icons/grabIcon/dist/voussoir-icon-icons-grabIcon.esm.js",
       "default": "./icons/grabIcon/dist/voussoir-icon-icons-grabIcon.cjs.js"
     },
     "./icons/gridIcon": {
+      "types": "./icons/gridIcon/dist/voussoir-icon-icons-gridIcon.cjs.js",
       "module": "./icons/gridIcon/dist/voussoir-icon-icons-gridIcon.esm.js",
       "default": "./icons/gridIcon/dist/voussoir-icon-icons-gridIcon.cjs.js"
     },
     "./icons/gripIcon": {
+      "types": "./icons/gripIcon/dist/voussoir-icon-icons-gripIcon.cjs.js",
       "module": "./icons/gripIcon/dist/voussoir-icon-icons-gripIcon.esm.js",
       "default": "./icons/gripIcon/dist/voussoir-icon-icons-gripIcon.cjs.js"
     },
     "./icons/handIcon": {
+      "types": "./icons/handIcon/dist/voussoir-icon-icons-handIcon.cjs.js",
       "module": "./icons/handIcon/dist/voussoir-icon-icons-handIcon.esm.js",
       "default": "./icons/handIcon/dist/voussoir-icon-icons-handIcon.cjs.js"
     },
     "./icons/hashIcon": {
+      "types": "./icons/hashIcon/dist/voussoir-icon-icons-hashIcon.cjs.js",
       "module": "./icons/hashIcon/dist/voussoir-icon-icons-hashIcon.esm.js",
       "default": "./icons/hashIcon/dist/voussoir-icon-icons-hashIcon.cjs.js"
     },
     "./icons/hazeIcon": {
+      "types": "./icons/hazeIcon/dist/voussoir-icon-icons-hazeIcon.cjs.js",
       "module": "./icons/hazeIcon/dist/voussoir-icon-icons-hazeIcon.esm.js",
       "default": "./icons/hazeIcon/dist/voussoir-icon-icons-hazeIcon.cjs.js"
     },
     "./icons/homeIcon": {
+      "types": "./icons/homeIcon/dist/voussoir-icon-icons-homeIcon.cjs.js",
       "module": "./icons/homeIcon/dist/voussoir-icon-icons-homeIcon.esm.js",
       "default": "./icons/homeIcon/dist/voussoir-icon-icons-homeIcon.cjs.js"
     },
     "./icons/infoIcon": {
+      "types": "./icons/infoIcon/dist/voussoir-icon-icons-infoIcon.cjs.js",
       "module": "./icons/infoIcon/dist/voussoir-icon-icons-infoIcon.esm.js",
       "default": "./icons/infoIcon/dist/voussoir-icon-icons-infoIcon.cjs.js"
     },
     "./icons/lampIcon": {
+      "types": "./icons/lampIcon/dist/voussoir-icon-icons-lampIcon.cjs.js",
       "module": "./icons/lampIcon/dist/voussoir-icon-icons-lampIcon.esm.js",
       "default": "./icons/lampIcon/dist/voussoir-icon-icons-lampIcon.cjs.js"
     },
     "./icons/leafIcon": {
+      "types": "./icons/leafIcon/dist/voussoir-icon-icons-leafIcon.cjs.js",
       "module": "./icons/leafIcon/dist/voussoir-icon-icons-leafIcon.esm.js",
       "default": "./icons/leafIcon/dist/voussoir-icon-icons-leafIcon.cjs.js"
     },
     "./icons/linkIcon": {
+      "types": "./icons/linkIcon/dist/voussoir-icon-icons-linkIcon.cjs.js",
       "module": "./icons/linkIcon/dist/voussoir-icon-icons-linkIcon.esm.js",
       "default": "./icons/linkIcon/dist/voussoir-icon-icons-linkIcon.cjs.js"
     },
     "./icons/listIcon": {
+      "types": "./icons/listIcon/dist/voussoir-icon-icons-listIcon.cjs.js",
       "module": "./icons/listIcon/dist/voussoir-icon-icons-listIcon.esm.js",
       "default": "./icons/listIcon/dist/voussoir-icon-icons-listIcon.cjs.js"
     },
     "./icons/lockIcon": {
+      "types": "./icons/lockIcon/dist/voussoir-icon-icons-lockIcon.cjs.js",
       "module": "./icons/lockIcon/dist/voussoir-icon-icons-lockIcon.esm.js",
       "default": "./icons/lockIcon/dist/voussoir-icon-icons-lockIcon.cjs.js"
     },
     "./icons/mailIcon": {
+      "types": "./icons/mailIcon/dist/voussoir-icon-icons-mailIcon.cjs.js",
       "module": "./icons/mailIcon/dist/voussoir-icon-icons-mailIcon.esm.js",
       "default": "./icons/mailIcon/dist/voussoir-icon-icons-mailIcon.cjs.js"
     },
     "./icons/menuIcon": {
+      "types": "./icons/menuIcon/dist/voussoir-icon-icons-menuIcon.cjs.js",
       "module": "./icons/menuIcon/dist/voussoir-icon-icons-menuIcon.esm.js",
       "default": "./icons/menuIcon/dist/voussoir-icon-icons-menuIcon.cjs.js"
     },
     "./icons/mic2Icon": {
+      "types": "./icons/mic2Icon/dist/voussoir-icon-icons-mic2Icon.cjs.js",
       "module": "./icons/mic2Icon/dist/voussoir-icon-icons-mic2Icon.esm.js",
       "default": "./icons/mic2Icon/dist/voussoir-icon-icons-mic2Icon.cjs.js"
     },
     "./icons/milkIcon": {
+      "types": "./icons/milkIcon/dist/voussoir-icon-icons-milkIcon.cjs.js",
       "module": "./icons/milkIcon/dist/voussoir-icon-icons-milkIcon.esm.js",
       "default": "./icons/milkIcon/dist/voussoir-icon-icons-milkIcon.cjs.js"
     },
     "./icons/moonIcon": {
+      "types": "./icons/moonIcon/dist/voussoir-icon-icons-moonIcon.cjs.js",
       "module": "./icons/moonIcon/dist/voussoir-icon-icons-moonIcon.esm.js",
       "default": "./icons/moonIcon/dist/voussoir-icon-icons-moonIcon.cjs.js"
     },
     "./icons/moveIcon": {
+      "types": "./icons/moveIcon/dist/voussoir-icon-icons-moveIcon.cjs.js",
       "module": "./icons/moveIcon/dist/voussoir-icon-icons-moveIcon.esm.js",
       "default": "./icons/moveIcon/dist/voussoir-icon-icons-moveIcon.cjs.js"
     },
     "./icons/pillIcon": {
+      "types": "./icons/pillIcon/dist/voussoir-icon-icons-pillIcon.cjs.js",
       "module": "./icons/pillIcon/dist/voussoir-icon-icons-pillIcon.esm.js",
       "default": "./icons/pillIcon/dist/voussoir-icon-icons-pillIcon.cjs.js"
     },
     "./icons/playIcon": {
+      "types": "./icons/playIcon/dist/voussoir-icon-icons-playIcon.cjs.js",
       "module": "./icons/playIcon/dist/voussoir-icon-icons-playIcon.esm.js",
       "default": "./icons/playIcon/dist/voussoir-icon-icons-playIcon.cjs.js"
     },
     "./icons/plugIcon": {
+      "types": "./icons/plugIcon/dist/voussoir-icon-icons-plugIcon.cjs.js",
       "module": "./icons/plugIcon/dist/voussoir-icon-icons-plugIcon.esm.js",
       "default": "./icons/plugIcon/dist/voussoir-icon-icons-plugIcon.cjs.js"
     },
     "./icons/plusIcon": {
+      "types": "./icons/plusIcon/dist/voussoir-icon-icons-plusIcon.cjs.js",
       "module": "./icons/plusIcon/dist/voussoir-icon-icons-plusIcon.esm.js",
       "default": "./icons/plusIcon/dist/voussoir-icon-icons-plusIcon.cjs.js"
     },
     "./icons/redoIcon": {
+      "types": "./icons/redoIcon/dist/voussoir-icon-icons-redoIcon.cjs.js",
       "module": "./icons/redoIcon/dist/voussoir-icon-icons-redoIcon.esm.js",
       "default": "./icons/redoIcon/dist/voussoir-icon-icons-redoIcon.cjs.js"
     },
     "./icons/saveIcon": {
+      "types": "./icons/saveIcon/dist/voussoir-icon-icons-saveIcon.cjs.js",
       "module": "./icons/saveIcon/dist/voussoir-icon-icons-saveIcon.esm.js",
       "default": "./icons/saveIcon/dist/voussoir-icon-icons-saveIcon.cjs.js"
     },
     "./icons/scanIcon": {
+      "types": "./icons/scanIcon/dist/voussoir-icon-icons-scanIcon.cjs.js",
       "module": "./icons/scanIcon/dist/voussoir-icon-icons-scanIcon.esm.js",
       "default": "./icons/scanIcon/dist/voussoir-icon-icons-scanIcon.cjs.js"
     },
     "./icons/sendIcon": {
+      "types": "./icons/sendIcon/dist/voussoir-icon-icons-sendIcon.cjs.js",
       "module": "./icons/sendIcon/dist/voussoir-icon-icons-sendIcon.esm.js",
       "default": "./icons/sendIcon/dist/voussoir-icon-icons-sendIcon.cjs.js"
     },
     "./icons/shipIcon": {
+      "types": "./icons/shipIcon/dist/voussoir-icon-icons-shipIcon.cjs.js",
       "module": "./icons/shipIcon/dist/voussoir-icon-icons-shipIcon.esm.js",
       "default": "./icons/shipIcon/dist/voussoir-icon-icons-shipIcon.cjs.js"
     },
     "./icons/sofaIcon": {
+      "types": "./icons/sofaIcon/dist/voussoir-icon-icons-sofaIcon.cjs.js",
       "module": "./icons/sofaIcon/dist/voussoir-icon-icons-sofaIcon.esm.js",
       "default": "./icons/sofaIcon/dist/voussoir-icon-icons-sofaIcon.cjs.js"
     },
     "./icons/soupIcon": {
+      "types": "./icons/soupIcon/dist/voussoir-icon-icons-soupIcon.cjs.js",
       "module": "./icons/soupIcon/dist/voussoir-icon-icons-soupIcon.esm.js",
       "default": "./icons/soupIcon/dist/voussoir-icon-icons-soupIcon.cjs.js"
     },
     "./icons/starIcon": {
+      "types": "./icons/starIcon/dist/voussoir-icon-icons-starIcon.cjs.js",
       "module": "./icons/starIcon/dist/voussoir-icon-icons-starIcon.esm.js",
       "default": "./icons/starIcon/dist/voussoir-icon-icons-starIcon.cjs.js"
     },
     "./icons/tagsIcon": {
+      "types": "./icons/tagsIcon/dist/voussoir-icon-icons-tagsIcon.cjs.js",
       "module": "./icons/tagsIcon/dist/voussoir-icon-icons-tagsIcon.esm.js",
       "default": "./icons/tagsIcon/dist/voussoir-icon-icons-tagsIcon.cjs.js"
     },
     "./icons/tentIcon": {
+      "types": "./icons/tentIcon/dist/voussoir-icon-icons-tentIcon.cjs.js",
       "module": "./icons/tentIcon/dist/voussoir-icon-icons-tentIcon.esm.js",
       "default": "./icons/tentIcon/dist/voussoir-icon-icons-tentIcon.cjs.js"
     },
     "./icons/typeIcon": {
+      "types": "./icons/typeIcon/dist/voussoir-icon-icons-typeIcon.cjs.js",
       "module": "./icons/typeIcon/dist/voussoir-icon-icons-typeIcon.esm.js",
       "default": "./icons/typeIcon/dist/voussoir-icon-icons-typeIcon.cjs.js"
     },
     "./icons/undoIcon": {
+      "types": "./icons/undoIcon/dist/voussoir-icon-icons-undoIcon.cjs.js",
       "module": "./icons/undoIcon/dist/voussoir-icon-icons-undoIcon.esm.js",
       "default": "./icons/undoIcon/dist/voussoir-icon-icons-undoIcon.cjs.js"
     },
     "./icons/userIcon": {
+      "types": "./icons/userIcon/dist/voussoir-icon-icons-userIcon.cjs.js",
       "module": "./icons/userIcon/dist/voussoir-icon-icons-userIcon.esm.js",
       "default": "./icons/userIcon/dist/voussoir-icon-icons-userIcon.cjs.js"
     },
     "./icons/viewIcon": {
+      "types": "./icons/viewIcon/dist/voussoir-icon-icons-viewIcon.cjs.js",
       "module": "./icons/viewIcon/dist/voussoir-icon-icons-viewIcon.esm.js",
       "default": "./icons/viewIcon/dist/voussoir-icon-icons-viewIcon.cjs.js"
     },
     "./icons/voteIcon": {
+      "types": "./icons/voteIcon/dist/voussoir-icon-icons-voteIcon.cjs.js",
       "module": "./icons/voteIcon/dist/voussoir-icon-icons-voteIcon.esm.js",
       "default": "./icons/voteIcon/dist/voussoir-icon-icons-voteIcon.cjs.js"
     },
     "./icons/wandIcon": {
+      "types": "./icons/wandIcon/dist/voussoir-icon-icons-wandIcon.cjs.js",
       "module": "./icons/wandIcon/dist/voussoir-icon-icons-wandIcon.esm.js",
       "default": "./icons/wandIcon/dist/voussoir-icon-icons-wandIcon.cjs.js"
     },
     "./icons/wifiIcon": {
+      "types": "./icons/wifiIcon/dist/voussoir-icon-icons-wifiIcon.cjs.js",
       "module": "./icons/wifiIcon/dist/voussoir-icon-icons-wifiIcon.esm.js",
       "default": "./icons/wifiIcon/dist/voussoir-icon-icons-wifiIcon.cjs.js"
     },
     "./icons/windIcon": {
+      "types": "./icons/windIcon/dist/voussoir-icon-icons-windIcon.cjs.js",
       "module": "./icons/windIcon/dist/voussoir-icon-icons-windIcon.esm.js",
       "default": "./icons/windIcon/dist/voussoir-icon-icons-windIcon.cjs.js"
     },
     "./icons/wineIcon": {
+      "types": "./icons/wineIcon/dist/voussoir-icon-icons-wineIcon.cjs.js",
       "module": "./icons/wineIcon/dist/voussoir-icon-icons-wineIcon.esm.js",
       "default": "./icons/wineIcon/dist/voussoir-icon-icons-wineIcon.cjs.js"
     },
     "./icons/albumIcon": {
+      "types": "./icons/albumIcon/dist/voussoir-icon-icons-albumIcon.cjs.js",
       "module": "./icons/albumIcon/dist/voussoir-icon-icons-albumIcon.esm.js",
       "default": "./icons/albumIcon/dist/voussoir-icon-icons-albumIcon.cjs.js"
     },
     "./icons/angryIcon": {
+      "types": "./icons/angryIcon/dist/voussoir-icon-icons-angryIcon.cjs.js",
       "module": "./icons/angryIcon/dist/voussoir-icon-icons-angryIcon.esm.js",
       "default": "./icons/angryIcon/dist/voussoir-icon-icons-angryIcon.cjs.js"
     },
     "./icons/appleIcon": {
+      "types": "./icons/appleIcon/dist/voussoir-icon-icons-appleIcon.cjs.js",
       "module": "./icons/appleIcon/dist/voussoir-icon-icons-appleIcon.esm.js",
       "default": "./icons/appleIcon/dist/voussoir-icon-icons-appleIcon.cjs.js"
     },
     "./icons/awardIcon": {
+      "types": "./icons/awardIcon/dist/voussoir-icon-icons-awardIcon.cjs.js",
       "module": "./icons/awardIcon/dist/voussoir-icon-icons-awardIcon.esm.js",
       "default": "./icons/awardIcon/dist/voussoir-icon-icons-awardIcon.cjs.js"
     },
     "./icons/boxesIcon": {
+      "types": "./icons/boxesIcon/dist/voussoir-icon-icons-boxesIcon.cjs.js",
       "module": "./icons/boxesIcon/dist/voussoir-icon-icons-boxesIcon.esm.js",
       "default": "./icons/boxesIcon/dist/voussoir-icon-icons-boxesIcon.cjs.js"
     },
     "./icons/brainIcon": {
+      "types": "./icons/brainIcon/dist/voussoir-icon-icons-brainIcon.cjs.js",
       "module": "./icons/brainIcon/dist/voussoir-icon-icons-brainIcon.esm.js",
       "default": "./icons/brainIcon/dist/voussoir-icon-icons-brainIcon.cjs.js"
     },
     "./icons/brushIcon": {
+      "types": "./icons/brushIcon/dist/voussoir-icon-icons-brushIcon.cjs.js",
       "module": "./icons/brushIcon/dist/voussoir-icon-icons-brushIcon.esm.js",
       "default": "./icons/brushIcon/dist/voussoir-icon-icons-brushIcon.cjs.js"
     },
     "./icons/candyIcon": {
+      "types": "./icons/candyIcon/dist/voussoir-icon-icons-candyIcon.cjs.js",
       "module": "./icons/candyIcon/dist/voussoir-icon-icons-candyIcon.esm.js",
       "default": "./icons/candyIcon/dist/voussoir-icon-icons-candyIcon.cjs.js"
     },
     "./icons/checkIcon": {
+      "types": "./icons/checkIcon/dist/voussoir-icon-icons-checkIcon.cjs.js",
       "module": "./icons/checkIcon/dist/voussoir-icon-icons-checkIcon.esm.js",
       "default": "./icons/checkIcon/dist/voussoir-icon-icons-checkIcon.cjs.js"
     },
     "./icons/clockIcon": {
+      "types": "./icons/clockIcon/dist/voussoir-icon-icons-clockIcon.cjs.js",
       "module": "./icons/clockIcon/dist/voussoir-icon-icons-clockIcon.esm.js",
       "default": "./icons/clockIcon/dist/voussoir-icon-icons-clockIcon.cjs.js"
     },
     "./icons/cloudIcon": {
+      "types": "./icons/cloudIcon/dist/voussoir-icon-icons-cloudIcon.cjs.js",
       "module": "./icons/cloudIcon/dist/voussoir-icon-icons-cloudIcon.esm.js",
       "default": "./icons/cloudIcon/dist/voussoir-icon-icons-cloudIcon.cjs.js"
     },
     "./icons/code2Icon": {
+      "types": "./icons/code2Icon/dist/voussoir-icon-icons-code2Icon.cjs.js",
       "module": "./icons/code2Icon/dist/voussoir-icon-icons-code2Icon.esm.js",
       "default": "./icons/code2Icon/dist/voussoir-icon-icons-code2Icon.cjs.js"
     },
     "./icons/coinsIcon": {
+      "types": "./icons/coinsIcon/dist/voussoir-icon-icons-coinsIcon.cjs.js",
       "module": "./icons/coinsIcon/dist/voussoir-icon-icons-coinsIcon.esm.js",
       "default": "./icons/coinsIcon/dist/voussoir-icon-icons-coinsIcon.cjs.js"
     },
     "./icons/crossIcon": {
+      "types": "./icons/crossIcon/dist/voussoir-icon-icons-crossIcon.cjs.js",
       "module": "./icons/crossIcon/dist/voussoir-icon-icons-crossIcon.esm.js",
       "default": "./icons/crossIcon/dist/voussoir-icon-icons-crossIcon.cjs.js"
     },
     "./icons/crownIcon": {
+      "types": "./icons/crownIcon/dist/voussoir-icon-icons-crownIcon.cjs.js",
       "module": "./icons/crownIcon/dist/voussoir-icon-icons-crownIcon.esm.js",
       "default": "./icons/crownIcon/dist/voussoir-icon-icons-crownIcon.cjs.js"
     },
     "./icons/dice1Icon": {
+      "types": "./icons/dice1Icon/dist/voussoir-icon-icons-dice1Icon.cjs.js",
       "module": "./icons/dice1Icon/dist/voussoir-icon-icons-dice1Icon.esm.js",
       "default": "./icons/dice1Icon/dist/voussoir-icon-icons-dice1Icon.cjs.js"
     },
     "./icons/dice2Icon": {
+      "types": "./icons/dice2Icon/dist/voussoir-icon-icons-dice2Icon.cjs.js",
       "module": "./icons/dice2Icon/dist/voussoir-icon-icons-dice2Icon.esm.js",
       "default": "./icons/dice2Icon/dist/voussoir-icon-icons-dice2Icon.cjs.js"
     },
     "./icons/dice3Icon": {
+      "types": "./icons/dice3Icon/dist/voussoir-icon-icons-dice3Icon.cjs.js",
       "module": "./icons/dice3Icon/dist/voussoir-icon-icons-dice3Icon.esm.js",
       "default": "./icons/dice3Icon/dist/voussoir-icon-icons-dice3Icon.cjs.js"
     },
     "./icons/dice4Icon": {
+      "types": "./icons/dice4Icon/dist/voussoir-icon-icons-dice4Icon.cjs.js",
       "module": "./icons/dice4Icon/dist/voussoir-icon-icons-dice4Icon.esm.js",
       "default": "./icons/dice4Icon/dist/voussoir-icon-icons-dice4Icon.cjs.js"
     },
     "./icons/dice5Icon": {
+      "types": "./icons/dice5Icon/dist/voussoir-icon-icons-dice5Icon.cjs.js",
       "module": "./icons/dice5Icon/dist/voussoir-icon-icons-dice5Icon.esm.js",
       "default": "./icons/dice5Icon/dist/voussoir-icon-icons-dice5Icon.cjs.js"
     },
     "./icons/dice6Icon": {
+      "types": "./icons/dice6Icon/dist/voussoir-icon-icons-dice6Icon.cjs.js",
       "module": "./icons/dice6Icon/dist/voussoir-icon-icons-dice6Icon.esm.js",
       "default": "./icons/dice6Icon/dist/voussoir-icon-icons-dice6Icon.cjs.js"
     },
     "./icons/dicesIcon": {
+      "types": "./icons/dicesIcon/dist/voussoir-icon-icons-dicesIcon.cjs.js",
       "module": "./icons/dicesIcon/dist/voussoir-icon-icons-dicesIcon.esm.js",
       "default": "./icons/dicesIcon/dist/voussoir-icon-icons-dicesIcon.cjs.js"
     },
     "./icons/edit2Icon": {
+      "types": "./icons/edit2Icon/dist/voussoir-icon-icons-edit2Icon.cjs.js",
       "module": "./icons/edit2Icon/dist/voussoir-icon-icons-edit2Icon.esm.js",
       "default": "./icons/edit2Icon/dist/voussoir-icon-icons-edit2Icon.cjs.js"
     },
     "./icons/edit3Icon": {
+      "types": "./icons/edit3Icon/dist/voussoir-icon-icons-edit3Icon.cjs.js",
       "module": "./icons/edit3Icon/dist/voussoir-icon-icons-edit3Icon.esm.js",
       "default": "./icons/edit3Icon/dist/voussoir-icon-icons-edit3Icon.cjs.js"
     },
     "./icons/equalIcon": {
+      "types": "./icons/equalIcon/dist/voussoir-icon-icons-equalIcon.cjs.js",
       "module": "./icons/equalIcon/dist/voussoir-icon-icons-equalIcon.esm.js",
       "default": "./icons/equalIcon/dist/voussoir-icon-icons-equalIcon.cjs.js"
     },
     "./icons/figmaIcon": {
+      "types": "./icons/figmaIcon/dist/voussoir-icon-icons-figmaIcon.cjs.js",
       "module": "./icons/figmaIcon/dist/voussoir-icon-icons-figmaIcon.esm.js",
       "default": "./icons/figmaIcon/dist/voussoir-icon-icons-figmaIcon.cjs.js"
     },
     "./icons/fileXIcon": {
+      "types": "./icons/fileXIcon/dist/voussoir-icon-icons-fileXIcon.cjs.js",
       "module": "./icons/fileXIcon/dist/voussoir-icon-icons-fileXIcon.esm.js",
       "default": "./icons/fileXIcon/dist/voussoir-icon-icons-fileXIcon.cjs.js"
     },
     "./icons/filesIcon": {
+      "types": "./icons/filesIcon/dist/voussoir-icon-icons-filesIcon.cjs.js",
       "module": "./icons/filesIcon/dist/voussoir-icon-icons-filesIcon.esm.js",
       "default": "./icons/filesIcon/dist/voussoir-icon-icons-filesIcon.cjs.js"
     },
     "./icons/flameIcon": {
+      "types": "./icons/flameIcon/dist/voussoir-icon-icons-flameIcon.cjs.js",
       "module": "./icons/flameIcon/dist/voussoir-icon-icons-flameIcon.esm.js",
       "default": "./icons/flameIcon/dist/voussoir-icon-icons-flameIcon.cjs.js"
     },
     "./icons/focusIcon": {
+      "types": "./icons/focusIcon/dist/voussoir-icon-icons-focusIcon.cjs.js",
       "module": "./icons/focusIcon/dist/voussoir-icon-icons-focusIcon.esm.js",
       "default": "./icons/focusIcon/dist/voussoir-icon-icons-focusIcon.cjs.js"
     },
     "./icons/frameIcon": {
+      "types": "./icons/frameIcon/dist/voussoir-icon-icons-frameIcon.cjs.js",
       "module": "./icons/frameIcon/dist/voussoir-icon-icons-frameIcon.esm.js",
       "default": "./icons/frameIcon/dist/voussoir-icon-icons-frameIcon.cjs.js"
     },
     "./icons/frownIcon": {
+      "types": "./icons/frownIcon/dist/voussoir-icon-icons-frownIcon.cjs.js",
       "module": "./icons/frownIcon/dist/voussoir-icon-icons-frownIcon.esm.js",
       "default": "./icons/frownIcon/dist/voussoir-icon-icons-frownIcon.cjs.js"
     },
     "./icons/gaugeIcon": {
+      "types": "./icons/gaugeIcon/dist/voussoir-icon-icons-gaugeIcon.cjs.js",
       "module": "./icons/gaugeIcon/dist/voussoir-icon-icons-gaugeIcon.esm.js",
       "default": "./icons/gaugeIcon/dist/voussoir-icon-icons-gaugeIcon.cjs.js"
     },
     "./icons/gavelIcon": {
+      "types": "./icons/gavelIcon/dist/voussoir-icon-icons-gavelIcon.cjs.js",
       "module": "./icons/gavelIcon/dist/voussoir-icon-icons-gavelIcon.esm.js",
       "default": "./icons/gavelIcon/dist/voussoir-icon-icons-gavelIcon.cjs.js"
     },
     "./icons/ghostIcon": {
+      "types": "./icons/ghostIcon/dist/voussoir-icon-icons-ghostIcon.cjs.js",
       "module": "./icons/ghostIcon/dist/voussoir-icon-icons-ghostIcon.esm.js",
       "default": "./icons/ghostIcon/dist/voussoir-icon-icons-ghostIcon.cjs.js"
     },
     "./icons/globeIcon": {
+      "types": "./icons/globeIcon/dist/voussoir-icon-icons-globeIcon.cjs.js",
       "module": "./icons/globeIcon/dist/voussoir-icon-icons-globeIcon.esm.js",
       "default": "./icons/globeIcon/dist/voussoir-icon-icons-globeIcon.cjs.js"
     },
     "./icons/grapeIcon": {
+      "types": "./icons/grapeIcon/dist/voussoir-icon-icons-grapeIcon.cjs.js",
       "module": "./icons/grapeIcon/dist/voussoir-icon-icons-grapeIcon.esm.js",
       "default": "./icons/grapeIcon/dist/voussoir-icon-icons-grapeIcon.cjs.js"
     },
     "./icons/heartIcon": {
+      "types": "./icons/heartIcon/dist/voussoir-icon-icons-heartIcon.cjs.js",
       "module": "./icons/heartIcon/dist/voussoir-icon-icons-heartIcon.esm.js",
       "default": "./icons/heartIcon/dist/voussoir-icon-icons-heartIcon.cjs.js"
     },
     "./icons/imageIcon": {
+      "types": "./icons/imageIcon/dist/voussoir-icon-icons-imageIcon.cjs.js",
       "module": "./icons/imageIcon/dist/voussoir-icon-icons-imageIcon.esm.js",
       "default": "./icons/imageIcon/dist/voussoir-icon-icons-imageIcon.cjs.js"
     },
     "./icons/inboxIcon": {
+      "types": "./icons/inboxIcon/dist/voussoir-icon-icons-inboxIcon.cjs.js",
       "module": "./icons/inboxIcon/dist/voussoir-icon-icons-inboxIcon.esm.js",
       "default": "./icons/inboxIcon/dist/voussoir-icon-icons-inboxIcon.cjs.js"
     },
     "./icons/lassoIcon": {
+      "types": "./icons/lassoIcon/dist/voussoir-icon-icons-lassoIcon.cjs.js",
       "module": "./icons/lassoIcon/dist/voussoir-icon-icons-lassoIcon.esm.js",
       "default": "./icons/lassoIcon/dist/voussoir-icon-icons-lassoIcon.cjs.js"
     },
     "./icons/laughIcon": {
+      "types": "./icons/laughIcon/dist/voussoir-icon-icons-laughIcon.cjs.js",
       "module": "./icons/laughIcon/dist/voussoir-icon-icons-laughIcon.esm.js",
       "default": "./icons/laughIcon/dist/voussoir-icon-icons-laughIcon.cjs.js"
     },
     "./icons/link2Icon": {
+      "types": "./icons/link2Icon/dist/voussoir-icon-icons-link2Icon.cjs.js",
       "module": "./icons/link2Icon/dist/voussoir-icon-icons-link2Icon.esm.js",
       "default": "./icons/link2Icon/dist/voussoir-icon-icons-link2Icon.cjs.js"
     },
     "./icons/listXIcon": {
+      "types": "./icons/listXIcon/dist/voussoir-icon-icons-listXIcon.cjs.js",
       "module": "./icons/listXIcon/dist/voussoir-icon-icons-listXIcon.esm.js",
       "default": "./icons/listXIcon/dist/voussoir-icon-icons-listXIcon.cjs.js"
     },
     "./icons/logInIcon": {
+      "types": "./icons/logInIcon/dist/voussoir-icon-icons-logInIcon.cjs.js",
       "module": "./icons/logInIcon/dist/voussoir-icon-icons-logInIcon.esm.js",
       "default": "./icons/logInIcon/dist/voussoir-icon-icons-logInIcon.cjs.js"
     },
     "./icons/mailXIcon": {
+      "types": "./icons/mailXIcon/dist/voussoir-icon-icons-mailXIcon.cjs.js",
       "module": "./icons/mailXIcon/dist/voussoir-icon-icons-mailXIcon.esm.js",
       "default": "./icons/mailXIcon/dist/voussoir-icon-icons-mailXIcon.cjs.js"
     },
     "./icons/mailsIcon": {
+      "types": "./icons/mailsIcon/dist/voussoir-icon-icons-mailsIcon.cjs.js",
       "module": "./icons/mailsIcon/dist/voussoir-icon-icons-mailsIcon.esm.js",
       "default": "./icons/mailsIcon/dist/voussoir-icon-icons-mailsIcon.cjs.js"
     },
     "./icons/medalIcon": {
+      "types": "./icons/medalIcon/dist/voussoir-icon-icons-medalIcon.cjs.js",
       "module": "./icons/medalIcon/dist/voussoir-icon-icons-medalIcon.esm.js",
       "default": "./icons/medalIcon/dist/voussoir-icon-icons-medalIcon.cjs.js"
     },
     "./icons/minusIcon": {
+      "types": "./icons/minusIcon/dist/voussoir-icon-icons-minusIcon.cjs.js",
       "module": "./icons/minusIcon/dist/voussoir-icon-icons-minusIcon.esm.js",
       "default": "./icons/minusIcon/dist/voussoir-icon-icons-minusIcon.cjs.js"
     },
     "./icons/mouseIcon": {
+      "types": "./icons/mouseIcon/dist/voussoir-icon-icons-mouseIcon.cjs.js",
       "module": "./icons/mouseIcon/dist/voussoir-icon-icons-mouseIcon.esm.js",
       "default": "./icons/mouseIcon/dist/voussoir-icon-icons-mouseIcon.cjs.js"
     },
     "./icons/musicIcon": {
+      "types": "./icons/musicIcon/dist/voussoir-icon-icons-musicIcon.cjs.js",
       "module": "./icons/musicIcon/dist/voussoir-icon-icons-musicIcon.esm.js",
       "default": "./icons/musicIcon/dist/voussoir-icon-icons-musicIcon.cjs.js"
     },
     "./icons/pauseIcon": {
+      "types": "./icons/pauseIcon/dist/voussoir-icon-icons-pauseIcon.cjs.js",
       "module": "./icons/pauseIcon/dist/voussoir-icon-icons-pauseIcon.esm.js",
       "default": "./icons/pauseIcon/dist/voussoir-icon-icons-pauseIcon.cjs.js"
     },
     "./icons/phoneIcon": {
+      "types": "./icons/phoneIcon/dist/voussoir-icon-icons-phoneIcon.cjs.js",
       "module": "./icons/phoneIcon/dist/voussoir-icon-icons-phoneIcon.esm.js",
       "default": "./icons/phoneIcon/dist/voussoir-icon-icons-phoneIcon.cjs.js"
     },
     "./icons/pizzaIcon": {
+      "types": "./icons/pizzaIcon/dist/voussoir-icon-icons-pizzaIcon.cjs.js",
       "module": "./icons/pizzaIcon/dist/voussoir-icon-icons-pizzaIcon.esm.js",
       "default": "./icons/pizzaIcon/dist/voussoir-icon-icons-pizzaIcon.cjs.js"
     },
     "./icons/planeIcon": {
+      "types": "./icons/planeIcon/dist/voussoir-icon-icons-planeIcon.cjs.js",
       "module": "./icons/planeIcon/dist/voussoir-icon-icons-planeIcon.esm.js",
       "default": "./icons/planeIcon/dist/voussoir-icon-icons-planeIcon.cjs.js"
     },
     "./icons/plug2Icon": {
+      "types": "./icons/plug2Icon/dist/voussoir-icon-icons-plug2Icon.cjs.js",
       "module": "./icons/plug2Icon/dist/voussoir-icon-icons-plug2Icon.esm.js",
       "default": "./icons/plug2Icon/dist/voussoir-icon-icons-plug2Icon.cjs.js"
     },
     "./icons/powerIcon": {
+      "types": "./icons/powerIcon/dist/voussoir-icon-icons-powerIcon.cjs.js",
       "module": "./icons/powerIcon/dist/voussoir-icon-icons-powerIcon.esm.js",
       "default": "./icons/powerIcon/dist/voussoir-icon-icons-powerIcon.cjs.js"
     },
     "./icons/quoteIcon": {
+      "types": "./icons/quoteIcon/dist/voussoir-icon-icons-quoteIcon.cjs.js",
       "module": "./icons/quoteIcon/dist/voussoir-icon-icons-quoteIcon.esm.js",
       "default": "./icons/quoteIcon/dist/voussoir-icon-icons-quoteIcon.cjs.js"
     },
     "./icons/radioIcon": {
+      "types": "./icons/radioIcon/dist/voussoir-icon-icons-radioIcon.cjs.js",
       "module": "./icons/radioIcon/dist/voussoir-icon-icons-radioIcon.esm.js",
       "default": "./icons/radioIcon/dist/voussoir-icon-icons-radioIcon.cjs.js"
     },
     "./icons/redo2Icon": {
+      "types": "./icons/redo2Icon/dist/voussoir-icon-icons-redo2Icon.cjs.js",
       "module": "./icons/redo2Icon/dist/voussoir-icon-icons-redo2Icon.esm.js",
       "default": "./icons/redo2Icon/dist/voussoir-icon-icons-redo2Icon.cjs.js"
     },
     "./icons/regexIcon": {
+      "types": "./icons/regexIcon/dist/voussoir-icon-icons-regexIcon.cjs.js",
       "module": "./icons/regexIcon/dist/voussoir-icon-icons-regexIcon.esm.js",
       "default": "./icons/regexIcon/dist/voussoir-icon-icons-regexIcon.cjs.js"
     },
     "./icons/replyIcon": {
+      "types": "./icons/replyIcon/dist/voussoir-icon-icons-replyIcon.cjs.js",
       "module": "./icons/replyIcon/dist/voussoir-icon-icons-replyIcon.esm.js",
       "default": "./icons/replyIcon/dist/voussoir-icon-icons-replyIcon.cjs.js"
     },
     "./icons/rulerIcon": {
+      "types": "./icons/rulerIcon/dist/voussoir-icon-icons-rulerIcon.cjs.js",
       "module": "./icons/rulerIcon/dist/voussoir-icon-icons-rulerIcon.esm.js",
       "default": "./icons/rulerIcon/dist/voussoir-icon-icons-rulerIcon.cjs.js"
     },
     "./icons/saladIcon": {
+      "types": "./icons/saladIcon/dist/voussoir-icon-icons-saladIcon.cjs.js",
       "module": "./icons/saladIcon/dist/voussoir-icon-icons-saladIcon.esm.js",
       "default": "./icons/saladIcon/dist/voussoir-icon-icons-saladIcon.cjs.js"
     },
     "./icons/scaleIcon": {
+      "types": "./icons/scaleIcon/dist/voussoir-icon-icons-scaleIcon.cjs.js",
       "module": "./icons/scaleIcon/dist/voussoir-icon-icons-scaleIcon.esm.js",
       "default": "./icons/scaleIcon/dist/voussoir-icon-icons-scaleIcon.cjs.js"
     },
     "./icons/shareIcon": {
+      "types": "./icons/shareIcon/dist/voussoir-icon-icons-shareIcon.cjs.js",
       "module": "./icons/shareIcon/dist/voussoir-icon-icons-shareIcon.esm.js",
       "default": "./icons/shareIcon/dist/voussoir-icon-icons-shareIcon.cjs.js"
     },
     "./icons/sheetIcon": {
+      "types": "./icons/sheetIcon/dist/voussoir-icon-icons-sheetIcon.cjs.js",
       "module": "./icons/sheetIcon/dist/voussoir-icon-icons-sheetIcon.esm.js",
       "default": "./icons/sheetIcon/dist/voussoir-icon-icons-sheetIcon.cjs.js"
     },
     "./icons/shirtIcon": {
+      "types": "./icons/shirtIcon/dist/voussoir-icon-icons-shirtIcon.cjs.js",
       "module": "./icons/shirtIcon/dist/voussoir-icon-icons-shirtIcon.esm.js",
       "default": "./icons/shirtIcon/dist/voussoir-icon-icons-shirtIcon.cjs.js"
     },
     "./icons/shrubIcon": {
+      "types": "./icons/shrubIcon/dist/voussoir-icon-icons-shrubIcon.cjs.js",
       "module": "./icons/shrubIcon/dist/voussoir-icon-icons-shrubIcon.esm.js",
       "default": "./icons/shrubIcon/dist/voussoir-icon-icons-shrubIcon.cjs.js"
     },
     "./icons/sigmaIcon": {
+      "types": "./icons/sigmaIcon/dist/voussoir-icon-icons-sigmaIcon.cjs.js",
       "module": "./icons/sigmaIcon/dist/voussoir-icon-icons-sigmaIcon.esm.js",
       "default": "./icons/sigmaIcon/dist/voussoir-icon-icons-sigmaIcon.cjs.js"
     },
     "./icons/sirenIcon": {
+      "types": "./icons/sirenIcon/dist/voussoir-icon-icons-sirenIcon.cjs.js",
       "module": "./icons/sirenIcon/dist/voussoir-icon-icons-sirenIcon.esm.js",
       "default": "./icons/sirenIcon/dist/voussoir-icon-icons-sirenIcon.cjs.js"
     },
     "./icons/skullIcon": {
+      "types": "./icons/skullIcon/dist/voussoir-icon-icons-skullIcon.cjs.js",
       "module": "./icons/skullIcon/dist/voussoir-icon-icons-skullIcon.esm.js",
       "default": "./icons/skullIcon/dist/voussoir-icon-icons-skullIcon.cjs.js"
     },
     "./icons/slackIcon": {
+      "types": "./icons/slackIcon/dist/voussoir-icon-icons-slackIcon.cjs.js",
       "module": "./icons/slackIcon/dist/voussoir-icon-icons-slackIcon.esm.js",
       "default": "./icons/slackIcon/dist/voussoir-icon-icons-slackIcon.cjs.js"
     },
     "./icons/slashIcon": {
+      "types": "./icons/slashIcon/dist/voussoir-icon-icons-slashIcon.cjs.js",
       "module": "./icons/slashIcon/dist/voussoir-icon-icons-slashIcon.esm.js",
       "default": "./icons/slashIcon/dist/voussoir-icon-icons-slashIcon.cjs.js"
     },
     "./icons/sliceIcon": {
+      "types": "./icons/sliceIcon/dist/voussoir-icon-icons-sliceIcon.cjs.js",
       "module": "./icons/sliceIcon/dist/voussoir-icon-icons-sliceIcon.esm.js",
       "default": "./icons/sliceIcon/dist/voussoir-icon-icons-sliceIcon.cjs.js"
     },
     "./icons/smileIcon": {
+      "types": "./icons/smileIcon/dist/voussoir-icon-icons-smileIcon.cjs.js",
       "module": "./icons/smileIcon/dist/voussoir-icon-icons-smileIcon.esm.js",
       "default": "./icons/smileIcon/dist/voussoir-icon-icons-smileIcon.cjs.js"
     },
     "./icons/stampIcon": {
+      "types": "./icons/stampIcon/dist/voussoir-icon-icons-stampIcon.cjs.js",
       "module": "./icons/stampIcon/dist/voussoir-icon-icons-stampIcon.esm.js",
       "default": "./icons/stampIcon/dist/voussoir-icon-icons-stampIcon.cjs.js"
     },
     "./icons/swordIcon": {
+      "types": "./icons/swordIcon/dist/voussoir-icon-icons-swordIcon.cjs.js",
       "module": "./icons/swordIcon/dist/voussoir-icon-icons-swordIcon.esm.js",
       "default": "./icons/swordIcon/dist/voussoir-icon-icons-swordIcon.cjs.js"
     },
     "./icons/tableIcon": {
+      "types": "./icons/tableIcon/dist/voussoir-icon-icons-tableIcon.cjs.js",
       "module": "./icons/tableIcon/dist/voussoir-icon-icons-tableIcon.esm.js",
       "default": "./icons/tableIcon/dist/voussoir-icon-icons-tableIcon.cjs.js"
     },
     "./icons/timerIcon": {
+      "types": "./icons/timerIcon/dist/voussoir-icon-icons-timerIcon.cjs.js",
       "module": "./icons/timerIcon/dist/voussoir-icon-icons-timerIcon.esm.js",
       "default": "./icons/timerIcon/dist/voussoir-icon-icons-timerIcon.cjs.js"
     },
     "./icons/trainIcon": {
+      "types": "./icons/trainIcon/dist/voussoir-icon-icons-trainIcon.cjs.js",
       "module": "./icons/trainIcon/dist/voussoir-icon-icons-trainIcon.esm.js",
       "default": "./icons/trainIcon/dist/voussoir-icon-icons-trainIcon.cjs.js"
     },
     "./icons/trashIcon": {
+      "types": "./icons/trashIcon/dist/voussoir-icon-icons-trashIcon.cjs.js",
       "module": "./icons/trashIcon/dist/voussoir-icon-icons-trashIcon.esm.js",
       "default": "./icons/trashIcon/dist/voussoir-icon-icons-trashIcon.cjs.js"
     },
     "./icons/treesIcon": {
+      "types": "./icons/treesIcon/dist/voussoir-icon-icons-treesIcon.cjs.js",
       "module": "./icons/treesIcon/dist/voussoir-icon-icons-treesIcon.esm.js",
       "default": "./icons/treesIcon/dist/voussoir-icon-icons-treesIcon.cjs.js"
     },
     "./icons/truckIcon": {
+      "types": "./icons/truckIcon/dist/voussoir-icon-icons-truckIcon.cjs.js",
       "module": "./icons/truckIcon/dist/voussoir-icon-icons-truckIcon.esm.js",
       "default": "./icons/truckIcon/dist/voussoir-icon-icons-truckIcon.cjs.js"
     },
     "./icons/undo2Icon": {
+      "types": "./icons/undo2Icon/dist/voussoir-icon-icons-undo2Icon.cjs.js",
       "module": "./icons/undo2Icon/dist/voussoir-icon-icons-undo2Icon.esm.js",
       "default": "./icons/undo2Icon/dist/voussoir-icon-icons-undo2Icon.cjs.js"
     },
     "./icons/userXIcon": {
+      "types": "./icons/userXIcon/dist/voussoir-icon-icons-userXIcon.cjs.js",
       "module": "./icons/userXIcon/dist/voussoir-icon-icons-userXIcon.esm.js",
       "default": "./icons/userXIcon/dist/voussoir-icon-icons-userXIcon.cjs.js"
     },
     "./icons/usersIcon": {
+      "types": "./icons/usersIcon/dist/voussoir-icon-icons-usersIcon.cjs.js",
       "module": "./icons/usersIcon/dist/voussoir-icon-icons-usersIcon.esm.js",
       "default": "./icons/usersIcon/dist/voussoir-icon-icons-usersIcon.cjs.js"
     },
     "./icons/veganIcon": {
+      "types": "./icons/veganIcon/dist/voussoir-icon-icons-veganIcon.cjs.js",
       "module": "./icons/veganIcon/dist/voussoir-icon-icons-veganIcon.esm.js",
       "default": "./icons/veganIcon/dist/voussoir-icon-icons-veganIcon.cjs.js"
     },
     "./icons/videoIcon": {
+      "types": "./icons/videoIcon/dist/voussoir-icon-icons-videoIcon.cjs.js",
       "module": "./icons/videoIcon/dist/voussoir-icon-icons-videoIcon.esm.js",
       "default": "./icons/videoIcon/dist/voussoir-icon-icons-videoIcon.cjs.js"
     },
     "./icons/wand2Icon": {
+      "types": "./icons/wand2Icon/dist/voussoir-icon-icons-wand2Icon.cjs.js",
       "module": "./icons/wand2Icon/dist/voussoir-icon-icons-wand2Icon.esm.js",
       "default": "./icons/wand2Icon/dist/voussoir-icon-icons-wand2Icon.cjs.js"
     },
     "./icons/watchIcon": {
+      "types": "./icons/watchIcon/dist/voussoir-icon-icons-watchIcon.cjs.js",
       "module": "./icons/watchIcon/dist/voussoir-icon-icons-watchIcon.esm.js",
       "default": "./icons/watchIcon/dist/voussoir-icon-icons-watchIcon.cjs.js"
     },
     "./icons/wavesIcon": {
+      "types": "./icons/wavesIcon/dist/voussoir-icon-icons-wavesIcon.cjs.js",
       "module": "./icons/wavesIcon/dist/voussoir-icon-icons-wavesIcon.esm.js",
       "default": "./icons/wavesIcon/dist/voussoir-icon-icons-wavesIcon.cjs.js"
     },
     "./icons/wheatIcon": {
+      "types": "./icons/wheatIcon/dist/voussoir-icon-icons-wheatIcon.cjs.js",
       "module": "./icons/wheatIcon/dist/voussoir-icon-icons-wheatIcon.esm.js",
       "default": "./icons/wheatIcon/dist/voussoir-icon-icons-wheatIcon.cjs.js"
     },
     "./icons/anchorIcon": {
+      "types": "./icons/anchorIcon/dist/voussoir-icon-icons-anchorIcon.cjs.js",
       "module": "./icons/anchorIcon/dist/voussoir-icon-icons-anchorIcon.esm.js",
       "default": "./icons/anchorIcon/dist/voussoir-icon-icons-anchorIcon.cjs.js"
     },
     "./icons/atSignIcon": {
+      "types": "./icons/atSignIcon/dist/voussoir-icon-icons-atSignIcon.cjs.js",
       "module": "./icons/atSignIcon/dist/voussoir-icon-icons-atSignIcon.esm.js",
       "default": "./icons/atSignIcon/dist/voussoir-icon-icons-atSignIcon.cjs.js"
     },
     "./icons/axis3dIcon": {
+      "types": "./icons/axis3dIcon/dist/voussoir-icon-icons-axis3dIcon.cjs.js",
       "module": "./icons/axis3dIcon/dist/voussoir-icon-icons-axis3dIcon.esm.js",
       "default": "./icons/axis3dIcon/dist/voussoir-icon-icons-axis3dIcon.cjs.js"
     },
     "./icons/bananaIcon": {
+      "types": "./icons/bananaIcon/dist/voussoir-icon-icons-bananaIcon.cjs.js",
       "module": "./icons/bananaIcon/dist/voussoir-icon-icons-bananaIcon.esm.js",
       "default": "./icons/bananaIcon/dist/voussoir-icon-icons-bananaIcon.cjs.js"
     },
     "./icons/beakerIcon": {
+      "types": "./icons/beakerIcon/dist/voussoir-icon-icons-beakerIcon.cjs.js",
       "module": "./icons/beakerIcon/dist/voussoir-icon-icons-beakerIcon.esm.js",
       "default": "./icons/beakerIcon/dist/voussoir-icon-icons-beakerIcon.cjs.js"
     },
     "./icons/binaryIcon": {
+      "types": "./icons/binaryIcon/dist/voussoir-icon-icons-binaryIcon.cjs.js",
       "module": "./icons/binaryIcon/dist/voussoir-icon-icons-binaryIcon.esm.js",
       "default": "./icons/binaryIcon/dist/voussoir-icon-icons-binaryIcon.cjs.js"
     },
     "./icons/blindsIcon": {
+      "types": "./icons/blindsIcon/dist/voussoir-icon-icons-blindsIcon.cjs.js",
       "module": "./icons/blindsIcon/dist/voussoir-icon-icons-blindsIcon.esm.js",
       "default": "./icons/blindsIcon/dist/voussoir-icon-icons-blindsIcon.cjs.js"
     },
     "./icons/cameraIcon": {
+      "types": "./icons/cameraIcon/dist/voussoir-icon-icons-cameraIcon.cjs.js",
       "module": "./icons/cameraIcon/dist/voussoir-icon-icons-cameraIcon.esm.js",
       "default": "./icons/cameraIcon/dist/voussoir-icon-icons-cameraIcon.cjs.js"
     },
     "./icons/carrotIcon": {
+      "types": "./icons/carrotIcon/dist/voussoir-icon-icons-carrotIcon.cjs.js",
       "module": "./icons/carrotIcon/dist/voussoir-icon-icons-carrotIcon.esm.js",
       "default": "./icons/carrotIcon/dist/voussoir-icon-icons-carrotIcon.cjs.js"
     },
     "./icons/cherryIcon": {
+      "types": "./icons/cherryIcon/dist/voussoir-icon-icons-cherryIcon.cjs.js",
       "module": "./icons/cherryIcon/dist/voussoir-icon-icons-cherryIcon.esm.js",
       "default": "./icons/cherryIcon/dist/voussoir-icon-icons-cherryIcon.cjs.js"
     },
     "./icons/chromeIcon": {
+      "types": "./icons/chromeIcon/dist/voussoir-icon-icons-chromeIcon.cjs.js",
       "module": "./icons/chromeIcon/dist/voussoir-icon-icons-chromeIcon.esm.js",
       "default": "./icons/chromeIcon/dist/voussoir-icon-icons-chromeIcon.cjs.js"
     },
     "./icons/circleIcon": {
+      "types": "./icons/circleIcon/dist/voussoir-icon-icons-circleIcon.cjs.js",
       "module": "./icons/circleIcon/dist/voussoir-icon-icons-circleIcon.esm.js",
       "default": "./icons/circleIcon/dist/voussoir-icon-icons-circleIcon.cjs.js"
     },
     "./icons/citrusIcon": {
+      "types": "./icons/citrusIcon/dist/voussoir-icon-icons-citrusIcon.cjs.js",
       "module": "./icons/citrusIcon/dist/voussoir-icon-icons-citrusIcon.esm.js",
       "default": "./icons/citrusIcon/dist/voussoir-icon-icons-citrusIcon.cjs.js"
     },
     "./icons/clock1Icon": {
+      "types": "./icons/clock1Icon/dist/voussoir-icon-icons-clock1Icon.cjs.js",
       "module": "./icons/clock1Icon/dist/voussoir-icon-icons-clock1Icon.esm.js",
       "default": "./icons/clock1Icon/dist/voussoir-icon-icons-clock1Icon.cjs.js"
     },
     "./icons/clock2Icon": {
+      "types": "./icons/clock2Icon/dist/voussoir-icon-icons-clock2Icon.cjs.js",
       "module": "./icons/clock2Icon/dist/voussoir-icon-icons-clock2Icon.esm.js",
       "default": "./icons/clock2Icon/dist/voussoir-icon-icons-clock2Icon.cjs.js"
     },
     "./icons/clock3Icon": {
+      "types": "./icons/clock3Icon/dist/voussoir-icon-icons-clock3Icon.cjs.js",
       "module": "./icons/clock3Icon/dist/voussoir-icon-icons-clock3Icon.esm.js",
       "default": "./icons/clock3Icon/dist/voussoir-icon-icons-clock3Icon.cjs.js"
     },
     "./icons/clock4Icon": {
+      "types": "./icons/clock4Icon/dist/voussoir-icon-icons-clock4Icon.cjs.js",
       "module": "./icons/clock4Icon/dist/voussoir-icon-icons-clock4Icon.esm.js",
       "default": "./icons/clock4Icon/dist/voussoir-icon-icons-clock4Icon.cjs.js"
     },
     "./icons/clock5Icon": {
+      "types": "./icons/clock5Icon/dist/voussoir-icon-icons-clock5Icon.cjs.js",
       "module": "./icons/clock5Icon/dist/voussoir-icon-icons-clock5Icon.esm.js",
       "default": "./icons/clock5Icon/dist/voussoir-icon-icons-clock5Icon.cjs.js"
     },
     "./icons/clock6Icon": {
+      "types": "./icons/clock6Icon/dist/voussoir-icon-icons-clock6Icon.cjs.js",
       "module": "./icons/clock6Icon/dist/voussoir-icon-icons-clock6Icon.esm.js",
       "default": "./icons/clock6Icon/dist/voussoir-icon-icons-clock6Icon.cjs.js"
     },
     "./icons/clock7Icon": {
+      "types": "./icons/clock7Icon/dist/voussoir-icon-icons-clock7Icon.cjs.js",
       "module": "./icons/clock7Icon/dist/voussoir-icon-icons-clock7Icon.esm.js",
       "default": "./icons/clock7Icon/dist/voussoir-icon-icons-clock7Icon.cjs.js"
     },
     "./icons/clock8Icon": {
+      "types": "./icons/clock8Icon/dist/voussoir-icon-icons-clock8Icon.cjs.js",
       "module": "./icons/clock8Icon/dist/voussoir-icon-icons-clock8Icon.esm.js",
       "default": "./icons/clock8Icon/dist/voussoir-icon-icons-clock8Icon.cjs.js"
     },
     "./icons/clock9Icon": {
+      "types": "./icons/clock9Icon/dist/voussoir-icon-icons-clock9Icon.cjs.js",
       "module": "./icons/clock9Icon/dist/voussoir-icon-icons-clock9Icon.esm.js",
       "default": "./icons/clock9Icon/dist/voussoir-icon-icons-clock9Icon.cjs.js"
     },
     "./icons/cloudyIcon": {
+      "types": "./icons/cloudyIcon/dist/voussoir-icon-icons-cloudyIcon.cjs.js",
       "module": "./icons/cloudyIcon/dist/voussoir-icon-icons-cloudyIcon.esm.js",
       "default": "./icons/cloudyIcon/dist/voussoir-icon-icons-cloudyIcon.cjs.js"
     },
     "./icons/cloverIcon": {
+      "types": "./icons/cloverIcon/dist/voussoir-icon-icons-cloverIcon.cjs.js",
       "module": "./icons/cloverIcon/dist/voussoir-icon-icons-cloverIcon.esm.js",
       "default": "./icons/cloverIcon/dist/voussoir-icon-icons-cloverIcon.cjs.js"
     },
     "./icons/coffeeIcon": {
+      "types": "./icons/coffeeIcon/dist/voussoir-icon-icons-coffeeIcon.cjs.js",
       "module": "./icons/coffeeIcon/dist/voussoir-icon-icons-coffeeIcon.esm.js",
       "default": "./icons/coffeeIcon/dist/voussoir-icon-icons-coffeeIcon.cjs.js"
     },
     "./icons/cookieIcon": {
+      "types": "./icons/cookieIcon/dist/voussoir-icon-icons-cookieIcon.cjs.js",
       "module": "./icons/cookieIcon/dist/voussoir-icon-icons-cookieIcon.esm.js",
       "default": "./icons/cookieIcon/dist/voussoir-icon-icons-cookieIcon.cjs.js"
     },
     "./icons/deleteIcon": {
+      "types": "./icons/deleteIcon/dist/voussoir-icon-icons-deleteIcon.cjs.js",
       "module": "./icons/deleteIcon/dist/voussoir-icon-icons-deleteIcon.esm.js",
       "default": "./icons/deleteIcon/dist/voussoir-icon-icons-deleteIcon.cjs.js"
     },
     "./icons/divideIcon": {
+      "types": "./icons/divideIcon/dist/voussoir-icon-icons-divideIcon.cjs.js",
       "module": "./icons/divideIcon/dist/voussoir-icon-icons-divideIcon.esm.js",
       "default": "./icons/divideIcon/dist/voussoir-icon-icons-divideIcon.cjs.js"
     },
     "./icons/dnaOffIcon": {
+      "types": "./icons/dnaOffIcon/dist/voussoir-icon-icons-dnaOffIcon.cjs.js",
       "module": "./icons/dnaOffIcon/dist/voussoir-icon-icons-dnaOffIcon.esm.js",
       "default": "./icons/dnaOffIcon/dist/voussoir-icon-icons-dnaOffIcon.cjs.js"
     },
     "./icons/earOffIcon": {
+      "types": "./icons/earOffIcon/dist/voussoir-icon-icons-earOffIcon.cjs.js",
       "module": "./icons/earOffIcon/dist/voussoir-icon-icons-earOffIcon.esm.js",
       "default": "./icons/earOffIcon/dist/voussoir-icon-icons-earOffIcon.cjs.js"
     },
     "./icons/eggOffIcon": {
+      "types": "./icons/eggOffIcon/dist/voussoir-icon-icons-eggOffIcon.cjs.js",
       "module": "./icons/eggOffIcon/dist/voussoir-icon-icons-eggOffIcon.esm.js",
       "default": "./icons/eggOffIcon/dist/voussoir-icon-icons-eggOffIcon.cjs.js"
     },
     "./icons/eraserIcon": {
+      "types": "./icons/eraserIcon/dist/voussoir-icon-icons-eraserIcon.cjs.js",
       "module": "./icons/eraserIcon/dist/voussoir-icon-icons-eraserIcon.esm.js",
       "default": "./icons/eraserIcon/dist/voussoir-icon-icons-eraserIcon.cjs.js"
     },
     "./icons/expandIcon": {
+      "types": "./icons/expandIcon/dist/voussoir-icon-icons-expandIcon.cjs.js",
       "module": "./icons/expandIcon/dist/voussoir-icon-icons-expandIcon.esm.js",
       "default": "./icons/expandIcon/dist/voussoir-icon-icons-expandIcon.cjs.js"
     },
     "./icons/eyeOffIcon": {
+      "types": "./icons/eyeOffIcon/dist/voussoir-icon-icons-eyeOffIcon.cjs.js",
       "module": "./icons/eyeOffIcon/dist/voussoir-icon-icons-eyeOffIcon.esm.js",
       "default": "./icons/eyeOffIcon/dist/voussoir-icon-icons-eyeOffIcon.cjs.js"
     },
     "./icons/fileUpIcon": {
+      "types": "./icons/fileUpIcon/dist/voussoir-icon-icons-fileUpIcon.cjs.js",
       "module": "./icons/fileUpIcon/dist/voussoir-icon-icons-fileUpIcon.esm.js",
       "default": "./icons/fileUpIcon/dist/voussoir-icon-icons-fileUpIcon.cjs.js"
     },
     "./icons/fileX2Icon": {
+      "types": "./icons/fileX2Icon/dist/voussoir-icon-icons-fileX2Icon.cjs.js",
       "module": "./icons/fileX2Icon/dist/voussoir-icon-icons-fileX2Icon.esm.js",
       "default": "./icons/fileX2Icon/dist/voussoir-icon-icons-fileX2Icon.cjs.js"
     },
     "./icons/filterIcon": {
+      "types": "./icons/filterIcon/dist/voussoir-icon-icons-filterIcon.cjs.js",
       "module": "./icons/filterIcon/dist/voussoir-icon-icons-filterIcon.esm.js",
       "default": "./icons/filterIcon/dist/voussoir-icon-icons-filterIcon.cjs.js"
     },
     "./icons/flowerIcon": {
+      "types": "./icons/flowerIcon/dist/voussoir-icon-icons-flowerIcon.cjs.js",
       "module": "./icons/flowerIcon/dist/voussoir-icon-icons-flowerIcon.esm.js",
       "default": "./icons/flowerIcon/dist/voussoir-icon-icons-flowerIcon.cjs.js"
     },
     "./icons/folderIcon": {
+      "types": "./icons/folderIcon/dist/voussoir-icon-icons-folderIcon.cjs.js",
       "module": "./icons/folderIcon/dist/voussoir-icon-icons-folderIcon.esm.js",
       "default": "./icons/folderIcon/dist/voussoir-icon-icons-folderIcon.cjs.js"
     },
     "./icons/framerIcon": {
+      "types": "./icons/framerIcon/dist/voussoir-icon-icons-framerIcon.cjs.js",
       "module": "./icons/framerIcon/dist/voussoir-icon-icons-framerIcon.esm.js",
       "default": "./icons/framerIcon/dist/voussoir-icon-icons-framerIcon.cjs.js"
     },
     "./icons/githubIcon": {
+      "types": "./icons/githubIcon/dist/voussoir-icon-icons-githubIcon.cjs.js",
       "module": "./icons/githubIcon/dist/voussoir-icon-icons-githubIcon.esm.js",
       "default": "./icons/githubIcon/dist/voussoir-icon-icons-githubIcon.cjs.js"
     },
     "./icons/gitlabIcon": {
+      "types": "./icons/gitlabIcon/dist/voussoir-icon-icons-gitlabIcon.cjs.js",
       "module": "./icons/gitlabIcon/dist/voussoir-icon-icons-gitlabIcon.esm.js",
       "default": "./icons/gitlabIcon/dist/voussoir-icon-icons-gitlabIcon.cjs.js"
     },
     "./icons/globe2Icon": {
+      "types": "./icons/globe2Icon/dist/voussoir-icon-icons-globe2Icon.cjs.js",
       "module": "./icons/globe2Icon/dist/voussoir-icon-icons-globe2Icon.esm.js",
       "default": "./icons/globe2Icon/dist/voussoir-icon-icons-globe2Icon.cjs.js"
     },
     "./icons/hammerIcon": {
+      "types": "./icons/hammerIcon/dist/voussoir-icon-icons-hammerIcon.cjs.js",
       "module": "./icons/hammerIcon/dist/voussoir-icon-icons-hammerIcon.esm.js",
       "default": "./icons/hammerIcon/dist/voussoir-icon-icons-hammerIcon.cjs.js"
     },
     "./icons/hopOffIcon": {
+      "types": "./icons/hopOffIcon/dist/voussoir-icon-icons-hopOffIcon.cjs.js",
       "module": "./icons/hopOffIcon/dist/voussoir-icon-icons-hopOffIcon.esm.js",
       "default": "./icons/hopOffIcon/dist/voussoir-icon-icons-hopOffIcon.cjs.js"
     },
     "./icons/importIcon": {
+      "types": "./icons/importIcon/dist/voussoir-icon-icons-importIcon.cjs.js",
       "module": "./icons/importIcon/dist/voussoir-icon-icons-importIcon.esm.js",
       "default": "./icons/importIcon/dist/voussoir-icon-icons-importIcon.cjs.js"
     },
     "./icons/indentIcon": {
+      "types": "./icons/indentIcon/dist/voussoir-icon-icons-indentIcon.cjs.js",
       "module": "./icons/indentIcon/dist/voussoir-icon-icons-indentIcon.esm.js",
       "default": "./icons/indentIcon/dist/voussoir-icon-icons-indentIcon.cjs.js"
     },
     "./icons/italicIcon": {
+      "types": "./icons/italicIcon/dist/voussoir-icon-icons-italicIcon.cjs.js",
       "module": "./icons/italicIcon/dist/voussoir-icon-icons-italicIcon.esm.js",
       "default": "./icons/italicIcon/dist/voussoir-icon-icons-italicIcon.cjs.js"
     },
     "./icons/laptopIcon": {
+      "types": "./icons/laptopIcon/dist/voussoir-icon-icons-laptopIcon.cjs.js",
       "module": "./icons/laptopIcon/dist/voussoir-icon-icons-laptopIcon.esm.js",
       "default": "./icons/laptopIcon/dist/voussoir-icon-icons-laptopIcon.cjs.js"
     },
     "./icons/layersIcon": {
+      "types": "./icons/layersIcon/dist/voussoir-icon-icons-layersIcon.cjs.js",
       "module": "./icons/layersIcon/dist/voussoir-icon-icons-layersIcon.esm.js",
       "default": "./icons/layersIcon/dist/voussoir-icon-icons-layersIcon.cjs.js"
     },
     "./icons/layoutIcon": {
+      "types": "./icons/layoutIcon/dist/voussoir-icon-icons-layoutIcon.cjs.js",
       "module": "./icons/layoutIcon/dist/voussoir-icon-icons-layoutIcon.esm.js",
       "default": "./icons/layoutIcon/dist/voussoir-icon-icons-layoutIcon.cjs.js"
     },
     "./icons/loaderIcon": {
+      "types": "./icons/loaderIcon/dist/voussoir-icon-icons-loaderIcon.cjs.js",
       "module": "./icons/loaderIcon/dist/voussoir-icon-icons-loaderIcon.esm.js",
       "default": "./icons/loaderIcon/dist/voussoir-icon-icons-loaderIcon.cjs.js"
     },
     "./icons/locateIcon": {
+      "types": "./icons/locateIcon/dist/voussoir-icon-icons-locateIcon.cjs.js",
       "module": "./icons/locateIcon/dist/voussoir-icon-icons-locateIcon.esm.js",
       "default": "./icons/locateIcon/dist/voussoir-icon-icons-locateIcon.cjs.js"
     },
     "./icons/logOutIcon": {
+      "types": "./icons/logOutIcon/dist/voussoir-icon-icons-logOutIcon.cjs.js",
       "module": "./icons/logOutIcon/dist/voussoir-icon-icons-logOutIcon.esm.js",
       "default": "./icons/logOutIcon/dist/voussoir-icon-icons-logOutIcon.cjs.js"
     },
     "./icons/magnetIcon": {
+      "types": "./icons/magnetIcon/dist/voussoir-icon-icons-magnetIcon.cjs.js",
       "module": "./icons/magnetIcon/dist/voussoir-icon-icons-magnetIcon.esm.js",
       "default": "./icons/magnetIcon/dist/voussoir-icon-icons-magnetIcon.cjs.js"
     },
     "./icons/mapPinIcon": {
+      "types": "./icons/mapPinIcon/dist/voussoir-icon-icons-mapPinIcon.cjs.js",
       "module": "./icons/mapPinIcon/dist/voussoir-icon-icons-mapPinIcon.esm.js",
       "default": "./icons/mapPinIcon/dist/voussoir-icon-icons-mapPinIcon.cjs.js"
     },
     "./icons/micOffIcon": {
+      "types": "./icons/micOffIcon/dist/voussoir-icon-icons-micOffIcon.cjs.js",
       "module": "./icons/micOffIcon/dist/voussoir-icon-icons-micOffIcon.esm.js",
       "default": "./icons/micOffIcon/dist/voussoir-icon-icons-micOffIcon.cjs.js"
     },
     "./icons/move3dIcon": {
+      "types": "./icons/move3dIcon/dist/voussoir-icon-icons-move3dIcon.cjs.js",
       "module": "./icons/move3dIcon/dist/voussoir-icon-icons-move3dIcon.esm.js",
       "default": "./icons/move3dIcon/dist/voussoir-icon-icons-move3dIcon.cjs.js"
     },
     "./icons/music2Icon": {
+      "types": "./icons/music2Icon/dist/voussoir-icon-icons-music2Icon.cjs.js",
       "module": "./icons/music2Icon/dist/voussoir-icon-icons-music2Icon.esm.js",
       "default": "./icons/music2Icon/dist/voussoir-icon-icons-music2Icon.cjs.js"
     },
     "./icons/music3Icon": {
+      "types": "./icons/music3Icon/dist/voussoir-icon-icons-music3Icon.cjs.js",
       "module": "./icons/music3Icon/dist/voussoir-icon-icons-music3Icon.esm.js",
       "default": "./icons/music3Icon/dist/voussoir-icon-icons-music3Icon.cjs.js"
     },
     "./icons/music4Icon": {
+      "types": "./icons/music4Icon/dist/voussoir-icon-icons-music4Icon.cjs.js",
       "module": "./icons/music4Icon/dist/voussoir-icon-icons-music4Icon.esm.js",
       "default": "./icons/music4Icon/dist/voussoir-icon-icons-music4Icon.cjs.js"
     },
     "./icons/nutOffIcon": {
+      "types": "./icons/nutOffIcon/dist/voussoir-icon-icons-nutOffIcon.cjs.js",
       "module": "./icons/nutOffIcon/dist/voussoir-icon-icons-nutOffIcon.esm.js",
       "default": "./icons/nutOffIcon/dist/voussoir-icon-icons-nutOffIcon.cjs.js"
     },
     "./icons/optionIcon": {
+      "types": "./icons/optionIcon/dist/voussoir-icon-icons-optionIcon.cjs.js",
       "module": "./icons/optionIcon/dist/voussoir-icon-icons-optionIcon.esm.js",
       "default": "./icons/optionIcon/dist/voussoir-icon-icons-optionIcon.cjs.js"
     },
     "./icons/pencilIcon": {
+      "types": "./icons/pencilIcon/dist/voussoir-icon-icons-pencilIcon.cjs.js",
       "module": "./icons/pencilIcon/dist/voussoir-icon-icons-pencilIcon.esm.js",
       "default": "./icons/pencilIcon/dist/voussoir-icon-icons-pencilIcon.cjs.js"
     },
     "./icons/pinOffIcon": {
+      "types": "./icons/pinOffIcon/dist/voussoir-icon-icons-pinOffIcon.cjs.js",
       "module": "./icons/pinOffIcon/dist/voussoir-icon-icons-pinOffIcon.esm.js",
       "default": "./icons/pinOffIcon/dist/voussoir-icon-icons-pinOffIcon.cjs.js"
     },
     "./icons/pocketIcon": {
+      "types": "./icons/pocketIcon/dist/voussoir-icon-icons-pocketIcon.cjs.js",
       "module": "./icons/pocketIcon/dist/voussoir-icon-icons-pocketIcon.esm.js",
       "default": "./icons/pocketIcon/dist/voussoir-icon-icons-pocketIcon.cjs.js"
     },
     "./icons/puzzleIcon": {
+      "types": "./icons/puzzleIcon/dist/voussoir-icon-icons-puzzleIcon.cjs.js",
       "module": "./icons/puzzleIcon/dist/voussoir-icon-icons-puzzleIcon.esm.js",
       "default": "./icons/puzzleIcon/dist/voussoir-icon-icons-puzzleIcon.cjs.js"
     },
     "./icons/qrCodeIcon": {
+      "types": "./icons/qrCodeIcon/dist/voussoir-icon-icons-qrCodeIcon.cjs.js",
       "module": "./icons/qrCodeIcon/dist/voussoir-icon-icons-qrCodeIcon.esm.js",
       "default": "./icons/qrCodeIcon/dist/voussoir-icon-icons-qrCodeIcon.cjs.js"
     },
     "./icons/repeatIcon": {
+      "types": "./icons/repeatIcon/dist/voussoir-icon-icons-repeatIcon.cjs.js",
       "module": "./icons/repeatIcon/dist/voussoir-icon-icons-repeatIcon.esm.js",
       "default": "./icons/repeatIcon/dist/voussoir-icon-icons-repeatIcon.cjs.js"
     },
     "./icons/rewindIcon": {
+      "types": "./icons/rewindIcon/dist/voussoir-icon-icons-rewindIcon.cjs.js",
       "module": "./icons/rewindIcon/dist/voussoir-icon-icons-rewindIcon.esm.js",
       "default": "./icons/rewindIcon/dist/voussoir-icon-icons-rewindIcon.cjs.js"
     },
     "./icons/rocketIcon": {
+      "types": "./icons/rocketIcon/dist/voussoir-icon-icons-rocketIcon.cjs.js",
       "module": "./icons/rocketIcon/dist/voussoir-icon-icons-rocketIcon.esm.js",
       "default": "./icons/rocketIcon/dist/voussoir-icon-icons-rocketIcon.cjs.js"
     },
     "./icons/routerIcon": {
+      "types": "./icons/routerIcon/dist/voussoir-icon-icons-routerIcon.cjs.js",
       "module": "./icons/routerIcon/dist/voussoir-icon-icons-routerIcon.esm.js",
       "default": "./icons/routerIcon/dist/voussoir-icon-icons-routerIcon.cjs.js"
     },
     "./icons/scrollIcon": {
+      "types": "./icons/scrollIcon/dist/voussoir-icon-icons-scrollIcon.cjs.js",
       "module": "./icons/scrollIcon/dist/voussoir-icon-icons-scrollIcon.esm.js",
       "default": "./icons/scrollIcon/dist/voussoir-icon-icons-scrollIcon.cjs.js"
     },
     "./icons/searchIcon": {
+      "types": "./icons/searchIcon/dist/voussoir-icon-icons-searchIcon.cjs.js",
       "module": "./icons/searchIcon/dist/voussoir-icon-icons-searchIcon.esm.js",
       "default": "./icons/searchIcon/dist/voussoir-icon-icons-searchIcon.cjs.js"
     },
     "./icons/serverIcon": {
+      "types": "./icons/serverIcon/dist/voussoir-icon-icons-serverIcon.cjs.js",
       "module": "./icons/serverIcon/dist/voussoir-icon-icons-serverIcon.esm.js",
       "default": "./icons/serverIcon/dist/voussoir-icon-icons-serverIcon.cjs.js"
     },
     "./icons/share2Icon": {
+      "types": "./icons/share2Icon/dist/voussoir-icon-icons-share2Icon.cjs.js",
       "module": "./icons/share2Icon/dist/voussoir-icon-icons-share2Icon.esm.js",
       "default": "./icons/share2Icon/dist/voussoir-icon-icons-share2Icon.cjs.js"
     },
     "./icons/shieldIcon": {
+      "types": "./icons/shieldIcon/dist/voussoir-icon-icons-shieldIcon.cjs.js",
       "module": "./icons/shieldIcon/dist/voussoir-icon-icons-shieldIcon.esm.js",
       "default": "./icons/shieldIcon/dist/voussoir-icon-icons-shieldIcon.cjs.js"
     },
     "./icons/shovelIcon": {
+      "types": "./icons/shovelIcon/dist/voussoir-icon-icons-shovelIcon.cjs.js",
       "module": "./icons/shovelIcon/dist/voussoir-icon-icons-shovelIcon.esm.js",
       "default": "./icons/shovelIcon/dist/voussoir-icon-icons-shovelIcon.cjs.js"
     },
     "./icons/shrinkIcon": {
+      "types": "./icons/shrinkIcon/dist/voussoir-icon-icons-shrinkIcon.cjs.js",
       "module": "./icons/shrinkIcon/dist/voussoir-icon-icons-shrinkIcon.esm.js",
       "default": "./icons/shrinkIcon/dist/voussoir-icon-icons-shrinkIcon.cjs.js"
     },
     "./icons/signalIcon": {
+      "types": "./icons/signalIcon/dist/voussoir-icon-icons-signalIcon.cjs.js",
       "module": "./icons/signalIcon/dist/voussoir-icon-icons-signalIcon.esm.js",
       "default": "./icons/signalIcon/dist/voussoir-icon-icons-signalIcon.cjs.js"
     },
     "./icons/splineIcon": {
+      "types": "./icons/splineIcon/dist/voussoir-icon-icons-splineIcon.cjs.js",
       "module": "./icons/splineIcon/dist/voussoir-icon-icons-splineIcon.esm.js",
       "default": "./icons/splineIcon/dist/voussoir-icon-icons-splineIcon.cjs.js"
     },
     "./icons/sproutIcon": {
+      "types": "./icons/sproutIcon/dist/voussoir-icon-icons-sproutIcon.cjs.js",
       "module": "./icons/sproutIcon/dist/voussoir-icon-icons-sproutIcon.esm.js",
       "default": "./icons/sproutIcon/dist/voussoir-icon-icons-sproutIcon.cjs.js"
     },
     "./icons/squareIcon": {
+      "types": "./icons/squareIcon/dist/voussoir-icon-icons-squareIcon.cjs.js",
       "module": "./icons/squareIcon/dist/voussoir-icon-icons-squareIcon.esm.js",
       "default": "./icons/squareIcon/dist/voussoir-icon-icons-squareIcon.cjs.js"
     },
     "./icons/sunDimIcon": {
+      "types": "./icons/sunDimIcon/dist/voussoir-icon-icons-sunDimIcon.cjs.js",
       "module": "./icons/sunDimIcon/dist/voussoir-icon-icons-sunDimIcon.esm.js",
       "default": "./icons/sunDimIcon/dist/voussoir-icon-icons-sunDimIcon.cjs.js"
     },
     "./icons/sunsetIcon": {
+      "types": "./icons/sunsetIcon/dist/voussoir-icon-icons-sunsetIcon.cjs.js",
       "module": "./icons/sunsetIcon/dist/voussoir-icon-icons-sunsetIcon.esm.js",
       "default": "./icons/sunsetIcon/dist/voussoir-icon-icons-sunsetIcon.cjs.js"
     },
     "./icons/swordsIcon": {
+      "types": "./icons/swordsIcon/dist/voussoir-icon-icons-swordsIcon.cjs.js",
       "module": "./icons/swordsIcon/dist/voussoir-icon-icons-swordsIcon.esm.js",
       "default": "./icons/swordsIcon/dist/voussoir-icon-icons-swordsIcon.cjs.js"
     },
     "./icons/table2Icon": {
+      "types": "./icons/table2Icon/dist/voussoir-icon-icons-table2Icon.cjs.js",
       "module": "./icons/table2Icon/dist/voussoir-icon-icons-table2Icon.esm.js",
       "default": "./icons/table2Icon/dist/voussoir-icon-icons-table2Icon.cjs.js"
     },
     "./icons/tabletIcon": {
+      "types": "./icons/tabletIcon/dist/voussoir-icon-icons-tabletIcon.cjs.js",
       "module": "./icons/tabletIcon/dist/voussoir-icon-icons-tabletIcon.esm.js",
       "default": "./icons/tabletIcon/dist/voussoir-icon-icons-tabletIcon.cjs.js"
     },
     "./icons/targetIcon": {
+      "types": "./icons/targetIcon/dist/voussoir-icon-icons-targetIcon.cjs.js",
       "module": "./icons/targetIcon/dist/voussoir-icon-icons-targetIcon.esm.js",
       "default": "./icons/targetIcon/dist/voussoir-icon-icons-targetIcon.cjs.js"
     },
     "./icons/ticketIcon": {
+      "types": "./icons/ticketIcon/dist/voussoir-icon-icons-ticketIcon.cjs.js",
       "module": "./icons/ticketIcon/dist/voussoir-icon-icons-ticketIcon.esm.js",
       "default": "./icons/ticketIcon/dist/voussoir-icon-icons-ticketIcon.cjs.js"
     },
     "./icons/trash2Icon": {
+      "types": "./icons/trash2Icon/dist/voussoir-icon-icons-trash2Icon.cjs.js",
       "module": "./icons/trash2Icon/dist/voussoir-icon-icons-trash2Icon.esm.js",
       "default": "./icons/trash2Icon/dist/voussoir-icon-icons-trash2Icon.cjs.js"
     },
     "./icons/trelloIcon": {
+      "types": "./icons/trelloIcon/dist/voussoir-icon-icons-trelloIcon.cjs.js",
       "module": "./icons/trelloIcon/dist/voussoir-icon-icons-trelloIcon.esm.js",
       "default": "./icons/trelloIcon/dist/voussoir-icon-icons-trelloIcon.cjs.js"
     },
     "./icons/trophyIcon": {
+      "types": "./icons/trophyIcon/dist/voussoir-icon-icons-trophyIcon.cjs.js",
       "module": "./icons/trophyIcon/dist/voussoir-icon-icons-trophyIcon.esm.js",
       "default": "./icons/trophyIcon/dist/voussoir-icon-icons-trophyIcon.cjs.js"
     },
     "./icons/twitchIcon": {
+      "types": "./icons/twitchIcon/dist/voussoir-icon-icons-twitchIcon.cjs.js",
       "module": "./icons/twitchIcon/dist/voussoir-icon-icons-twitchIcon.esm.js",
       "default": "./icons/twitchIcon/dist/voussoir-icon-icons-twitchIcon.cjs.js"
     },
     "./icons/unlinkIcon": {
+      "types": "./icons/unlinkIcon/dist/voussoir-icon-icons-unlinkIcon.cjs.js",
       "module": "./icons/unlinkIcon/dist/voussoir-icon-icons-unlinkIcon.esm.js",
       "default": "./icons/unlinkIcon/dist/voussoir-icon-icons-unlinkIcon.cjs.js"
     },
     "./icons/unlockIcon": {
+      "types": "./icons/unlockIcon/dist/voussoir-icon-icons-unlockIcon.cjs.js",
       "module": "./icons/unlockIcon/dist/voussoir-icon-icons-unlockIcon.esm.js",
       "default": "./icons/unlockIcon/dist/voussoir-icon-icons-unlockIcon.cjs.js"
     },
     "./icons/uploadIcon": {
+      "types": "./icons/uploadIcon/dist/voussoir-icon-icons-uploadIcon.cjs.js",
       "module": "./icons/uploadIcon/dist/voussoir-icon-icons-uploadIcon.esm.js",
       "default": "./icons/uploadIcon/dist/voussoir-icon-icons-uploadIcon.cjs.js"
     },
     "./icons/volumeIcon": {
+      "types": "./icons/volumeIcon/dist/voussoir-icon-icons-volumeIcon.cjs.js",
       "module": "./icons/volumeIcon/dist/voussoir-icon-icons-volumeIcon.esm.js",
       "default": "./icons/volumeIcon/dist/voussoir-icon-icons-volumeIcon.cjs.js"
     },
     "./icons/walletIcon": {
+      "types": "./icons/walletIcon/dist/voussoir-icon-icons-walletIcon.cjs.js",
       "module": "./icons/walletIcon/dist/voussoir-icon-icons-walletIcon.esm.js",
       "default": "./icons/walletIcon/dist/voussoir-icon-icons-walletIcon.cjs.js"
     },
     "./icons/webcamIcon": {
+      "types": "./icons/webcamIcon/dist/voussoir-icon-icons-webcamIcon.cjs.js",
       "module": "./icons/webcamIcon/dist/voussoir-icon-icons-webcamIcon.esm.js",
       "default": "./icons/webcamIcon/dist/voussoir-icon-icons-webcamIcon.cjs.js"
     },
     "./icons/wrenchIcon": {
+      "types": "./icons/wrenchIcon/dist/voussoir-icon-icons-wrenchIcon.cjs.js",
       "module": "./icons/wrenchIcon/dist/voussoir-icon-icons-wrenchIcon.esm.js",
       "default": "./icons/wrenchIcon/dist/voussoir-icon-icons-wrenchIcon.cjs.js"
     },
     "./icons/zapOffIcon": {
+      "types": "./icons/zapOffIcon/dist/voussoir-icon-icons-zapOffIcon.cjs.js",
       "module": "./icons/zapOffIcon/dist/voussoir-icon-icons-zapOffIcon.esm.js",
       "default": "./icons/zapOffIcon/dist/voussoir-icon-icons-zapOffIcon.cjs.js"
     },
     "./icons/zoomInIcon": {
+      "types": "./icons/zoomInIcon/dist/voussoir-icon-icons-zoomInIcon.cjs.js",
       "module": "./icons/zoomInIcon/dist/voussoir-icon-icons-zoomInIcon.esm.js",
       "default": "./icons/zoomInIcon/dist/voussoir-icon-icons-zoomInIcon.cjs.js"
     },
     "./icons/airVentIcon": {
+      "types": "./icons/airVentIcon/dist/voussoir-icon-icons-airVentIcon.cjs.js",
       "module": "./icons/airVentIcon/dist/voussoir-icon-icons-airVentIcon.esm.js",
       "default": "./icons/airVentIcon/dist/voussoir-icon-icons-airVentIcon.cjs.js"
     },
     "./icons/airplayIcon": {
+      "types": "./icons/airplayIcon/dist/voussoir-icon-icons-airplayIcon.cjs.js",
       "module": "./icons/airplayIcon/dist/voussoir-icon-icons-airplayIcon.esm.js",
       "default": "./icons/airplayIcon/dist/voussoir-icon-icons-airplayIcon.cjs.js"
     },
     "./icons/annoyedIcon": {
+      "types": "./icons/annoyedIcon/dist/voussoir-icon-icons-annoyedIcon.cjs.js",
       "module": "./icons/annoyedIcon/dist/voussoir-icon-icons-annoyedIcon.esm.js",
       "default": "./icons/annoyedIcon/dist/voussoir-icon-icons-annoyedIcon.cjs.js"
     },
     "./icons/archiveIcon": {
+      "types": "./icons/archiveIcon/dist/voussoir-icon-icons-archiveIcon.cjs.js",
       "module": "./icons/archiveIcon/dist/voussoir-icon-icons-archiveIcon.esm.js",
       "default": "./icons/archiveIcon/dist/voussoir-icon-icons-archiveIcon.cjs.js"
     },
     "./icons/arrowUpIcon": {
+      "types": "./icons/arrowUpIcon/dist/voussoir-icon-icons-arrowUpIcon.cjs.js",
       "module": "./icons/arrowUpIcon/dist/voussoir-icon-icons-arrowUpIcon.esm.js",
       "default": "./icons/arrowUpIcon/dist/voussoir-icon-icons-arrowUpIcon.cjs.js"
     },
     "./icons/batteryIcon": {
+      "types": "./icons/batteryIcon/dist/voussoir-icon-icons-batteryIcon.cjs.js",
       "module": "./icons/batteryIcon/dist/voussoir-icon-icons-batteryIcon.esm.js",
       "default": "./icons/batteryIcon/dist/voussoir-icon-icons-batteryIcon.cjs.js"
     },
     "./icons/beanOffIcon": {
+      "types": "./icons/beanOffIcon/dist/voussoir-icon-icons-beanOffIcon.cjs.js",
       "module": "./icons/beanOffIcon/dist/voussoir-icon-icons-beanOffIcon.esm.js",
       "default": "./icons/beanOffIcon/dist/voussoir-icon-icons-beanOffIcon.cjs.js"
     },
     "./icons/bellOffIcon": {
+      "types": "./icons/bellOffIcon/dist/voussoir-icon-icons-bellOffIcon.cjs.js",
       "module": "./icons/bellOffIcon/dist/voussoir-icon-icons-bellOffIcon.esm.js",
       "default": "./icons/bellOffIcon/dist/voussoir-icon-icons-bellOffIcon.cjs.js"
     },
     "./icons/bitcoinIcon": {
+      "types": "./icons/bitcoinIcon/dist/voussoir-icon-icons-bitcoinIcon.cjs.js",
       "module": "./icons/bitcoinIcon/dist/voussoir-icon-icons-bitcoinIcon.esm.js",
       "default": "./icons/bitcoinIcon/dist/voussoir-icon-icons-bitcoinIcon.cjs.js"
     },
     "./icons/chefHatIcon": {
+      "types": "./icons/chefHatIcon/dist/voussoir-icon-icons-chefHatIcon.cjs.js",
       "module": "./icons/chefHatIcon/dist/voussoir-icon-icons-chefHatIcon.esm.js",
       "default": "./icons/chefHatIcon/dist/voussoir-icon-icons-chefHatIcon.cjs.js"
     },
     "./icons/clock10Icon": {
+      "types": "./icons/clock10Icon/dist/voussoir-icon-icons-clock10Icon.cjs.js",
       "module": "./icons/clock10Icon/dist/voussoir-icon-icons-clock10Icon.esm.js",
       "default": "./icons/clock10Icon/dist/voussoir-icon-icons-clock10Icon.cjs.js"
     },
     "./icons/clock11Icon": {
+      "types": "./icons/clock11Icon/dist/voussoir-icon-icons-clock11Icon.cjs.js",
       "module": "./icons/clock11Icon/dist/voussoir-icon-icons-clock11Icon.esm.js",
       "default": "./icons/clock11Icon/dist/voussoir-icon-icons-clock11Icon.cjs.js"
     },
     "./icons/clock12Icon": {
+      "types": "./icons/clock12Icon/dist/voussoir-icon-icons-clock12Icon.cjs.js",
       "module": "./icons/clock12Icon/dist/voussoir-icon-icons-clock12Icon.esm.js",
       "default": "./icons/clock12Icon/dist/voussoir-icon-icons-clock12Icon.cjs.js"
     },
     "./icons/codepenIcon": {
+      "types": "./icons/codepenIcon/dist/voussoir-icon-icons-codepenIcon.cjs.js",
       "module": "./icons/codepenIcon/dist/voussoir-icon-icons-codepenIcon.esm.js",
       "default": "./icons/codepenIcon/dist/voussoir-icon-icons-codepenIcon.cjs.js"
     },
     "./icons/columnsIcon": {
+      "types": "./icons/columnsIcon/dist/voussoir-icon-icons-columnsIcon.cjs.js",
       "module": "./icons/columnsIcon/dist/voussoir-icon-icons-columnsIcon.esm.js",
       "default": "./icons/columnsIcon/dist/voussoir-icon-icons-columnsIcon.cjs.js"
     },
     "./icons/commandIcon": {
+      "types": "./icons/commandIcon/dist/voussoir-icon-icons-commandIcon.cjs.js",
       "module": "./icons/commandIcon/dist/voussoir-icon-icons-commandIcon.esm.js",
       "default": "./icons/commandIcon/dist/voussoir-icon-icons-commandIcon.cjs.js"
     },
     "./icons/compassIcon": {
+      "types": "./icons/compassIcon/dist/voussoir-icon-icons-compassIcon.cjs.js",
       "module": "./icons/compassIcon/dist/voussoir-icon-icons-compassIcon.esm.js",
       "default": "./icons/compassIcon/dist/voussoir-icon-icons-compassIcon.cjs.js"
     },
     "./icons/contactIcon": {
+      "types": "./icons/contactIcon/dist/voussoir-icon-icons-contactIcon.cjs.js",
       "module": "./icons/contactIcon/dist/voussoir-icon-icons-contactIcon.esm.js",
       "default": "./icons/contactIcon/dist/voussoir-icon-icons-contactIcon.cjs.js"
     },
     "./icons/cupSodaIcon": {
+      "types": "./icons/cupSodaIcon/dist/voussoir-icon-icons-cupSodaIcon.cjs.js",
       "module": "./icons/cupSodaIcon/dist/voussoir-icon-icons-cupSodaIcon.esm.js",
       "default": "./icons/cupSodaIcon/dist/voussoir-icon-icons-cupSodaIcon.cjs.js"
     },
     "./icons/diamondIcon": {
+      "types": "./icons/diamondIcon/dist/voussoir-icon-icons-diamondIcon.cjs.js",
       "module": "./icons/diamondIcon/dist/voussoir-icon-icons-diamondIcon.esm.js",
       "default": "./icons/diamondIcon/dist/voussoir-icon-icons-diamondIcon.cjs.js"
     },
     "./icons/dropletIcon": {
+      "types": "./icons/dropletIcon/dist/voussoir-icon-icons-dropletIcon.cjs.js",
       "module": "./icons/dropletIcon/dist/voussoir-icon-icons-dropletIcon.esm.js",
       "default": "./icons/dropletIcon/dist/voussoir-icon-icons-dropletIcon.cjs.js"
     },
     "./icons/factoryIcon": {
+      "types": "./icons/factoryIcon/dist/voussoir-icon-icons-factoryIcon.cjs.js",
       "module": "./icons/factoryIcon/dist/voussoir-icon-icons-factoryIcon.esm.js",
       "default": "./icons/factoryIcon/dist/voussoir-icon-icons-factoryIcon.cjs.js"
     },
     "./icons/featherIcon": {
+      "types": "./icons/featherIcon/dist/voussoir-icon-icons-featherIcon.cjs.js",
       "module": "./icons/featherIcon/dist/voussoir-icon-icons-featherIcon.esm.js",
       "default": "./icons/featherIcon/dist/voussoir-icon-icons-featherIcon.cjs.js"
     },
     "./icons/fileBoxIcon": {
+      "types": "./icons/fileBoxIcon/dist/voussoir-icon-icons-fileBoxIcon.cjs.js",
       "module": "./icons/fileBoxIcon/dist/voussoir-icon-icons-fileBoxIcon.esm.js",
       "default": "./icons/fileBoxIcon/dist/voussoir-icon-icons-fileBoxIcon.cjs.js"
     },
     "./icons/fileCogIcon": {
+      "types": "./icons/fileCogIcon/dist/voussoir-icon-icons-fileCogIcon.cjs.js",
       "module": "./icons/fileCogIcon/dist/voussoir-icon-icons-fileCogIcon.esm.js",
       "default": "./icons/fileCogIcon/dist/voussoir-icon-icons-fileCogIcon.cjs.js"
     },
     "./icons/fileKeyIcon": {
+      "types": "./icons/fileKeyIcon/dist/voussoir-icon-icons-fileKeyIcon.cjs.js",
       "module": "./icons/fileKeyIcon/dist/voussoir-icon-icons-fileKeyIcon.esm.js",
       "default": "./icons/fileKeyIcon/dist/voussoir-icon-icons-fileKeyIcon.cjs.js"
     },
     "./icons/filterXIcon": {
+      "types": "./icons/filterXIcon/dist/voussoir-icon-icons-filterXIcon.cjs.js",
       "module": "./icons/filterXIcon/dist/voussoir-icon-icons-filterXIcon.esm.js",
       "default": "./icons/filterXIcon/dist/voussoir-icon-icons-filterXIcon.cjs.js"
     },
     "./icons/fishOffIcon": {
+      "types": "./icons/fishOffIcon/dist/voussoir-icon-icons-fishOffIcon.cjs.js",
       "module": "./icons/fishOffIcon/dist/voussoir-icon-icons-fishOffIcon.esm.js",
       "default": "./icons/fishOffIcon/dist/voussoir-icon-icons-fishOffIcon.cjs.js"
     },
     "./icons/flagOffIcon": {
+      "types": "./icons/flagOffIcon/dist/voussoir-icon-icons-flagOffIcon.cjs.js",
       "module": "./icons/flagOffIcon/dist/voussoir-icon-icons-flagOffIcon.esm.js",
       "default": "./icons/flagOffIcon/dist/voussoir-icon-icons-flagOffIcon.cjs.js"
     },
     "./icons/flower2Icon": {
+      "types": "./icons/flower2Icon/dist/voussoir-icon-icons-flower2Icon.cjs.js",
       "module": "./icons/flower2Icon/dist/voussoir-icon-icons-flower2Icon.esm.js",
       "default": "./icons/flower2Icon/dist/voussoir-icon-icons-flower2Icon.cjs.js"
     },
     "./icons/folderXIcon": {
+      "types": "./icons/folderXIcon/dist/voussoir-icon-icons-folderXIcon.cjs.js",
       "module": "./icons/folderXIcon/dist/voussoir-icon-icons-folderXIcon.esm.js",
       "default": "./icons/folderXIcon/dist/voussoir-icon-icons-folderXIcon.cjs.js"
     },
     "./icons/foldersIcon": {
+      "types": "./icons/foldersIcon/dist/voussoir-icon-icons-foldersIcon.cjs.js",
       "module": "./icons/foldersIcon/dist/voussoir-icon-icons-foldersIcon.esm.js",
       "default": "./icons/foldersIcon/dist/voussoir-icon-icons-foldersIcon.cjs.js"
     },
     "./icons/forwardIcon": {
+      "types": "./icons/forwardIcon/dist/voussoir-icon-icons-forwardIcon.cjs.js",
       "module": "./icons/forwardIcon/dist/voussoir-icon-icons-forwardIcon.esm.js",
       "default": "./icons/forwardIcon/dist/voussoir-icon-icons-forwardIcon.cjs.js"
     },
     "./icons/gamepadIcon": {
+      "types": "./icons/gamepadIcon/dist/voussoir-icon-icons-gamepadIcon.cjs.js",
       "module": "./icons/gamepadIcon/dist/voussoir-icon-icons-gamepadIcon.esm.js",
       "default": "./icons/gamepadIcon/dist/voussoir-icon-icons-gamepadIcon.cjs.js"
     },
     "./icons/gitForkIcon": {
+      "types": "./icons/gitForkIcon/dist/voussoir-icon-icons-gitForkIcon.cjs.js",
       "module": "./icons/gitForkIcon/dist/voussoir-icon-icons-gitForkIcon.esm.js",
       "default": "./icons/gitForkIcon/dist/voussoir-icon-icons-gitForkIcon.cjs.js"
     },
     "./icons/glassesIcon": {
+      "types": "./icons/glassesIcon/dist/voussoir-icon-icons-glassesIcon.cjs.js",
       "module": "./icons/glassesIcon/dist/voussoir-icon-icons-glassesIcon.esm.js",
       "default": "./icons/glassesIcon/dist/voussoir-icon-icons-glassesIcon.cjs.js"
     },
     "./icons/hardHatIcon": {
+      "types": "./icons/hardHatIcon/dist/voussoir-icon-icons-hardHatIcon.cjs.js",
       "module": "./icons/hardHatIcon/dist/voussoir-icon-icons-hardHatIcon.esm.js",
       "default": "./icons/hardHatIcon/dist/voussoir-icon-icons-hardHatIcon.cjs.js"
     },
     "./icons/headingIcon": {
+      "types": "./icons/headingIcon/dist/voussoir-icon-icons-headingIcon.cjs.js",
       "module": "./icons/headingIcon/dist/voussoir-icon-icons-headingIcon.esm.js",
       "default": "./icons/headingIcon/dist/voussoir-icon-icons-headingIcon.cjs.js"
     },
     "./icons/hexagonIcon": {
+      "types": "./icons/hexagonIcon/dist/voussoir-icon-icons-hexagonIcon.cjs.js",
       "module": "./icons/hexagonIcon/dist/voussoir-icon-icons-hexagonIcon.esm.js",
       "default": "./icons/hexagonIcon/dist/voussoir-icon-icons-hexagonIcon.cjs.js"
     },
     "./icons/historyIcon": {
+      "types": "./icons/historyIcon/dist/voussoir-icon-icons-historyIcon.cjs.js",
       "module": "./icons/historyIcon/dist/voussoir-icon-icons-historyIcon.esm.js",
       "default": "./icons/historyIcon/dist/voussoir-icon-icons-historyIcon.cjs.js"
     },
     "./icons/inspectIcon": {
+      "types": "./icons/inspectIcon/dist/voussoir-icon-icons-inspectIcon.cjs.js",
       "module": "./icons/inspectIcon/dist/voussoir-icon-icons-inspectIcon.esm.js",
       "default": "./icons/inspectIcon/dist/voussoir-icon-icons-inspectIcon.cjs.js"
     },
     "./icons/laptop2Icon": {
+      "types": "./icons/laptop2Icon/dist/voussoir-icon-icons-laptop2Icon.cjs.js",
       "module": "./icons/laptop2Icon/dist/voussoir-icon-icons-laptop2Icon.esm.js",
       "default": "./icons/laptop2Icon/dist/voussoir-icon-icons-laptop2Icon.cjs.js"
     },
     "./icons/libraryIcon": {
+      "types": "./icons/libraryIcon/dist/voussoir-icon-icons-libraryIcon.cjs.js",
       "module": "./icons/libraryIcon/dist/voussoir-icon-icons-libraryIcon.esm.js",
       "default": "./icons/libraryIcon/dist/voussoir-icon-icons-libraryIcon.cjs.js"
     },
     "./icons/listEndIcon": {
+      "types": "./icons/listEndIcon/dist/voussoir-icon-icons-listEndIcon.cjs.js",
       "module": "./icons/listEndIcon/dist/voussoir-icon-icons-listEndIcon.esm.js",
       "default": "./icons/listEndIcon/dist/voussoir-icon-icons-listEndIcon.cjs.js"
     },
     "./icons/loader2Icon": {
+      "types": "./icons/loader2Icon/dist/voussoir-icon-icons-loader2Icon.cjs.js",
       "module": "./icons/loader2Icon/dist/voussoir-icon-icons-loader2Icon.esm.js",
       "default": "./icons/loader2Icon/dist/voussoir-icon-icons-loader2Icon.cjs.js"
     },
     "./icons/luggageIcon": {
+      "types": "./icons/luggageIcon/dist/voussoir-icon-icons-luggageIcon.cjs.js",
       "module": "./icons/luggageIcon/dist/voussoir-icon-icons-luggageIcon.esm.js",
       "default": "./icons/luggageIcon/dist/voussoir-icon-icons-luggageIcon.cjs.js"
     },
     "./icons/martiniIcon": {
+      "types": "./icons/martiniIcon/dist/voussoir-icon-icons-martiniIcon.cjs.js",
       "module": "./icons/martiniIcon/dist/voussoir-icon-icons-martiniIcon.esm.js",
       "default": "./icons/martiniIcon/dist/voussoir-icon-icons-martiniIcon.cjs.js"
     },
     "./icons/milkOffIcon": {
+      "types": "./icons/milkOffIcon/dist/voussoir-icon-icons-milkOffIcon.cjs.js",
       "module": "./icons/milkOffIcon/dist/voussoir-icon-icons-milkOffIcon.esm.js",
       "default": "./icons/milkOffIcon/dist/voussoir-icon-icons-milkOffIcon.cjs.js"
     },
     "./icons/monitorIcon": {
+      "types": "./icons/monitorIcon/dist/voussoir-icon-icons-monitorIcon.cjs.js",
       "module": "./icons/monitorIcon/dist/voussoir-icon-icons-monitorIcon.esm.js",
       "default": "./icons/monitorIcon/dist/voussoir-icon-icons-monitorIcon.cjs.js"
     },
     "./icons/networkIcon": {
+      "types": "./icons/networkIcon/dist/voussoir-icon-icons-networkIcon.cjs.js",
       "module": "./icons/networkIcon/dist/voussoir-icon-icons-networkIcon.esm.js",
       "default": "./icons/networkIcon/dist/voussoir-icon-icons-networkIcon.cjs.js"
     },
     "./icons/octagonIcon": {
+      "types": "./icons/octagonIcon/dist/voussoir-icon-icons-octagonIcon.cjs.js",
       "module": "./icons/octagonIcon/dist/voussoir-icon-icons-octagonIcon.esm.js",
       "default": "./icons/octagonIcon/dist/voussoir-icon-icons-octagonIcon.cjs.js"
     },
     "./icons/outdentIcon": {
+      "types": "./icons/outdentIcon/dist/voussoir-icon-icons-outdentIcon.cjs.js",
       "module": "./icons/outdentIcon/dist/voussoir-icon-icons-outdentIcon.esm.js",
       "default": "./icons/outdentIcon/dist/voussoir-icon-icons-outdentIcon.cjs.js"
     },
     "./icons/packageIcon": {
+      "types": "./icons/packageIcon/dist/voussoir-icon-icons-packageIcon.cjs.js",
       "module": "./icons/packageIcon/dist/voussoir-icon-icons-packageIcon.esm.js",
       "default": "./icons/packageIcon/dist/voussoir-icon-icons-packageIcon.cjs.js"
     },
     "./icons/paletteIcon": {
+      "types": "./icons/paletteIcon/dist/voussoir-icon-icons-paletteIcon.cjs.js",
       "module": "./icons/paletteIcon/dist/voussoir-icon-icons-paletteIcon.esm.js",
       "default": "./icons/paletteIcon/dist/voussoir-icon-icons-paletteIcon.cjs.js"
     },
     "./icons/penToolIcon": {
+      "types": "./icons/penToolIcon/dist/voussoir-icon-icons-penToolIcon.cjs.js",
       "module": "./icons/penToolIcon/dist/voussoir-icon-icons-penToolIcon.esm.js",
       "default": "./icons/penToolIcon/dist/voussoir-icon-icons-penToolIcon.cjs.js"
     },
     "./icons/percentIcon": {
+      "types": "./icons/percentIcon/dist/voussoir-icon-icons-percentIcon.cjs.js",
       "module": "./icons/percentIcon/dist/voussoir-icon-icons-percentIcon.esm.js",
       "default": "./icons/percentIcon/dist/voussoir-icon-icons-percentIcon.cjs.js"
     },
     "./icons/pilcrowIcon": {
+      "types": "./icons/pilcrowIcon/dist/voussoir-icon-icons-pilcrowIcon.cjs.js",
       "module": "./icons/pilcrowIcon/dist/voussoir-icon-icons-pilcrowIcon.esm.js",
       "default": "./icons/pilcrowIcon/dist/voussoir-icon-icons-pilcrowIcon.cjs.js"
     },
     "./icons/pipetteIcon": {
+      "types": "./icons/pipetteIcon/dist/voussoir-icon-icons-pipetteIcon.cjs.js",
       "module": "./icons/pipetteIcon/dist/voussoir-icon-icons-pipetteIcon.esm.js",
       "default": "./icons/pipetteIcon/dist/voussoir-icon-icons-pipetteIcon.cjs.js"
     },
     "./icons/plugZapIcon": {
+      "types": "./icons/plugZapIcon/dist/voussoir-icon-icons-plugZapIcon.cjs.js",
       "module": "./icons/plugZapIcon/dist/voussoir-icon-icons-plugZapIcon.esm.js",
       "default": "./icons/plugZapIcon/dist/voussoir-icon-icons-plugZapIcon.cjs.js"
     },
     "./icons/podcastIcon": {
+      "types": "./icons/podcastIcon/dist/voussoir-icon-icons-podcastIcon.cjs.js",
       "module": "./icons/podcastIcon/dist/voussoir-icon-icons-podcastIcon.esm.js",
       "default": "./icons/podcastIcon/dist/voussoir-icon-icons-podcastIcon.cjs.js"
     },
     "./icons/pointerIcon": {
+      "types": "./icons/pointerIcon/dist/voussoir-icon-icons-pointerIcon.cjs.js",
       "module": "./icons/pointerIcon/dist/voussoir-icon-icons-pointerIcon.esm.js",
       "default": "./icons/pointerIcon/dist/voussoir-icon-icons-pointerIcon.cjs.js"
     },
     "./icons/printerIcon": {
+      "types": "./icons/printerIcon/dist/voussoir-icon-icons-printerIcon.cjs.js",
       "module": "./icons/printerIcon/dist/voussoir-icon-icons-printerIcon.esm.js",
       "default": "./icons/printerIcon/dist/voussoir-icon-icons-printerIcon.cjs.js"
     },
     "./icons/recycleIcon": {
+      "types": "./icons/recycleIcon/dist/voussoir-icon-icons-recycleIcon.cjs.js",
       "module": "./icons/recycleIcon/dist/voussoir-icon-icons-recycleIcon.esm.js",
       "default": "./icons/recycleIcon/dist/voussoir-icon-icons-recycleIcon.cjs.js"
     },
     "./icons/repeat1Icon": {
+      "types": "./icons/repeat1Icon/dist/voussoir-icon-icons-repeat1Icon.cjs.js",
       "module": "./icons/repeat1Icon/dist/voussoir-icon-icons-repeat1Icon.esm.js",
       "default": "./icons/repeat1Icon/dist/voussoir-icon-icons-repeat1Icon.cjs.js"
     },
     "./icons/scale3dIcon": {
+      "types": "./icons/scale3dIcon/dist/voussoir-icon-icons-scale3dIcon.cjs.js",
       "module": "./icons/scale3dIcon/dist/voussoir-icon-icons-scale3dIcon.esm.js",
       "default": "./icons/scale3dIcon/dist/voussoir-icon-icons-scale3dIcon.cjs.js"
     },
     "./icons/scalingIcon": {
+      "types": "./icons/scalingIcon/dist/voussoir-icon-icons-scalingIcon.cjs.js",
       "module": "./icons/scalingIcon/dist/voussoir-icon-icons-scalingIcon.esm.js",
       "default": "./icons/scalingIcon/dist/voussoir-icon-icons-scalingIcon.cjs.js"
     },
     "./icons/shuffleIcon": {
+      "types": "./icons/shuffleIcon/dist/voussoir-icon-icons-shuffleIcon.cjs.js",
       "module": "./icons/shuffleIcon/dist/voussoir-icon-icons-shuffleIcon.esm.js",
       "default": "./icons/shuffleIcon/dist/voussoir-icon-icons-shuffleIcon.cjs.js"
     },
     "./icons/sidebarIcon": {
+      "types": "./icons/sidebarIcon/dist/voussoir-icon-icons-sidebarIcon.cjs.js",
       "module": "./icons/sidebarIcon/dist/voussoir-icon-icons-sidebarIcon.esm.js",
       "default": "./icons/sidebarIcon/dist/voussoir-icon-icons-sidebarIcon.cjs.js"
     },
     "./icons/slidersIcon": {
+      "types": "./icons/slidersIcon/dist/voussoir-icon-icons-slidersIcon.cjs.js",
       "module": "./icons/slidersIcon/dist/voussoir-icon-icons-slidersIcon.esm.js",
       "default": "./icons/slidersIcon/dist/voussoir-icon-icons-slidersIcon.cjs.js"
     },
     "./icons/sortAscIcon": {
+      "types": "./icons/sortAscIcon/dist/voussoir-icon-icons-sortAscIcon.cjs.js",
       "module": "./icons/sortAscIcon/dist/voussoir-icon-icons-sortAscIcon.esm.js",
       "default": "./icons/sortAscIcon/dist/voussoir-icon-icons-sortAscIcon.cjs.js"
     },
     "./icons/speakerIcon": {
+      "types": "./icons/speakerIcon/dist/voussoir-icon-icons-speakerIcon.cjs.js",
       "module": "./icons/speakerIcon/dist/voussoir-icon-icons-speakerIcon.esm.js",
       "default": "./icons/speakerIcon/dist/voussoir-icon-icons-speakerIcon.cjs.js"
     },
     "./icons/starOffIcon": {
+      "types": "./icons/starOffIcon/dist/voussoir-icon-icons-starOffIcon.cjs.js",
       "module": "./icons/starOffIcon/dist/voussoir-icon-icons-starOffIcon.esm.js",
       "default": "./icons/starOffIcon/dist/voussoir-icon-icons-starOffIcon.cjs.js"
     },
     "./icons/stickerIcon": {
+      "types": "./icons/stickerIcon/dist/voussoir-icon-icons-stickerIcon.cjs.js",
       "module": "./icons/stickerIcon/dist/voussoir-icon-icons-stickerIcon.esm.js",
       "default": "./icons/stickerIcon/dist/voussoir-icon-icons-stickerIcon.cjs.js"
     },
     "./icons/sunMoonIcon": {
+      "types": "./icons/sunMoonIcon/dist/voussoir-icon-icons-sunMoonIcon.cjs.js",
       "module": "./icons/sunMoonIcon/dist/voussoir-icon-icons-sunMoonIcon.esm.js",
       "default": "./icons/sunMoonIcon/dist/voussoir-icon-icons-sunMoonIcon.cjs.js"
     },
     "./icons/sunSnowIcon": {
+      "types": "./icons/sunSnowIcon/dist/voussoir-icon-icons-sunSnowIcon.cjs.js",
       "module": "./icons/sunSnowIcon/dist/voussoir-icon-icons-sunSnowIcon.esm.js",
       "default": "./icons/sunSnowIcon/dist/voussoir-icon-icons-sunSnowIcon.cjs.js"
     },
     "./icons/sunriseIcon": {
+      "types": "./icons/sunriseIcon/dist/voussoir-icon-icons-sunriseIcon.cjs.js",
       "module": "./icons/sunriseIcon/dist/voussoir-icon-icons-sunriseIcon.esm.js",
       "default": "./icons/sunriseIcon/dist/voussoir-icon-icons-sunriseIcon.cjs.js"
     },
     "./icons/syringeIcon": {
+      "types": "./icons/syringeIcon/dist/voussoir-icon-icons-syringeIcon.cjs.js",
       "module": "./icons/syringeIcon/dist/voussoir-icon-icons-syringeIcon.esm.js",
       "default": "./icons/syringeIcon/dist/voussoir-icon-icons-syringeIcon.cjs.js"
     },
     "./icons/tabletsIcon": {
+      "types": "./icons/tabletsIcon/dist/voussoir-icon-icons-tabletsIcon.cjs.js",
       "module": "./icons/tabletsIcon/dist/voussoir-icon-icons-tabletsIcon.esm.js",
       "default": "./icons/tabletsIcon/dist/voussoir-icon-icons-tabletsIcon.cjs.js"
     },
     "./icons/tornadoIcon": {
+      "types": "./icons/tornadoIcon/dist/voussoir-icon-icons-tornadoIcon.cjs.js",
       "module": "./icons/tornadoIcon/dist/voussoir-icon-icons-tornadoIcon.esm.js",
       "default": "./icons/tornadoIcon/dist/voussoir-icon-icons-tornadoIcon.cjs.js"
     },
     "./icons/twitterIcon": {
+      "types": "./icons/twitterIcon/dist/voussoir-icon-icons-twitterIcon.cjs.js",
       "module": "./icons/twitterIcon/dist/voussoir-icon-icons-twitterIcon.esm.js",
       "default": "./icons/twitterIcon/dist/voussoir-icon-icons-twitterIcon.cjs.js"
     },
     "./icons/unlink2Icon": {
+      "types": "./icons/unlink2Icon/dist/voussoir-icon-icons-unlink2Icon.cjs.js",
       "module": "./icons/unlink2Icon/dist/voussoir-icon-icons-unlink2Icon.esm.js",
       "default": "./icons/unlink2Icon/dist/voussoir-icon-icons-unlink2Icon.cjs.js"
     },
     "./icons/userCogIcon": {
+      "types": "./icons/userCogIcon/dist/voussoir-icon-icons-userCogIcon.cjs.js",
       "module": "./icons/userCogIcon/dist/voussoir-icon-icons-userCogIcon.esm.js",
       "default": "./icons/userCogIcon/dist/voussoir-icon-icons-userCogIcon.cjs.js"
     },
     "./icons/vibrateIcon": {
+      "types": "./icons/vibrateIcon/dist/voussoir-icon-icons-vibrateIcon.cjs.js",
       "module": "./icons/vibrateIcon/dist/voussoir-icon-icons-vibrateIcon.esm.js",
       "default": "./icons/vibrateIcon/dist/voussoir-icon-icons-vibrateIcon.cjs.js"
     },
     "./icons/volume1Icon": {
+      "types": "./icons/volume1Icon/dist/voussoir-icon-icons-volume1Icon.cjs.js",
       "module": "./icons/volume1Icon/dist/voussoir-icon-icons-volume1Icon.esm.js",
       "default": "./icons/volume1Icon/dist/voussoir-icon-icons-volume1Icon.cjs.js"
     },
     "./icons/volume2Icon": {
+      "types": "./icons/volume2Icon/dist/voussoir-icon-icons-volume2Icon.cjs.js",
       "module": "./icons/volume2Icon/dist/voussoir-icon-icons-volume2Icon.esm.js",
       "default": "./icons/volume2Icon/dist/voussoir-icon-icons-volume2Icon.cjs.js"
     },
     "./icons/volumeXIcon": {
+      "types": "./icons/volumeXIcon/dist/voussoir-icon-icons-volumeXIcon.cjs.js",
       "module": "./icons/volumeXIcon/dist/voussoir-icon-icons-volumeXIcon.esm.js",
       "default": "./icons/volumeXIcon/dist/voussoir-icon-icons-volumeXIcon.cjs.js"
     },
     "./icons/webhookIcon": {
+      "types": "./icons/webhookIcon/dist/voussoir-icon-icons-webhookIcon.cjs.js",
       "module": "./icons/webhookIcon/dist/voussoir-icon-icons-webhookIcon.esm.js",
       "default": "./icons/webhookIcon/dist/voussoir-icon-icons-webhookIcon.cjs.js"
     },
     "./icons/wifiOffIcon": {
+      "types": "./icons/wifiOffIcon/dist/voussoir-icon-icons-wifiOffIcon.cjs.js",
       "module": "./icons/wifiOffIcon/dist/voussoir-icon-icons-wifiOffIcon.esm.js",
       "default": "./icons/wifiOffIcon/dist/voussoir-icon-icons-wifiOffIcon.cjs.js"
     },
     "./icons/wineOffIcon": {
+      "types": "./icons/wineOffIcon/dist/voussoir-icon-icons-wineOffIcon.cjs.js",
       "module": "./icons/wineOffIcon/dist/voussoir-icon-icons-wineOffIcon.esm.js",
       "default": "./icons/wineOffIcon/dist/voussoir-icon-icons-wineOffIcon.cjs.js"
     },
     "./icons/xCircleIcon": {
+      "types": "./icons/xCircleIcon/dist/voussoir-icon-icons-xCircleIcon.cjs.js",
       "module": "./icons/xCircleIcon/dist/voussoir-icon-icons-xCircleIcon.esm.js",
       "default": "./icons/xCircleIcon/dist/voussoir-icon-icons-xCircleIcon.cjs.js"
     },
     "./icons/xSquareIcon": {
+      "types": "./icons/xSquareIcon/dist/voussoir-icon-icons-xSquareIcon.cjs.js",
       "module": "./icons/xSquareIcon/dist/voussoir-icon-icons-xSquareIcon.esm.js",
       "default": "./icons/xSquareIcon/dist/voussoir-icon-icons-xSquareIcon.cjs.js"
     },
     "./icons/youtubeIcon": {
+      "types": "./icons/youtubeIcon/dist/voussoir-icon-icons-youtubeIcon.cjs.js",
       "module": "./icons/youtubeIcon/dist/voussoir-icon-icons-youtubeIcon.esm.js",
       "default": "./icons/youtubeIcon/dist/voussoir-icon-icons-youtubeIcon.cjs.js"
     },
     "./icons/zoomOutIcon": {
+      "types": "./icons/zoomOutIcon/dist/voussoir-icon-icons-zoomOutIcon.cjs.js",
       "module": "./icons/zoomOutIcon/dist/voussoir-icon-icons-zoomOutIcon.esm.js",
       "default": "./icons/zoomOutIcon/dist/voussoir-icon-icons-zoomOutIcon.cjs.js"
     },
     "./icons/activityIcon": {
+      "types": "./icons/activityIcon/dist/voussoir-icon-icons-activityIcon.cjs.js",
       "module": "./icons/activityIcon/dist/voussoir-icon-icons-activityIcon.esm.js",
       "default": "./icons/activityIcon/dist/voussoir-icon-icons-activityIcon.cjs.js"
     },
     "./icons/apertureIcon": {
+      "types": "./icons/apertureIcon/dist/voussoir-icon-icons-apertureIcon.cjs.js",
       "module": "./icons/apertureIcon/dist/voussoir-icon-icons-apertureIcon.esm.js",
       "default": "./icons/apertureIcon/dist/voussoir-icon-icons-apertureIcon.cjs.js"
     },
     "./icons/armchairIcon": {
+      "types": "./icons/armchairIcon/dist/voussoir-icon-icons-armchairIcon.cjs.js",
       "module": "./icons/armchairIcon/dist/voussoir-icon-icons-armchairIcon.esm.js",
       "default": "./icons/armchairIcon/dist/voussoir-icon-icons-armchairIcon.cjs.js"
     },
     "./icons/asteriskIcon": {
+      "types": "./icons/asteriskIcon/dist/voussoir-icon-icons-asteriskIcon.cjs.js",
       "module": "./icons/asteriskIcon/dist/voussoir-icon-icons-asteriskIcon.esm.js",
       "default": "./icons/asteriskIcon/dist/voussoir-icon-icons-asteriskIcon.cjs.js"
     },
     "./icons/backpackIcon": {
+      "types": "./icons/backpackIcon/dist/voussoir-icon-icons-backpackIcon.cjs.js",
       "module": "./icons/backpackIcon/dist/voussoir-icon-icons-backpackIcon.esm.js",
       "default": "./icons/backpackIcon/dist/voussoir-icon-icons-backpackIcon.cjs.js"
     },
     "./icons/banknoteIcon": {
+      "types": "./icons/banknoteIcon/dist/voussoir-icon-icons-banknoteIcon.cjs.js",
       "module": "./icons/banknoteIcon/dist/voussoir-icon-icons-banknoteIcon.esm.js",
       "default": "./icons/banknoteIcon/dist/voussoir-icon-icons-banknoteIcon.cjs.js"
     },
     "./icons/barChartIcon": {
+      "types": "./icons/barChartIcon/dist/voussoir-icon-icons-barChartIcon.cjs.js",
       "module": "./icons/barChartIcon/dist/voussoir-icon-icons-barChartIcon.esm.js",
       "default": "./icons/barChartIcon/dist/voussoir-icon-icons-barChartIcon.cjs.js"
     },
     "./icons/baselineIcon": {
+      "types": "./icons/baselineIcon/dist/voussoir-icon-icons-baselineIcon.cjs.js",
       "module": "./icons/baselineIcon/dist/voussoir-icon-icons-baselineIcon.esm.js",
       "default": "./icons/baselineIcon/dist/voussoir-icon-icons-baselineIcon.cjs.js"
     },
     "./icons/bellPlusIcon": {
+      "types": "./icons/bellPlusIcon/dist/voussoir-icon-icons-bellPlusIcon.cjs.js",
       "module": "./icons/bellPlusIcon/dist/voussoir-icon-icons-bellPlusIcon.esm.js",
       "default": "./icons/bellPlusIcon/dist/voussoir-icon-icons-bellPlusIcon.cjs.js"
     },
     "./icons/bellRingIcon": {
+      "types": "./icons/bellRingIcon/dist/voussoir-icon-icons-bellRingIcon.cjs.js",
       "module": "./icons/bellRingIcon/dist/voussoir-icon-icons-bellRingIcon.esm.js",
       "default": "./icons/bellRingIcon/dist/voussoir-icon-icons-bellRingIcon.cjs.js"
     },
     "./icons/bookOpenIcon": {
+      "types": "./icons/bookOpenIcon/dist/voussoir-icon-icons-bookOpenIcon.cjs.js",
       "module": "./icons/bookOpenIcon/dist/voussoir-icon-icons-bookOpenIcon.esm.js",
       "default": "./icons/bookOpenIcon/dist/voussoir-icon-icons-bookOpenIcon.cjs.js"
     },
     "./icons/bookmarkIcon": {
+      "types": "./icons/bookmarkIcon/dist/voussoir-icon-icons-bookmarkIcon.cjs.js",
       "module": "./icons/bookmarkIcon/dist/voussoir-icon-icons-bookmarkIcon.esm.js",
       "default": "./icons/bookmarkIcon/dist/voussoir-icon-icons-bookmarkIcon.cjs.js"
     },
     "./icons/brainCogIcon": {
+      "types": "./icons/brainCogIcon/dist/voussoir-icon-icons-brainCogIcon.cjs.js",
       "module": "./icons/brainCogIcon/dist/voussoir-icon-icons-brainCogIcon.esm.js",
       "default": "./icons/brainCogIcon/dist/voussoir-icon-icons-brainCogIcon.cjs.js"
     },
     "./icons/buildingIcon": {
+      "types": "./icons/buildingIcon/dist/voussoir-icon-icons-buildingIcon.cjs.js",
       "module": "./icons/buildingIcon/dist/voussoir-icon-icons-buildingIcon.esm.js",
       "default": "./icons/buildingIcon/dist/voussoir-icon-icons-buildingIcon.cjs.js"
     },
     "./icons/calendarIcon": {
+      "types": "./icons/calendarIcon/dist/voussoir-icon-icons-calendarIcon.cjs.js",
       "module": "./icons/calendarIcon/dist/voussoir-icon-icons-calendarIcon.esm.js",
       "default": "./icons/calendarIcon/dist/voussoir-icon-icons-calendarIcon.cjs.js"
     },
     "./icons/candyOffIcon": {
+      "types": "./icons/candyOffIcon/dist/voussoir-icon-icons-candyOffIcon.cjs.js",
       "module": "./icons/candyOffIcon/dist/voussoir-icon-icons-candyOffIcon.esm.js",
       "default": "./icons/candyOffIcon/dist/voussoir-icon-icons-candyOffIcon.cjs.js"
     },
     "./icons/cloudCogIcon": {
+      "types": "./icons/cloudCogIcon/dist/voussoir-icon-icons-cloudCogIcon.cjs.js",
       "module": "./icons/cloudCogIcon/dist/voussoir-icon-icons-cloudCogIcon.esm.js",
       "default": "./icons/cloudCogIcon/dist/voussoir-icon-icons-cloudCogIcon.cjs.js"
     },
     "./icons/cloudFogIcon": {
+      "types": "./icons/cloudFogIcon/dist/voussoir-icon-icons-cloudFogIcon.cjs.js",
       "module": "./icons/cloudFogIcon/dist/voussoir-icon-icons-cloudFogIcon.esm.js",
       "default": "./icons/cloudFogIcon/dist/voussoir-icon-icons-cloudFogIcon.cjs.js"
     },
     "./icons/cloudOffIcon": {
+      "types": "./icons/cloudOffIcon/dist/voussoir-icon-icons-cloudOffIcon.cjs.js",
       "module": "./icons/cloudOffIcon/dist/voussoir-icon-icons-cloudOffIcon.esm.js",
       "default": "./icons/cloudOffIcon/dist/voussoir-icon-icons-cloudOffIcon.cjs.js"
     },
     "./icons/cloudSunIcon": {
+      "types": "./icons/cloudSunIcon/dist/voussoir-icon-icons-cloudSunIcon.cjs.js",
       "module": "./icons/cloudSunIcon/dist/voussoir-icon-icons-cloudSunIcon.esm.js",
       "default": "./icons/cloudSunIcon/dist/voussoir-icon-icons-cloudSunIcon.cjs.js"
     },
     "./icons/contrastIcon": {
+      "types": "./icons/contrastIcon/dist/voussoir-icon-icons-contrastIcon.cjs.js",
       "module": "./icons/contrastIcon/dist/voussoir-icon-icons-contrastIcon.esm.js",
       "default": "./icons/contrastIcon/dist/voussoir-icon-icons-contrastIcon.cjs.js"
     },
     "./icons/copyleftIcon": {
+      "types": "./icons/copyleftIcon/dist/voussoir-icon-icons-copyleftIcon.cjs.js",
       "module": "./icons/copyleftIcon/dist/voussoir-icon-icons-copyleftIcon.esm.js",
       "default": "./icons/copyleftIcon/dist/voussoir-icon-icons-copyleftIcon.cjs.js"
     },
     "./icons/currencyIcon": {
+      "types": "./icons/currencyIcon/dist/voussoir-icon-icons-currencyIcon.cjs.js",
       "module": "./icons/currencyIcon/dist/voussoir-icon-icons-currencyIcon.esm.js",
       "default": "./icons/currencyIcon/dist/voussoir-icon-icons-currencyIcon.cjs.js"
     },
     "./icons/databaseIcon": {
+      "types": "./icons/databaseIcon/dist/voussoir-icon-icons-databaseIcon.cjs.js",
       "module": "./icons/databaseIcon/dist/voussoir-icon-icons-databaseIcon.esm.js",
       "default": "./icons/databaseIcon/dist/voussoir-icon-icons-databaseIcon.cjs.js"
     },
     "./icons/downloadIcon": {
+      "types": "./icons/downloadIcon/dist/voussoir-icon-icons-downloadIcon.cjs.js",
       "module": "./icons/downloadIcon/dist/voussoir-icon-icons-downloadIcon.esm.js",
       "default": "./icons/downloadIcon/dist/voussoir-icon-icons-downloadIcon.cjs.js"
     },
     "./icons/dribbbleIcon": {
+      "types": "./icons/dribbbleIcon/dist/voussoir-icon-icons-dribbbleIcon.cjs.js",
       "module": "./icons/dribbbleIcon/dist/voussoir-icon-icons-dribbbleIcon.esm.js",
       "default": "./icons/dribbbleIcon/dist/voussoir-icon-icons-dribbbleIcon.cjs.js"
     },
     "./icons/dropletsIcon": {
+      "types": "./icons/dropletsIcon/dist/voussoir-icon-icons-dropletsIcon.cjs.js",
       "module": "./icons/dropletsIcon/dist/voussoir-icon-icons-dropletsIcon.esm.js",
       "default": "./icons/dropletsIcon/dist/voussoir-icon-icons-dropletsIcon.cjs.js"
     },
     "./icons/dumbbellIcon": {
+      "types": "./icons/dumbbellIcon/dist/voussoir-icon-icons-dumbbellIcon.cjs.js",
       "module": "./icons/dumbbellIcon/dist/voussoir-icon-icons-dumbbellIcon.esm.js",
       "default": "./icons/dumbbellIcon/dist/voussoir-icon-icons-dumbbellIcon.cjs.js"
     },
     "./icons/eggFriedIcon": {
+      "types": "./icons/eggFriedIcon/dist/voussoir-icon-icons-eggFriedIcon.cjs.js",
       "module": "./icons/eggFriedIcon/dist/voussoir-icon-icons-eggFriedIcon.esm.js",
       "default": "./icons/eggFriedIcon/dist/voussoir-icon-icons-eggFriedIcon.cjs.js"
     },
     "./icons/equalNotIcon": {
+      "types": "./icons/equalNotIcon/dist/voussoir-icon-icons-equalNotIcon.cjs.js",
       "module": "./icons/equalNotIcon/dist/voussoir-icon-icons-equalNotIcon.esm.js",
       "default": "./icons/equalNotIcon/dist/voussoir-icon-icons-equalNotIcon.cjs.js"
     },
     "./icons/facebookIcon": {
+      "types": "./icons/facebookIcon/dist/voussoir-icon-icons-facebookIcon.cjs.js",
       "module": "./icons/facebookIcon/dist/voussoir-icon-icons-facebookIcon.esm.js",
       "default": "./icons/facebookIcon/dist/voussoir-icon-icons-facebookIcon.cjs.js"
     },
     "./icons/fileCodeIcon": {
+      "types": "./icons/fileCodeIcon/dist/voussoir-icon-icons-fileCodeIcon.cjs.js",
       "module": "./icons/fileCodeIcon/dist/voussoir-icon-icons-fileCodeIcon.esm.js",
       "default": "./icons/fileCodeIcon/dist/voussoir-icon-icons-fileCodeIcon.cjs.js"
     },
     "./icons/fileCog2Icon": {
+      "types": "./icons/fileCog2Icon/dist/voussoir-icon-icons-fileCog2Icon.cjs.js",
       "module": "./icons/fileCog2Icon/dist/voussoir-icon-icons-fileCog2Icon.esm.js",
       "default": "./icons/fileCog2Icon/dist/voussoir-icon-icons-fileCog2Icon.cjs.js"
     },
     "./icons/fileDiffIcon": {
+      "types": "./icons/fileDiffIcon/dist/voussoir-icon-icons-fileDiffIcon.cjs.js",
       "module": "./icons/fileDiffIcon/dist/voussoir-icon-icons-fileDiffIcon.esm.js",
       "default": "./icons/fileDiffIcon/dist/voussoir-icon-icons-fileDiffIcon.cjs.js"
     },
     "./icons/fileDownIcon": {
+      "types": "./icons/fileDownIcon/dist/voussoir-icon-icons-fileDownIcon.cjs.js",
       "module": "./icons/fileDownIcon/dist/voussoir-icon-icons-fileDownIcon.esm.js",
       "default": "./icons/fileDownIcon/dist/voussoir-icon-icons-fileDownIcon.cjs.js"
     },
     "./icons/fileEditIcon": {
+      "types": "./icons/fileEditIcon/dist/voussoir-icon-icons-fileEditIcon.cjs.js",
       "module": "./icons/fileEditIcon/dist/voussoir-icon-icons-fileEditIcon.esm.js",
       "default": "./icons/fileEditIcon/dist/voussoir-icon-icons-fileEditIcon.cjs.js"
     },
     "./icons/fileJsonIcon": {
+      "types": "./icons/fileJsonIcon/dist/voussoir-icon-icons-fileJsonIcon.cjs.js",
       "module": "./icons/fileJsonIcon/dist/voussoir-icon-icons-fileJsonIcon.esm.js",
       "default": "./icons/fileJsonIcon/dist/voussoir-icon-icons-fileJsonIcon.cjs.js"
     },
     "./icons/fileKey2Icon": {
+      "types": "./icons/fileKey2Icon/dist/voussoir-icon-icons-fileKey2Icon.cjs.js",
       "module": "./icons/fileKey2Icon/dist/voussoir-icon-icons-fileKey2Icon.esm.js",
       "default": "./icons/fileKey2Icon/dist/voussoir-icon-icons-fileKey2Icon.cjs.js"
     },
     "./icons/fileLockIcon": {
+      "types": "./icons/fileLockIcon/dist/voussoir-icon-icons-fileLockIcon.cjs.js",
       "module": "./icons/fileLockIcon/dist/voussoir-icon-icons-fileLockIcon.esm.js",
       "default": "./icons/fileLockIcon/dist/voussoir-icon-icons-fileLockIcon.cjs.js"
     },
     "./icons/filePlusIcon": {
+      "types": "./icons/filePlusIcon/dist/voussoir-icon-icons-filePlusIcon.cjs.js",
       "module": "./icons/filePlusIcon/dist/voussoir-icon-icons-filePlusIcon.esm.js",
       "default": "./icons/filePlusIcon/dist/voussoir-icon-icons-filePlusIcon.cjs.js"
     },
     "./icons/fileScanIcon": {
+      "types": "./icons/fileScanIcon/dist/voussoir-icon-icons-fileScanIcon.cjs.js",
       "module": "./icons/fileScanIcon/dist/voussoir-icon-icons-fileScanIcon.esm.js",
       "default": "./icons/fileScanIcon/dist/voussoir-icon-icons-fileScanIcon.cjs.js"
     },
     "./icons/fileTextIcon": {
+      "types": "./icons/fileTextIcon/dist/voussoir-icon-icons-fileTextIcon.cjs.js",
       "module": "./icons/fileTextIcon/dist/voussoir-icon-icons-fileTextIcon.esm.js",
       "default": "./icons/fileTextIcon/dist/voussoir-icon-icons-fileTextIcon.cjs.js"
     },
     "./icons/fileTypeIcon": {
+      "types": "./icons/fileTypeIcon/dist/voussoir-icon-icons-fileTypeIcon.cjs.js",
       "module": "./icons/fileTypeIcon/dist/voussoir-icon-icons-fileTypeIcon.esm.js",
       "default": "./icons/fileTypeIcon/dist/voussoir-icon-icons-fileTypeIcon.cjs.js"
     },
     "./icons/folderUpIcon": {
+      "types": "./icons/folderUpIcon/dist/voussoir-icon-icons-folderUpIcon.cjs.js",
       "module": "./icons/folderUpIcon/dist/voussoir-icon-icons-folderUpIcon.esm.js",
       "default": "./icons/folderUpIcon/dist/voussoir-icon-icons-folderUpIcon.cjs.js"
     },
     "./icons/forkliftIcon": {
+      "types": "./icons/forkliftIcon/dist/voussoir-icon-icons-forkliftIcon.cjs.js",
       "module": "./icons/forkliftIcon/dist/voussoir-icon-icons-forkliftIcon.esm.js",
       "default": "./icons/forkliftIcon/dist/voussoir-icon-icons-forkliftIcon.cjs.js"
     },
     "./icons/gamepad2Icon": {
+      "types": "./icons/gamepad2Icon/dist/voussoir-icon-icons-gamepad2Icon.cjs.js",
       "module": "./icons/gamepad2Icon/dist/voussoir-icon-icons-gamepad2Icon.esm.js",
       "default": "./icons/gamepad2Icon/dist/voussoir-icon-icons-gamepad2Icon.cjs.js"
     },
     "./icons/gitMergeIcon": {
+      "types": "./icons/gitMergeIcon/dist/voussoir-icon-icons-gitMergeIcon.cjs.js",
       "module": "./icons/gitMergeIcon/dist/voussoir-icon-icons-gitMergeIcon.esm.js",
       "default": "./icons/gitMergeIcon/dist/voussoir-icon-icons-gitMergeIcon.cjs.js"
     },
     "./icons/heading1Icon": {
+      "types": "./icons/heading1Icon/dist/voussoir-icon-icons-heading1Icon.cjs.js",
       "module": "./icons/heading1Icon/dist/voussoir-icon-icons-heading1Icon.esm.js",
       "default": "./icons/heading1Icon/dist/voussoir-icon-icons-heading1Icon.cjs.js"
     },
     "./icons/heading2Icon": {
+      "types": "./icons/heading2Icon/dist/voussoir-icon-icons-heading2Icon.cjs.js",
       "module": "./icons/heading2Icon/dist/voussoir-icon-icons-heading2Icon.esm.js",
       "default": "./icons/heading2Icon/dist/voussoir-icon-icons-heading2Icon.cjs.js"
     },
     "./icons/heading3Icon": {
+      "types": "./icons/heading3Icon/dist/voussoir-icon-icons-heading3Icon.cjs.js",
       "module": "./icons/heading3Icon/dist/voussoir-icon-icons-heading3Icon.esm.js",
       "default": "./icons/heading3Icon/dist/voussoir-icon-icons-heading3Icon.cjs.js"
     },
     "./icons/heading4Icon": {
+      "types": "./icons/heading4Icon/dist/voussoir-icon-icons-heading4Icon.cjs.js",
       "module": "./icons/heading4Icon/dist/voussoir-icon-icons-heading4Icon.esm.js",
       "default": "./icons/heading4Icon/dist/voussoir-icon-icons-heading4Icon.cjs.js"
     },
     "./icons/heading5Icon": {
+      "types": "./icons/heading5Icon/dist/voussoir-icon-icons-heading5Icon.cjs.js",
       "module": "./icons/heading5Icon/dist/voussoir-icon-icons-heading5Icon.esm.js",
       "default": "./icons/heading5Icon/dist/voussoir-icon-icons-heading5Icon.cjs.js"
     },
     "./icons/heading6Icon": {
+      "types": "./icons/heading6Icon/dist/voussoir-icon-icons-heading6Icon.cjs.js",
       "module": "./icons/heading6Icon/dist/voussoir-icon-icons-heading6Icon.esm.js",
       "default": "./icons/heading6Icon/dist/voussoir-icon-icons-heading6Icon.cjs.js"
     },
     "./icons/heartOffIcon": {
+      "types": "./icons/heartOffIcon/dist/voussoir-icon-icons-heartOffIcon.cjs.js",
       "module": "./icons/heartOffIcon/dist/voussoir-icon-icons-heartOffIcon.esm.js",
       "default": "./icons/heartOffIcon/dist/voussoir-icon-icons-heartOffIcon.cjs.js"
     },
     "./icons/iceCreamIcon": {
+      "types": "./icons/iceCreamIcon/dist/voussoir-icon-icons-iceCreamIcon.cjs.js",
       "module": "./icons/iceCreamIcon/dist/voussoir-icon-icons-iceCreamIcon.esm.js",
       "default": "./icons/iceCreamIcon/dist/voussoir-icon-icons-iceCreamIcon.cjs.js"
     },
     "./icons/imageOffIcon": {
+      "types": "./icons/imageOffIcon/dist/voussoir-icon-icons-imageOffIcon.cjs.js",
       "module": "./icons/imageOffIcon/dist/voussoir-icon-icons-imageOffIcon.esm.js",
       "default": "./icons/imageOffIcon/dist/voussoir-icon-icons-imageOffIcon.cjs.js"
     },
     "./icons/infinityIcon": {
+      "types": "./icons/infinityIcon/dist/voussoir-icon-icons-infinityIcon.cjs.js",
       "module": "./icons/infinityIcon/dist/voussoir-icon-icons-infinityIcon.esm.js",
       "default": "./icons/infinityIcon/dist/voussoir-icon-icons-infinityIcon.cjs.js"
     },
     "./icons/joystickIcon": {
+      "types": "./icons/joystickIcon/dist/voussoir-icon-icons-joystickIcon.cjs.js",
       "module": "./icons/joystickIcon/dist/voussoir-icon-icons-joystickIcon.esm.js",
       "default": "./icons/joystickIcon/dist/voussoir-icon-icons-joystickIcon.cjs.js"
     },
     "./icons/keyboardIcon": {
+      "types": "./icons/keyboardIcon/dist/voussoir-icon-icons-keyboardIcon.cjs.js",
       "module": "./icons/keyboardIcon/dist/voussoir-icon-icons-keyboardIcon.esm.js",
       "default": "./icons/keyboardIcon/dist/voussoir-icon-icons-keyboardIcon.cjs.js"
     },
     "./icons/lampDeskIcon": {
+      "types": "./icons/lampDeskIcon/dist/voussoir-icon-icons-lampDeskIcon.cjs.js",
       "module": "./icons/lampDeskIcon/dist/voussoir-icon-icons-lampDeskIcon.esm.js",
       "default": "./icons/lampDeskIcon/dist/voussoir-icon-icons-lampDeskIcon.cjs.js"
     },
     "./icons/landmarkIcon": {
+      "types": "./icons/landmarkIcon/dist/voussoir-icon-icons-landmarkIcon.cjs.js",
       "module": "./icons/landmarkIcon/dist/voussoir-icon-icons-landmarkIcon.esm.js",
       "default": "./icons/landmarkIcon/dist/voussoir-icon-icons-landmarkIcon.cjs.js"
     },
     "./icons/lifeBuoyIcon": {
+      "types": "./icons/lifeBuoyIcon/dist/voussoir-icon-icons-lifeBuoyIcon.cjs.js",
       "module": "./icons/lifeBuoyIcon/dist/voussoir-icon-icons-lifeBuoyIcon.esm.js",
       "default": "./icons/lifeBuoyIcon/dist/voussoir-icon-icons-lifeBuoyIcon.cjs.js"
     },
     "./icons/link2OffIcon": {
+      "types": "./icons/link2OffIcon/dist/voussoir-icon-icons-link2OffIcon.cjs.js",
       "module": "./icons/link2OffIcon/dist/voussoir-icon-icons-link2OffIcon.esm.js",
       "default": "./icons/link2OffIcon/dist/voussoir-icon-icons-link2OffIcon.cjs.js"
     },
     "./icons/linkedinIcon": {
+      "types": "./icons/linkedinIcon/dist/voussoir-icon-icons-linkedinIcon.cjs.js",
       "module": "./icons/linkedinIcon/dist/voussoir-icon-icons-linkedinIcon.esm.js",
       "default": "./icons/linkedinIcon/dist/voussoir-icon-icons-linkedinIcon.cjs.js"
     },
     "./icons/listPlusIcon": {
+      "types": "./icons/listPlusIcon/dist/voussoir-icon-icons-listPlusIcon.cjs.js",
       "module": "./icons/listPlusIcon/dist/voussoir-icon-icons-listPlusIcon.esm.js",
       "default": "./icons/listPlusIcon/dist/voussoir-icon-icons-listPlusIcon.cjs.js"
     },
     "./icons/mailOpenIcon": {
+      "types": "./icons/mailOpenIcon/dist/voussoir-icon-icons-mailOpenIcon.cjs.js",
       "module": "./icons/mailOpenIcon/dist/voussoir-icon-icons-mailOpenIcon.esm.js",
       "default": "./icons/mailOpenIcon/dist/voussoir-icon-icons-mailOpenIcon.cjs.js"
     },
     "./icons/mailPlusIcon": {
+      "types": "./icons/mailPlusIcon/dist/voussoir-icon-icons-mailPlusIcon.cjs.js",
       "module": "./icons/mailPlusIcon/dist/voussoir-icon-icons-mailPlusIcon.esm.js",
       "default": "./icons/mailPlusIcon/dist/voussoir-icon-icons-mailPlusIcon.cjs.js"
     },
     "./icons/maximizeIcon": {
+      "types": "./icons/maximizeIcon/dist/voussoir-icon-icons-maximizeIcon.cjs.js",
       "module": "./icons/maximizeIcon/dist/voussoir-icon-icons-maximizeIcon.esm.js",
       "default": "./icons/maximizeIcon/dist/voussoir-icon-icons-maximizeIcon.cjs.js"
     },
     "./icons/minimizeIcon": {
+      "types": "./icons/minimizeIcon/dist/voussoir-icon-icons-minimizeIcon.cjs.js",
       "module": "./icons/minimizeIcon/dist/voussoir-icon-icons-minimizeIcon.esm.js",
       "default": "./icons/minimizeIcon/dist/voussoir-icon-icons-minimizeIcon.cjs.js"
     },
     "./icons/mountainIcon": {
+      "types": "./icons/mountainIcon/dist/voussoir-icon-icons-mountainIcon.cjs.js",
       "module": "./icons/mountainIcon/dist/voussoir-icon-icons-mountainIcon.esm.js",
       "default": "./icons/mountainIcon/dist/voussoir-icon-icons-mountainIcon.cjs.js"
     },
     "./icons/package2Icon": {
+      "types": "./icons/package2Icon/dist/voussoir-icon-icons-package2Icon.cjs.js",
       "module": "./icons/package2Icon/dist/voussoir-icon-icons-package2Icon.esm.js",
       "default": "./icons/package2Icon/dist/voussoir-icon-icons-package2Icon.cjs.js"
     },
     "./icons/packageXIcon": {
+      "types": "./icons/packageXIcon/dist/voussoir-icon-icons-packageXIcon.cjs.js",
       "module": "./icons/packageXIcon/dist/voussoir-icon-icons-packageXIcon.esm.js",
       "default": "./icons/packageXIcon/dist/voussoir-icon-icons-packageXIcon.cjs.js"
     },
     "./icons/palmtreeIcon": {
+      "types": "./icons/palmtreeIcon/dist/voussoir-icon-icons-palmtreeIcon.cjs.js",
       "module": "./icons/palmtreeIcon/dist/voussoir-icon-icons-palmtreeIcon.esm.js",
       "default": "./icons/palmtreeIcon/dist/voussoir-icon-icons-palmtreeIcon.cjs.js"
     },
     "./icons/phoneOffIcon": {
+      "types": "./icons/phoneOffIcon/dist/voussoir-icon-icons-phoneOffIcon.cjs.js",
       "module": "./icons/phoneOffIcon/dist/voussoir-icon-icons-phoneOffIcon.esm.js",
       "default": "./icons/phoneOffIcon/dist/voussoir-icon-icons-phoneOffIcon.cjs.js"
     },
     "./icons/pieChartIcon": {
+      "types": "./icons/pieChartIcon/dist/voussoir-icon-icons-pieChartIcon.cjs.js",
       "module": "./icons/pieChartIcon/dist/voussoir-icon-icons-pieChartIcon.esm.js",
       "default": "./icons/pieChartIcon/dist/voussoir-icon-icons-pieChartIcon.cjs.js"
     },
     "./icons/powerOffIcon": {
+      "types": "./icons/powerOffIcon/dist/voussoir-icon-icons-powerOffIcon.cjs.js",
       "module": "./icons/powerOffIcon/dist/voussoir-icon-icons-powerOffIcon.esm.js",
       "default": "./icons/powerOffIcon/dist/voussoir-icon-icons-powerOffIcon.cjs.js"
     },
     "./icons/replyAllIcon": {
+      "types": "./icons/replyAllIcon/dist/voussoir-icon-icons-replyAllIcon.cjs.js",
       "module": "./icons/replyAllIcon/dist/voussoir-icon-icons-replyAllIcon.esm.js",
       "default": "./icons/replyAllIcon/dist/voussoir-icon-icons-replyAllIcon.cjs.js"
     },
     "./icons/rotate3dIcon": {
+      "types": "./icons/rotate3dIcon/dist/voussoir-icon-icons-rotate3dIcon.cjs.js",
       "module": "./icons/rotate3dIcon/dist/voussoir-icon-icons-rotate3dIcon.esm.js",
       "default": "./icons/rotate3dIcon/dist/voussoir-icon-icons-rotate3dIcon.cjs.js"
     },
     "./icons/rotateCwIcon": {
+      "types": "./icons/rotateCwIcon/dist/voussoir-icon-icons-rotateCwIcon.cjs.js",
       "module": "./icons/rotateCwIcon/dist/voussoir-icon-icons-rotateCwIcon.esm.js",
       "default": "./icons/rotateCwIcon/dist/voussoir-icon-icons-rotateCwIcon.cjs.js"
     },
     "./icons/sailboatIcon": {
+      "types": "./icons/sailboatIcon/dist/voussoir-icon-icons-sailboatIcon.cjs.js",
       "module": "./icons/sailboatIcon/dist/voussoir-icon-icons-sailboatIcon.esm.js",
       "default": "./icons/sailboatIcon/dist/voussoir-icon-icons-sailboatIcon.cjs.js"
     },
     "./icons/sandwichIcon": {
+      "types": "./icons/sandwichIcon/dist/voussoir-icon-icons-sandwichIcon.cjs.js",
       "module": "./icons/sandwichIcon/dist/voussoir-icon-icons-sandwichIcon.esm.js",
       "default": "./icons/sandwichIcon/dist/voussoir-icon-icons-sandwichIcon.cjs.js"
     },
     "./icons/scanFaceIcon": {
+      "types": "./icons/scanFaceIcon/dist/voussoir-icon-icons-scanFaceIcon.cjs.js",
       "module": "./icons/scanFaceIcon/dist/voussoir-icon-icons-scanFaceIcon.esm.js",
       "default": "./icons/scanFaceIcon/dist/voussoir-icon-icons-scanFaceIcon.cjs.js"
     },
     "./icons/scanLineIcon": {
+      "types": "./icons/scanLineIcon/dist/voussoir-icon-icons-scanLineIcon.cjs.js",
       "module": "./icons/scanLineIcon/dist/voussoir-icon-icons-scanLineIcon.esm.js",
       "default": "./icons/scanLineIcon/dist/voussoir-icon-icons-scanLineIcon.cjs.js"
     },
     "./icons/scissorsIcon": {
+      "types": "./icons/scissorsIcon/dist/voussoir-icon-icons-scissorsIcon.cjs.js",
       "module": "./icons/scissorsIcon/dist/voussoir-icon-icons-scissorsIcon.esm.js",
       "default": "./icons/scissorsIcon/dist/voussoir-icon-icons-scissorsIcon.cjs.js"
     },
     "./icons/settingsIcon": {
+      "types": "./icons/settingsIcon/dist/voussoir-icon-icons-settingsIcon.cjs.js",
       "module": "./icons/settingsIcon/dist/voussoir-icon-icons-settingsIcon.esm.js",
       "default": "./icons/settingsIcon/dist/voussoir-icon-icons-settingsIcon.cjs.js"
     },
     "./icons/skipBackIcon": {
+      "types": "./icons/skipBackIcon/dist/voussoir-icon-icons-skipBackIcon.cjs.js",
       "module": "./icons/skipBackIcon/dist/voussoir-icon-icons-skipBackIcon.esm.js",
       "default": "./icons/skipBackIcon/dist/voussoir-icon-icons-skipBackIcon.cjs.js"
     },
     "./icons/sortDescIcon": {
+      "types": "./icons/sortDescIcon/dist/voussoir-icon-icons-sortDescIcon.cjs.js",
       "module": "./icons/sortDescIcon/dist/voussoir-icon-icons-sortDescIcon.esm.js",
       "default": "./icons/sortDescIcon/dist/voussoir-icon-icons-sortDescIcon.cjs.js"
     },
     "./icons/starHalfIcon": {
+      "types": "./icons/starHalfIcon/dist/voussoir-icon-icons-starHalfIcon.cjs.js",
       "module": "./icons/starHalfIcon/dist/voussoir-icon-icons-starHalfIcon.esm.js",
       "default": "./icons/starHalfIcon/dist/voussoir-icon-icons-starHalfIcon.cjs.js"
     },
     "./icons/terminalIcon": {
+      "types": "./icons/terminalIcon/dist/voussoir-icon-icons-terminalIcon.cjs.js",
       "module": "./icons/terminalIcon/dist/voussoir-icon-icons-terminalIcon.esm.js",
       "default": "./icons/terminalIcon/dist/voussoir-icon-icons-terminalIcon.cjs.js"
     },
     "./icons/thumbsUpIcon": {
+      "types": "./icons/thumbsUpIcon/dist/voussoir-icon-icons-thumbsUpIcon.cjs.js",
       "module": "./icons/thumbsUpIcon/dist/voussoir-icon-icons-thumbsUpIcon.esm.js",
       "default": "./icons/thumbsUpIcon/dist/voussoir-icon-icons-thumbsUpIcon.cjs.js"
     },
     "./icons/timerOffIcon": {
+      "types": "./icons/timerOffIcon/dist/voussoir-icon-icons-timerOffIcon.cjs.js",
       "module": "./icons/timerOffIcon/dist/voussoir-icon-icons-timerOffIcon.esm.js",
       "default": "./icons/timerOffIcon/dist/voussoir-icon-icons-timerOffIcon.cjs.js"
     },
     "./icons/toyBrickIcon": {
+      "types": "./icons/toyBrickIcon/dist/voussoir-icon-icons-toyBrickIcon.cjs.js",
       "module": "./icons/toyBrickIcon/dist/voussoir-icon-icons-toyBrickIcon.esm.js",
       "default": "./icons/toyBrickIcon/dist/voussoir-icon-icons-toyBrickIcon.cjs.js"
     },
     "./icons/treePineIcon": {
+      "types": "./icons/treePineIcon/dist/voussoir-icon-icons-treePineIcon.cjs.js",
       "module": "./icons/treePineIcon/dist/voussoir-icon-icons-treePineIcon.esm.js",
       "default": "./icons/treePineIcon/dist/voussoir-icon-icons-treePineIcon.cjs.js"
     },
     "./icons/triangleIcon": {
+      "types": "./icons/triangleIcon/dist/voussoir-icon-icons-triangleIcon.cjs.js",
       "module": "./icons/triangleIcon/dist/voussoir-icon-icons-triangleIcon.esm.js",
       "default": "./icons/triangleIcon/dist/voussoir-icon-icons-triangleIcon.cjs.js"
     },
     "./icons/umbrellaIcon": {
+      "types": "./icons/umbrellaIcon/dist/voussoir-icon-icons-umbrellaIcon.cjs.js",
       "module": "./icons/umbrellaIcon/dist/voussoir-icon-icons-umbrellaIcon.esm.js",
       "default": "./icons/umbrellaIcon/dist/voussoir-icon-icons-umbrellaIcon.cjs.js"
     },
     "./icons/userPlusIcon": {
+      "types": "./icons/userPlusIcon/dist/voussoir-icon-icons-userPlusIcon.cjs.js",
       "module": "./icons/userPlusIcon/dist/voussoir-icon-icons-userPlusIcon.esm.js",
       "default": "./icons/userPlusIcon/dist/voussoir-icon-icons-userPlusIcon.cjs.js"
     },
     "./icons/utensilsIcon": {
+      "types": "./icons/utensilsIcon/dist/voussoir-icon-icons-utensilsIcon.cjs.js",
       "module": "./icons/utensilsIcon/dist/voussoir-icon-icons-utensilsIcon.esm.js",
       "default": "./icons/utensilsIcon/dist/voussoir-icon-icons-utensilsIcon.cjs.js"
     },
     "./icons/verifiedIcon": {
+      "types": "./icons/verifiedIcon/dist/voussoir-icon-icons-verifiedIcon.cjs.js",
       "module": "./icons/verifiedIcon/dist/voussoir-icon-icons-verifiedIcon.esm.js",
       "default": "./icons/verifiedIcon/dist/voussoir-icon-icons-verifiedIcon.cjs.js"
     },
     "./icons/videoOffIcon": {
+      "types": "./icons/videoOffIcon/dist/voussoir-icon-icons-videoOffIcon.cjs.js",
       "module": "./icons/videoOffIcon/dist/voussoir-icon-icons-videoOffIcon.esm.js",
       "default": "./icons/videoOffIcon/dist/voussoir-icon-icons-videoOffIcon.cjs.js"
     },
     "./icons/wheatOffIcon": {
+      "types": "./icons/wheatOffIcon/dist/voussoir-icon-icons-wheatOffIcon.cjs.js",
       "module": "./icons/wheatOffIcon/dist/voussoir-icon-icons-wheatOffIcon.esm.js",
       "default": "./icons/wheatOffIcon/dist/voussoir-icon-icons-wheatOffIcon.cjs.js"
     },
     "./icons/wrapTextIcon": {
+      "types": "./icons/wrapTextIcon/dist/voussoir-icon-icons-wrapTextIcon.cjs.js",
       "module": "./icons/wrapTextIcon/dist/voussoir-icon-icons-wrapTextIcon.esm.js",
       "default": "./icons/wrapTextIcon/dist/voussoir-icon-icons-wrapTextIcon.cjs.js"
     },
     "./icons/xOctagonIcon": {
+      "types": "./icons/xOctagonIcon/dist/voussoir-icon-icons-xOctagonIcon.cjs.js",
       "module": "./icons/xOctagonIcon/dist/voussoir-icon-icons-xOctagonIcon.esm.js",
       "default": "./icons/xOctagonIcon/dist/voussoir-icon-icons-xOctagonIcon.cjs.js"
     },
     "./icons/alarmPlusIcon": {
+      "types": "./icons/alarmPlusIcon/dist/voussoir-icon-icons-alarmPlusIcon.cjs.js",
       "module": "./icons/alarmPlusIcon/dist/voussoir-icon-icons-alarmPlusIcon.esm.js",
       "default": "./icons/alarmPlusIcon/dist/voussoir-icon-icons-alarmPlusIcon.cjs.js"
     },
     "./icons/alignLeftIcon": {
+      "types": "./icons/alignLeftIcon/dist/voussoir-icon-icons-alignLeftIcon.cjs.js",
       "module": "./icons/alignLeftIcon/dist/voussoir-icon-icons-alignLeftIcon.esm.js",
       "default": "./icons/alignLeftIcon/dist/voussoir-icon-icons-alignLeftIcon.cjs.js"
     },
     "./icons/arrowDownIcon": {
+      "types": "./icons/arrowDownIcon/dist/voussoir-icon-icons-arrowDownIcon.cjs.js",
       "module": "./icons/arrowDownIcon/dist/voussoir-icon-icons-arrowDownIcon.esm.js",
       "default": "./icons/arrowDownIcon/dist/voussoir-icon-icons-arrowDownIcon.cjs.js"
     },
     "./icons/arrowLeftIcon": {
+      "types": "./icons/arrowLeftIcon/dist/voussoir-icon-icons-arrowLeftIcon.cjs.js",
       "module": "./icons/arrowLeftIcon/dist/voussoir-icon-icons-arrowLeftIcon.esm.js",
       "default": "./icons/arrowLeftIcon/dist/voussoir-icon-icons-arrowLeftIcon.cjs.js"
     },
     "./icons/barChart2Icon": {
+      "types": "./icons/barChart2Icon/dist/voussoir-icon-icons-barChart2Icon.cjs.js",
       "module": "./icons/barChart2Icon/dist/voussoir-icon-icons-barChart2Icon.esm.js",
       "default": "./icons/barChart2Icon/dist/voussoir-icon-icons-barChart2Icon.cjs.js"
     },
     "./icons/barChart3Icon": {
+      "types": "./icons/barChart3Icon/dist/voussoir-icon-icons-barChart3Icon.cjs.js",
       "module": "./icons/barChart3Icon/dist/voussoir-icon-icons-barChart3Icon.esm.js",
       "default": "./icons/barChart3Icon/dist/voussoir-icon-icons-barChart3Icon.cjs.js"
     },
     "./icons/barChart4Icon": {
+      "types": "./icons/barChart4Icon/dist/voussoir-icon-icons-barChart4Icon.cjs.js",
       "module": "./icons/barChart4Icon/dist/voussoir-icon-icons-barChart4Icon.esm.js",
       "default": "./icons/barChart4Icon/dist/voussoir-icon-icons-barChart4Icon.cjs.js"
     },
     "./icons/bedDoubleIcon": {
+      "types": "./icons/bedDoubleIcon/dist/voussoir-icon-icons-bedDoubleIcon.cjs.js",
       "module": "./icons/bedDoubleIcon/dist/voussoir-icon-icons-bedDoubleIcon.esm.js",
       "default": "./icons/bedDoubleIcon/dist/voussoir-icon-icons-bedDoubleIcon.cjs.js"
     },
     "./icons/bedSingleIcon": {
+      "types": "./icons/bedSingleIcon/dist/voussoir-icon-icons-bedSingleIcon.cjs.js",
       "module": "./icons/bedSingleIcon/dist/voussoir-icon-icons-bedSingleIcon.esm.js",
       "default": "./icons/bedSingleIcon/dist/voussoir-icon-icons-bedSingleIcon.cjs.js"
     },
     "./icons/bellMinusIcon": {
+      "types": "./icons/bellMinusIcon/dist/voussoir-icon-icons-bellMinusIcon.cjs.js",
       "module": "./icons/bellMinusIcon/dist/voussoir-icon-icons-bellMinusIcon.esm.js",
       "default": "./icons/bellMinusIcon/dist/voussoir-icon-icons-bellMinusIcon.cjs.js"
     },
     "./icons/bluetoothIcon": {
+      "types": "./icons/bluetoothIcon/dist/voussoir-icon-icons-bluetoothIcon.cjs.js",
       "module": "./icons/bluetoothIcon/dist/voussoir-icon-icons-bluetoothIcon.esm.js",
       "default": "./icons/bluetoothIcon/dist/voussoir-icon-icons-bluetoothIcon.cjs.js"
     },
     "./icons/boxSelectIcon": {
+      "types": "./icons/boxSelectIcon/dist/voussoir-icon-icons-boxSelectIcon.cjs.js",
       "module": "./icons/boxSelectIcon/dist/voussoir-icon-icons-boxSelectIcon.esm.js",
       "default": "./icons/boxSelectIcon/dist/voussoir-icon-icons-boxSelectIcon.cjs.js"
     },
     "./icons/briefcaseIcon": {
+      "types": "./icons/briefcaseIcon/dist/voussoir-icon-icons-briefcaseIcon.cjs.js",
       "module": "./icons/briefcaseIcon/dist/voussoir-icon-icons-briefcaseIcon.esm.js",
       "default": "./icons/briefcaseIcon/dist/voussoir-icon-icons-briefcaseIcon.cjs.js"
     },
     "./icons/building2Icon": {
+      "types": "./icons/building2Icon/dist/voussoir-icon-icons-building2Icon.cjs.js",
       "module": "./icons/building2Icon/dist/voussoir-icon-icons-building2Icon.esm.js",
       "default": "./icons/building2Icon/dist/voussoir-icon-icons-building2Icon.cjs.js"
     },
     "./icons/calendarXIcon": {
+      "types": "./icons/calendarXIcon/dist/voussoir-icon-icons-calendarXIcon.cjs.js",
       "module": "./icons/calendarXIcon/dist/voussoir-icon-icons-calendarXIcon.esm.js",
       "default": "./icons/calendarXIcon/dist/voussoir-icon-icons-calendarXIcon.cjs.js"
     },
     "./icons/cameraOffIcon": {
+      "types": "./icons/cameraOffIcon/dist/voussoir-icon-icons-cameraOffIcon.cjs.js",
       "module": "./icons/cameraOffIcon/dist/voussoir-icon-icons-cameraOffIcon.esm.js",
       "default": "./icons/cameraOffIcon/dist/voussoir-icon-icons-cameraOffIcon.cjs.js"
     },
     "./icons/chevronUpIcon": {
+      "types": "./icons/chevronUpIcon/dist/voussoir-icon-icons-chevronUpIcon.cjs.js",
       "module": "./icons/chevronUpIcon/dist/voussoir-icon-icons-chevronUpIcon.esm.js",
       "default": "./icons/chevronUpIcon/dist/voussoir-icon-icons-chevronUpIcon.cjs.js"
     },
     "./icons/cigaretteIcon": {
+      "types": "./icons/cigaretteIcon/dist/voussoir-icon-icons-cigaretteIcon.cjs.js",
       "module": "./icons/cigaretteIcon/dist/voussoir-icon-icons-cigaretteIcon.esm.js",
       "default": "./icons/cigaretteIcon/dist/voussoir-icon-icons-cigaretteIcon.cjs.js"
     },
     "./icons/circleDotIcon": {
+      "types": "./icons/circleDotIcon/dist/voussoir-icon-icons-circleDotIcon.cjs.js",
       "module": "./icons/circleDotIcon/dist/voussoir-icon-icons-circleDotIcon.esm.js",
       "default": "./icons/circleDotIcon/dist/voussoir-icon-icons-circleDotIcon.cjs.js"
     },
     "./icons/clipboardIcon": {
+      "types": "./icons/clipboardIcon/dist/voussoir-icon-icons-clipboardIcon.cjs.js",
       "module": "./icons/clipboardIcon/dist/voussoir-icon-icons-clipboardIcon.esm.js",
       "default": "./icons/clipboardIcon/dist/voussoir-icon-icons-clipboardIcon.cjs.js"
     },
     "./icons/cloudHailIcon": {
+      "types": "./icons/cloudHailIcon/dist/voussoir-icon-icons-cloudHailIcon.cjs.js",
       "module": "./icons/cloudHailIcon/dist/voussoir-icon-icons-cloudHailIcon.esm.js",
       "default": "./icons/cloudHailIcon/dist/voussoir-icon-icons-cloudHailIcon.cjs.js"
     },
     "./icons/cloudMoonIcon": {
+      "types": "./icons/cloudMoonIcon/dist/voussoir-icon-icons-cloudMoonIcon.cjs.js",
       "module": "./icons/cloudMoonIcon/dist/voussoir-icon-icons-cloudMoonIcon.esm.js",
       "default": "./icons/cloudMoonIcon/dist/voussoir-icon-icons-cloudMoonIcon.cjs.js"
     },
     "./icons/cloudRainIcon": {
+      "types": "./icons/cloudRainIcon/dist/voussoir-icon-icons-cloudRainIcon.cjs.js",
       "module": "./icons/cloudRainIcon/dist/voussoir-icon-icons-cloudRainIcon.esm.js",
       "default": "./icons/cloudRainIcon/dist/voussoir-icon-icons-cloudRainIcon.cjs.js"
     },
     "./icons/cloudSnowIcon": {
+      "types": "./icons/cloudSnowIcon/dist/voussoir-icon-icons-cloudSnowIcon.cjs.js",
       "module": "./icons/cloudSnowIcon/dist/voussoir-icon-icons-cloudSnowIcon.esm.js",
       "default": "./icons/cloudSnowIcon/dist/voussoir-icon-icons-cloudSnowIcon.cjs.js"
     },
     "./icons/componentIcon": {
+      "types": "./icons/componentIcon/dist/voussoir-icon-icons-componentIcon.cjs.js",
       "module": "./icons/componentIcon/dist/voussoir-icon-icons-componentIcon.esm.js",
       "default": "./icons/componentIcon/dist/voussoir-icon-icons-componentIcon.cjs.js"
     },
     "./icons/copyrightIcon": {
+      "types": "./icons/copyrightIcon/dist/voussoir-icon-icons-copyrightIcon.cjs.js",
       "module": "./icons/copyrightIcon/dist/voussoir-icon-icons-copyrightIcon.esm.js",
       "default": "./icons/copyrightIcon/dist/voussoir-icon-icons-copyrightIcon.cjs.js"
     },
     "./icons/croissantIcon": {
+      "types": "./icons/croissantIcon/dist/voussoir-icon-icons-croissantIcon.cjs.js",
       "module": "./icons/croissantIcon/dist/voussoir-icon-icons-croissantIcon.esm.js",
       "default": "./icons/croissantIcon/dist/voussoir-icon-icons-croissantIcon.cjs.js"
     },
     "./icons/crosshairIcon": {
+      "types": "./icons/crosshairIcon/dist/voussoir-icon-icons-crosshairIcon.cjs.js",
       "module": "./icons/crosshairIcon/dist/voussoir-icon-icons-crosshairIcon.esm.js",
       "default": "./icons/crosshairIcon/dist/voussoir-icon-icons-crosshairIcon.cjs.js"
     },
     "./icons/drumstickIcon": {
+      "types": "./icons/drumstickIcon/dist/voussoir-icon-icons-drumstickIcon.cjs.js",
       "module": "./icons/drumstickIcon/dist/voussoir-icon-icons-drumstickIcon.esm.js",
       "default": "./icons/drumstickIcon/dist/voussoir-icon-icons-drumstickIcon.cjs.js"
     },
     "./icons/fileAudioIcon": {
+      "types": "./icons/fileAudioIcon/dist/voussoir-icon-icons-fileAudioIcon.cjs.js",
       "module": "./icons/fileAudioIcon/dist/voussoir-icon-icons-fileAudioIcon.esm.js",
       "default": "./icons/fileAudioIcon/dist/voussoir-icon-icons-fileAudioIcon.cjs.js"
     },
     "./icons/fileBadgeIcon": {
+      "types": "./icons/fileBadgeIcon/dist/voussoir-icon-icons-fileBadgeIcon.cjs.js",
       "module": "./icons/fileBadgeIcon/dist/voussoir-icon-icons-fileBadgeIcon.esm.js",
       "default": "./icons/fileBadgeIcon/dist/voussoir-icon-icons-fileBadgeIcon.cjs.js"
     },
     "./icons/fileCheckIcon": {
+      "types": "./icons/fileCheckIcon/dist/voussoir-icon-icons-fileCheckIcon.cjs.js",
       "module": "./icons/fileCheckIcon/dist/voussoir-icon-icons-fileCheckIcon.esm.js",
       "default": "./icons/fileCheckIcon/dist/voussoir-icon-icons-fileCheckIcon.cjs.js"
     },
     "./icons/fileClockIcon": {
+      "types": "./icons/fileClockIcon/dist/voussoir-icon-icons-fileClockIcon.cjs.js",
       "module": "./icons/fileClockIcon/dist/voussoir-icon-icons-fileClockIcon.esm.js",
       "default": "./icons/fileClockIcon/dist/voussoir-icon-icons-fileClockIcon.cjs.js"
     },
     "./icons/fileDigitIcon": {
+      "types": "./icons/fileDigitIcon/dist/voussoir-icon-icons-fileDigitIcon.cjs.js",
       "module": "./icons/fileDigitIcon/dist/voussoir-icon-icons-fileDigitIcon.esm.js",
       "default": "./icons/fileDigitIcon/dist/voussoir-icon-icons-fileDigitIcon.cjs.js"
     },
     "./icons/fileHeartIcon": {
+      "types": "./icons/fileHeartIcon/dist/voussoir-icon-icons-fileHeartIcon.cjs.js",
       "module": "./icons/fileHeartIcon/dist/voussoir-icon-icons-fileHeartIcon.esm.js",
       "default": "./icons/fileHeartIcon/dist/voussoir-icon-icons-fileHeartIcon.cjs.js"
     },
     "./icons/fileImageIcon": {
+      "types": "./icons/fileImageIcon/dist/voussoir-icon-icons-fileImageIcon.cjs.js",
       "module": "./icons/fileImageIcon/dist/voussoir-icon-icons-fileImageIcon.esm.js",
       "default": "./icons/fileImageIcon/dist/voussoir-icon-icons-fileImageIcon.cjs.js"
     },
     "./icons/fileInputIcon": {
+      "types": "./icons/fileInputIcon/dist/voussoir-icon-icons-fileInputIcon.cjs.js",
       "module": "./icons/fileInputIcon/dist/voussoir-icon-icons-fileInputIcon.esm.js",
       "default": "./icons/fileInputIcon/dist/voussoir-icon-icons-fileInputIcon.cjs.js"
     },
     "./icons/fileJson2Icon": {
+      "types": "./icons/fileJson2Icon/dist/voussoir-icon-icons-fileJson2Icon.cjs.js",
       "module": "./icons/fileJson2Icon/dist/voussoir-icon-icons-fileJson2Icon.esm.js",
       "default": "./icons/fileJson2Icon/dist/voussoir-icon-icons-fileJson2Icon.cjs.js"
     },
     "./icons/fileLock2Icon": {
+      "types": "./icons/fileLock2Icon/dist/voussoir-icon-icons-fileLock2Icon.cjs.js",
       "module": "./icons/fileLock2Icon/dist/voussoir-icon-icons-fileLock2Icon.esm.js",
       "default": "./icons/fileLock2Icon/dist/voussoir-icon-icons-fileLock2Icon.cjs.js"
     },
     "./icons/fileMinusIcon": {
+      "types": "./icons/fileMinusIcon/dist/voussoir-icon-icons-fileMinusIcon.cjs.js",
       "module": "./icons/fileMinusIcon/dist/voussoir-icon-icons-fileMinusIcon.esm.js",
       "default": "./icons/fileMinusIcon/dist/voussoir-icon-icons-fileMinusIcon.cjs.js"
     },
     "./icons/filePlus2Icon": {
+      "types": "./icons/filePlus2Icon/dist/voussoir-icon-icons-filePlus2Icon.cjs.js",
       "module": "./icons/filePlus2Icon/dist/voussoir-icon-icons-filePlus2Icon.esm.js",
       "default": "./icons/filePlus2Icon/dist/voussoir-icon-icons-filePlus2Icon.cjs.js"
     },
     "./icons/fileType2Icon": {
+      "types": "./icons/fileType2Icon/dist/voussoir-icon-icons-fileType2Icon.cjs.js",
       "module": "./icons/fileType2Icon/dist/voussoir-icon-icons-fileType2Icon.esm.js",
       "default": "./icons/fileType2Icon/dist/voussoir-icon-icons-fileType2Icon.cjs.js"
     },
     "./icons/fileVideoIcon": {
+      "types": "./icons/fileVideoIcon/dist/voussoir-icon-icons-fileVideoIcon.cjs.js",
       "module": "./icons/fileVideoIcon/dist/voussoir-icon-icons-fileVideoIcon.esm.js",
       "default": "./icons/fileVideoIcon/dist/voussoir-icon-icons-fileVideoIcon.cjs.js"
     },
     "./icons/folderCogIcon": {
+      "types": "./icons/folderCogIcon/dist/voussoir-icon-icons-folderCogIcon.cjs.js",
       "module": "./icons/folderCogIcon/dist/voussoir-icon-icons-folderCogIcon.esm.js",
       "default": "./icons/folderCogIcon/dist/voussoir-icon-icons-folderCogIcon.cjs.js"
     },
     "./icons/folderKeyIcon": {
+      "types": "./icons/folderKeyIcon/dist/voussoir-icon-icons-folderKeyIcon.cjs.js",
       "module": "./icons/folderKeyIcon/dist/voussoir-icon-icons-folderKeyIcon.esm.js",
       "default": "./icons/folderKeyIcon/dist/voussoir-icon-icons-folderKeyIcon.cjs.js"
     },
     "./icons/formInputIcon": {
+      "types": "./icons/formInputIcon/dist/voussoir-icon-icons-formInputIcon.cjs.js",
       "module": "./icons/formInputIcon/dist/voussoir-icon-icons-formInputIcon.esm.js",
       "default": "./icons/formInputIcon/dist/voussoir-icon-icons-formInputIcon.cjs.js"
     },
     "./icons/gitBranchIcon": {
+      "types": "./icons/gitBranchIcon/dist/voussoir-icon-icons-gitBranchIcon.cjs.js",
       "module": "./icons/gitBranchIcon/dist/voussoir-icon-icons-gitBranchIcon.esm.js",
       "default": "./icons/gitBranchIcon/dist/voussoir-icon-icons-gitBranchIcon.cjs.js"
     },
     "./icons/gitCommitIcon": {
+      "types": "./icons/gitCommitIcon/dist/voussoir-icon-icons-gitCommitIcon.cjs.js",
       "module": "./icons/gitCommitIcon/dist/voussoir-icon-icons-gitCommitIcon.esm.js",
       "default": "./icons/gitCommitIcon/dist/voussoir-icon-icons-gitCommitIcon.cjs.js"
     },
     "./icons/handMetalIcon": {
+      "types": "./icons/handMetalIcon/dist/voussoir-icon-icons-handMetalIcon.cjs.js",
       "module": "./icons/handMetalIcon/dist/voussoir-icon-icons-handMetalIcon.esm.js",
       "default": "./icons/handMetalIcon/dist/voussoir-icon-icons-handMetalIcon.cjs.js"
     },
     "./icons/hardDriveIcon": {
+      "types": "./icons/hardDriveIcon/dist/voussoir-icon-icons-hardDriveIcon.cjs.js",
       "module": "./icons/hardDriveIcon/dist/voussoir-icon-icons-hardDriveIcon.esm.js",
       "default": "./icons/hardDriveIcon/dist/voussoir-icon-icons-hardDriveIcon.cjs.js"
     },
     "./icons/hourglassIcon": {
+      "types": "./icons/hourglassIcon/dist/voussoir-icon-icons-hourglassIcon.cjs.js",
       "module": "./icons/hourglassIcon/dist/voussoir-icon-icons-hourglassIcon.esm.js",
       "default": "./icons/hourglassIcon/dist/voussoir-icon-icons-hourglassIcon.cjs.js"
     },
     "./icons/iceCream2Icon": {
+      "types": "./icons/iceCream2Icon/dist/voussoir-icon-icons-iceCream2Icon.cjs.js",
       "module": "./icons/iceCream2Icon/dist/voussoir-icon-icons-iceCream2Icon.esm.js",
       "default": "./icons/iceCream2Icon/dist/voussoir-icon-icons-iceCream2Icon.cjs.js"
     },
     "./icons/imagePlusIcon": {
+      "types": "./icons/imagePlusIcon/dist/voussoir-icon-icons-imagePlusIcon.cjs.js",
       "module": "./icons/imagePlusIcon/dist/voussoir-icon-icons-imagePlusIcon.esm.js",
       "default": "./icons/imagePlusIcon/dist/voussoir-icon-icons-imagePlusIcon.cjs.js"
     },
     "./icons/instagramIcon": {
+      "types": "./icons/instagramIcon/dist/voussoir-icon-icons-instagramIcon.cjs.js",
       "module": "./icons/instagramIcon/dist/voussoir-icon-icons-instagramIcon.esm.js",
       "default": "./icons/instagramIcon/dist/voussoir-icon-icons-instagramIcon.cjs.js"
     },
     "./icons/lampFloorIcon": {
+      "types": "./icons/lampFloorIcon/dist/voussoir-icon-icons-lampFloorIcon.cjs.js",
       "module": "./icons/lampFloorIcon/dist/voussoir-icon-icons-lampFloorIcon.esm.js",
       "default": "./icons/lampFloorIcon/dist/voussoir-icon-icons-lampFloorIcon.cjs.js"
     },
     "./icons/languagesIcon": {
+      "types": "./icons/languagesIcon/dist/voussoir-icon-icons-languagesIcon.cjs.js",
       "module": "./icons/languagesIcon/dist/voussoir-icon-icons-languagesIcon.esm.js",
       "default": "./icons/languagesIcon/dist/voussoir-icon-icons-languagesIcon.cjs.js"
     },
     "./icons/lightbulbIcon": {
+      "types": "./icons/lightbulbIcon/dist/voussoir-icon-icons-lightbulbIcon.cjs.js",
       "module": "./icons/lightbulbIcon/dist/voussoir-icon-icons-lightbulbIcon.esm.js",
       "default": "./icons/lightbulbIcon/dist/voussoir-icon-icons-lightbulbIcon.cjs.js"
     },
     "./icons/lineChartIcon": {
+      "types": "./icons/lineChartIcon/dist/voussoir-icon-icons-lineChartIcon.cjs.js",
       "module": "./icons/lineChartIcon/dist/voussoir-icon-icons-lineChartIcon.esm.js",
       "default": "./icons/lineChartIcon/dist/voussoir-icon-icons-lineChartIcon.cjs.js"
     },
     "./icons/listMinusIcon": {
+      "types": "./icons/listMinusIcon/dist/voussoir-icon-icons-listMinusIcon.cjs.js",
       "module": "./icons/listMinusIcon/dist/voussoir-icon-icons-listMinusIcon.esm.js",
       "default": "./icons/listMinusIcon/dist/voussoir-icon-icons-listMinusIcon.cjs.js"
     },
     "./icons/listMusicIcon": {
+      "types": "./icons/listMusicIcon/dist/voussoir-icon-icons-listMusicIcon.cjs.js",
       "module": "./icons/listMusicIcon/dist/voussoir-icon-icons-listMusicIcon.esm.js",
       "default": "./icons/listMusicIcon/dist/voussoir-icon-icons-listMusicIcon.cjs.js"
     },
     "./icons/listStartIcon": {
+      "types": "./icons/listStartIcon/dist/voussoir-icon-icons-listStartIcon.cjs.js",
       "module": "./icons/listStartIcon/dist/voussoir-icon-icons-listStartIcon.esm.js",
       "default": "./icons/listStartIcon/dist/voussoir-icon-icons-listStartIcon.cjs.js"
     },
     "./icons/listVideoIcon": {
+      "types": "./icons/listVideoIcon/dist/voussoir-icon-icons-listVideoIcon.cjs.js",
       "module": "./icons/listVideoIcon/dist/voussoir-icon-icons-listVideoIcon.esm.js",
       "default": "./icons/listVideoIcon/dist/voussoir-icon-icons-listVideoIcon.cjs.js"
     },
     "./icons/locateOffIcon": {
+      "types": "./icons/locateOffIcon/dist/voussoir-icon-icons-locateOffIcon.cjs.js",
       "module": "./icons/locateOffIcon/dist/voussoir-icon-icons-locateOffIcon.esm.js",
       "default": "./icons/locateOffIcon/dist/voussoir-icon-icons-locateOffIcon.cjs.js"
     },
     "./icons/mailCheckIcon": {
+      "types": "./icons/mailCheckIcon/dist/voussoir-icon-icons-mailCheckIcon.cjs.js",
       "module": "./icons/mailCheckIcon/dist/voussoir-icon-icons-mailCheckIcon.esm.js",
       "default": "./icons/mailCheckIcon/dist/voussoir-icon-icons-mailCheckIcon.cjs.js"
     },
     "./icons/mailMinusIcon": {
+      "types": "./icons/mailMinusIcon/dist/voussoir-icon-icons-mailMinusIcon.cjs.js",
       "module": "./icons/mailMinusIcon/dist/voussoir-icon-icons-mailMinusIcon.esm.js",
       "default": "./icons/mailMinusIcon/dist/voussoir-icon-icons-mailMinusIcon.cjs.js"
     },
     "./icons/mapPinOffIcon": {
+      "types": "./icons/mapPinOffIcon/dist/voussoir-icon-icons-mapPinOffIcon.cjs.js",
       "module": "./icons/mapPinOffIcon/dist/voussoir-icon-icons-mapPinOffIcon.esm.js",
       "default": "./icons/mapPinOffIcon/dist/voussoir-icon-icons-mapPinOffIcon.cjs.js"
     },
     "./icons/maximize2Icon": {
+      "types": "./icons/maximize2Icon/dist/voussoir-icon-icons-maximize2Icon.cjs.js",
       "module": "./icons/maximize2Icon/dist/voussoir-icon-icons-maximize2Icon.esm.js",
       "default": "./icons/maximize2Icon/dist/voussoir-icon-icons-maximize2Icon.cjs.js"
     },
     "./icons/megaphoneIcon": {
+      "types": "./icons/megaphoneIcon/dist/voussoir-icon-icons-megaphoneIcon.cjs.js",
       "module": "./icons/megaphoneIcon/dist/voussoir-icon-icons-megaphoneIcon.esm.js",
       "default": "./icons/megaphoneIcon/dist/voussoir-icon-icons-megaphoneIcon.cjs.js"
     },
     "./icons/microwaveIcon": {
+      "types": "./icons/microwaveIcon/dist/voussoir-icon-icons-microwaveIcon.cjs.js",
       "module": "./icons/microwaveIcon/dist/voussoir-icon-icons-microwaveIcon.esm.js",
       "default": "./icons/microwaveIcon/dist/voussoir-icon-icons-microwaveIcon.cjs.js"
     },
     "./icons/milestoneIcon": {
+      "types": "./icons/milestoneIcon/dist/voussoir-icon-icons-milestoneIcon.cjs.js",
       "module": "./icons/milestoneIcon/dist/voussoir-icon-icons-milestoneIcon.esm.js",
       "default": "./icons/milestoneIcon/dist/voussoir-icon-icons-milestoneIcon.cjs.js"
     },
     "./icons/minimize2Icon": {
+      "types": "./icons/minimize2Icon/dist/voussoir-icon-icons-minimize2Icon.cjs.js",
       "module": "./icons/minimize2Icon/dist/voussoir-icon-icons-minimize2Icon.esm.js",
       "default": "./icons/minimize2Icon/dist/voussoir-icon-icons-minimize2Icon.cjs.js"
     },
     "./icons/newspaperIcon": {
+      "types": "./icons/newspaperIcon/dist/voussoir-icon-icons-newspaperIcon.cjs.js",
       "module": "./icons/newspaperIcon/dist/voussoir-icon-icons-newspaperIcon.esm.js",
       "default": "./icons/newspaperIcon/dist/voussoir-icon-icons-newspaperIcon.cjs.js"
     },
     "./icons/paperclipIcon": {
+      "types": "./icons/paperclipIcon/dist/voussoir-icon-icons-paperclipIcon.cjs.js",
       "module": "./icons/paperclipIcon/dist/voussoir-icon-icons-paperclipIcon.esm.js",
       "default": "./icons/paperclipIcon/dist/voussoir-icon-icons-paperclipIcon.cjs.js"
     },
     "./icons/phoneCallIcon": {
+      "types": "./icons/phoneCallIcon/dist/voussoir-icon-icons-phoneCallIcon.cjs.js",
       "module": "./icons/phoneCallIcon/dist/voussoir-icon-icons-phoneCallIcon.esm.js",
       "default": "./icons/phoneCallIcon/dist/voussoir-icon-icons-phoneCallIcon.cjs.js"
     },
     "./icons/piggyBankIcon": {
+      "types": "./icons/piggyBankIcon/dist/voussoir-icon-icons-piggyBankIcon.cjs.js",
       "module": "./icons/piggyBankIcon/dist/voussoir-icon-icons-piggyBankIcon.esm.js",
       "default": "./icons/piggyBankIcon/dist/voussoir-icon-icons-piggyBankIcon.cjs.js"
     },
     "./icons/refreshCwIcon": {
+      "types": "./icons/refreshCwIcon/dist/voussoir-icon-icons-refreshCwIcon.cjs.js",
       "module": "./icons/refreshCwIcon/dist/voussoir-icon-icons-refreshCwIcon.esm.js",
       "default": "./icons/refreshCwIcon/dist/voussoir-icon-icons-refreshCwIcon.cjs.js"
     },
     "./icons/rotateCcwIcon": {
+      "types": "./icons/rotateCcwIcon/dist/voussoir-icon-icons-rotateCcwIcon.cjs.js",
       "module": "./icons/rotateCcwIcon/dist/voussoir-icon-icons-rotateCcwIcon.esm.js",
       "default": "./icons/rotateCcwIcon/dist/voussoir-icon-icons-rotateCcwIcon.cjs.js"
     },
     "./icons/serverCogIcon": {
+      "types": "./icons/serverCogIcon/dist/voussoir-icon-icons-serverCogIcon.cjs.js",
       "module": "./icons/serverCogIcon/dist/voussoir-icon-icons-serverCogIcon.esm.js",
       "default": "./icons/serverCogIcon/dist/voussoir-icon-icons-serverCogIcon.cjs.js"
     },
     "./icons/serverOffIcon": {
+      "types": "./icons/serverOffIcon/dist/voussoir-icon-icons-serverOffIcon.cjs.js",
       "module": "./icons/serverOffIcon/dist/voussoir-icon-icons-serverOffIcon.esm.js",
       "default": "./icons/serverOffIcon/dist/voussoir-icon-icons-serverOffIcon.cjs.js"
     },
     "./icons/settings2Icon": {
+      "types": "./icons/settings2Icon/dist/voussoir-icon-icons-settings2Icon.cjs.js",
       "module": "./icons/settings2Icon/dist/voussoir-icon-icons-settings2Icon.esm.js",
       "default": "./icons/settings2Icon/dist/voussoir-icon-icons-settings2Icon.cjs.js"
     },
     "./icons/shieldOffIcon": {
+      "types": "./icons/shieldOffIcon/dist/voussoir-icon-icons-shieldOffIcon.cjs.js",
       "module": "./icons/shieldOffIcon/dist/voussoir-icon-icons-shieldOffIcon.esm.js",
       "default": "./icons/shieldOffIcon/dist/voussoir-icon-icons-shieldOffIcon.cjs.js"
     },
     "./icons/signalLowIcon": {
+      "types": "./icons/signalLowIcon/dist/voussoir-icon-icons-signalLowIcon.cjs.js",
       "module": "./icons/signalLowIcon/dist/voussoir-icon-icons-signalLowIcon.esm.js",
       "default": "./icons/signalLowIcon/dist/voussoir-icon-icons-signalLowIcon.cjs.js"
     },
     "./icons/smilePlusIcon": {
+      "types": "./icons/smilePlusIcon/dist/voussoir-icon-icons-smilePlusIcon.cjs.js",
       "module": "./icons/smilePlusIcon/dist/voussoir-icon-icons-smilePlusIcon.esm.js",
       "default": "./icons/smilePlusIcon/dist/voussoir-icon-icons-smilePlusIcon.cjs.js"
     },
     "./icons/snowflakeIcon": {
+      "types": "./icons/snowflakeIcon/dist/voussoir-icon-icons-snowflakeIcon.cjs.js",
       "module": "./icons/snowflakeIcon/dist/voussoir-icon-icons-snowflakeIcon.esm.js",
       "default": "./icons/snowflakeIcon/dist/voussoir-icon-icons-snowflakeIcon.cjs.js"
     },
     "./icons/subscriptIcon": {
+      "types": "./icons/subscriptIcon/dist/voussoir-icon-icons-subscriptIcon.cjs.js",
       "module": "./icons/subscriptIcon/dist/voussoir-icon-icons-subscriptIcon.esm.js",
       "default": "./icons/subscriptIcon/dist/voussoir-icon-icons-subscriptIcon.cjs.js"
     },
     "./icons/subtitlesIcon": {
+      "types": "./icons/subtitlesIcon/dist/voussoir-icon-icons-subtitlesIcon.cjs.js",
       "module": "./icons/subtitlesIcon/dist/voussoir-icon-icons-subtitlesIcon.esm.js",
       "default": "./icons/subtitlesIcon/dist/voussoir-icon-icons-subtitlesIcon.cjs.js"
     },
     "./icons/sunMediumIcon": {
+      "types": "./icons/sunMediumIcon/dist/voussoir-icon-icons-sunMediumIcon.cjs.js",
       "module": "./icons/sunMediumIcon/dist/voussoir-icon-icons-sunMediumIcon.esm.js",
       "default": "./icons/sunMediumIcon/dist/voussoir-icon-icons-sunMediumIcon.cjs.js"
     },
     "./icons/underlineIcon": {
+      "types": "./icons/underlineIcon/dist/voussoir-icon-icons-underlineIcon.cjs.js",
       "module": "./icons/underlineIcon/dist/voussoir-icon-icons-underlineIcon.esm.js",
       "default": "./icons/underlineIcon/dist/voussoir-icon-icons-underlineIcon.cjs.js"
     },
     "./icons/userCheckIcon": {
+      "types": "./icons/userCheckIcon/dist/voussoir-icon-icons-userCheckIcon.cjs.js",
       "module": "./icons/userCheckIcon/dist/voussoir-icon-icons-userCheckIcon.esm.js",
       "default": "./icons/userCheckIcon/dist/voussoir-icon-icons-userCheckIcon.cjs.js"
     },
     "./icons/userMinusIcon": {
+      "types": "./icons/userMinusIcon/dist/voussoir-icon-icons-userMinusIcon.cjs.js",
       "module": "./icons/userMinusIcon/dist/voussoir-icon-icons-userMinusIcon.esm.js",
       "default": "./icons/userMinusIcon/dist/voussoir-icon-icons-userMinusIcon.cjs.js"
     },
     "./icons/voicemailIcon": {
+      "types": "./icons/voicemailIcon/dist/voussoir-icon-icons-voicemailIcon.cjs.js",
       "module": "./icons/voicemailIcon/dist/voussoir-icon-icons-voicemailIcon.esm.js",
       "default": "./icons/voicemailIcon/dist/voussoir-icon-icons-voicemailIcon.cjs.js"
     },
     "./icons/alarmCheckIcon": {
+      "types": "./icons/alarmCheckIcon/dist/voussoir-icon-icons-alarmCheckIcon.cjs.js",
       "module": "./icons/alarmCheckIcon/dist/voussoir-icon-icons-alarmCheckIcon.esm.js",
       "default": "./icons/alarmCheckIcon/dist/voussoir-icon-icons-alarmCheckIcon.cjs.js"
     },
     "./icons/alarmClockIcon": {
+      "types": "./icons/alarmClockIcon/dist/voussoir-icon-icons-alarmClockIcon.cjs.js",
       "module": "./icons/alarmClockIcon/dist/voussoir-icon-icons-alarmClockIcon.esm.js",
       "default": "./icons/alarmClockIcon/dist/voussoir-icon-icons-alarmClockIcon.cjs.js"
     },
     "./icons/alarmMinusIcon": {
+      "types": "./icons/alarmMinusIcon/dist/voussoir-icon-icons-alarmMinusIcon.cjs.js",
       "module": "./icons/alarmMinusIcon/dist/voussoir-icon-icons-alarmMinusIcon.esm.js",
       "default": "./icons/alarmMinusIcon/dist/voussoir-icon-icons-alarmMinusIcon.cjs.js"
     },
     "./icons/alignRightIcon": {
+      "types": "./icons/alignRightIcon/dist/voussoir-icon-icons-alignRightIcon.cjs.js",
       "module": "./icons/alignRightIcon/dist/voussoir-icon-icons-alignRightIcon.esm.js",
       "default": "./icons/alignRightIcon/dist/voussoir-icon-icons-alignRightIcon.cjs.js"
     },
     "./icons/arrowBigUpIcon": {
+      "types": "./icons/arrowBigUpIcon/dist/voussoir-icon-icons-arrowBigUpIcon.cjs.js",
       "module": "./icons/arrowBigUpIcon/dist/voussoir-icon-icons-arrowBigUpIcon.esm.js",
       "default": "./icons/arrowBigUpIcon/dist/voussoir-icon-icons-arrowBigUpIcon.cjs.js"
     },
     "./icons/arrowRightIcon": {
+      "types": "./icons/arrowRightIcon/dist/voussoir-icon-icons-arrowRightIcon.cjs.js",
       "module": "./icons/arrowRightIcon/dist/voussoir-icon-icons-arrowRightIcon.esm.js",
       "default": "./icons/arrowRightIcon/dist/voussoir-icon-icons-arrowRightIcon.cjs.js"
     },
     "./icons/batteryLowIcon": {
+      "types": "./icons/batteryLowIcon/dist/voussoir-icon-icons-batteryLowIcon.cjs.js",
       "module": "./icons/batteryLowIcon/dist/voussoir-icon-icons-batteryLowIcon.esm.js",
       "default": "./icons/batteryLowIcon/dist/voussoir-icon-icons-batteryLowIcon.cjs.js"
     },
     "./icons/calculatorIcon": {
+      "types": "./icons/calculatorIcon/dist/voussoir-icon-icons-calculatorIcon.cjs.js",
       "module": "./icons/calculatorIcon/dist/voussoir-icon-icons-calculatorIcon.esm.js",
       "default": "./icons/calculatorIcon/dist/voussoir-icon-icons-calculatorIcon.cjs.js"
     },
     "./icons/calendarX2Icon": {
+      "types": "./icons/calendarX2Icon/dist/voussoir-icon-icons-calendarX2Icon.cjs.js",
       "module": "./icons/calendarX2Icon/dist/voussoir-icon-icons-calendarX2Icon.esm.js",
       "default": "./icons/calendarX2Icon/dist/voussoir-icon-icons-calendarX2Icon.cjs.js"
     },
     "./icons/checkCheckIcon": {
+      "types": "./icons/checkCheckIcon/dist/voussoir-icon-icons-checkCheckIcon.cjs.js",
       "module": "./icons/checkCheckIcon/dist/voussoir-icon-icons-checkCheckIcon.esm.js",
       "default": "./icons/checkCheckIcon/dist/voussoir-icon-icons-checkCheckIcon.cjs.js"
     },
     "./icons/chevronsUpIcon": {
+      "types": "./icons/chevronsUpIcon/dist/voussoir-icon-icons-chevronsUpIcon.cjs.js",
       "module": "./icons/chevronsUpIcon/dist/voussoir-icon-icons-chevronsUpIcon.esm.js",
       "default": "./icons/chevronsUpIcon/dist/voussoir-icon-icons-chevronsUpIcon.cjs.js"
     },
     "./icons/clipboardXIcon": {
+      "types": "./icons/clipboardXIcon/dist/voussoir-icon-icons-clipboardXIcon.cjs.js",
       "module": "./icons/clipboardXIcon/dist/voussoir-icon-icons-clipboardXIcon.esm.js",
       "default": "./icons/clipboardXIcon/dist/voussoir-icon-icons-clipboardXIcon.cjs.js"
     },
     "./icons/creditCardIcon": {
+      "types": "./icons/creditCardIcon/dist/voussoir-icon-icons-creditCardIcon.cjs.js",
       "module": "./icons/creditCardIcon/dist/voussoir-icon-icons-creditCardIcon.esm.js",
       "default": "./icons/creditCardIcon/dist/voussoir-icon-icons-creditCardIcon.cjs.js"
     },
     "./icons/dollarSignIcon": {
+      "types": "./icons/dollarSignIcon/dist/voussoir-icon-icons-dollarSignIcon.cjs.js",
       "module": "./icons/dollarSignIcon/dist/voussoir-icon-icons-dollarSignIcon.esm.js",
       "default": "./icons/dollarSignIcon/dist/voussoir-icon-icons-dollarSignIcon.cjs.js"
     },
     "./icons/fileAudio2Icon": {
+      "types": "./icons/fileAudio2Icon/dist/voussoir-icon-icons-fileAudio2Icon.cjs.js",
       "module": "./icons/fileAudio2Icon/dist/voussoir-icon-icons-fileAudio2Icon.esm.js",
       "default": "./icons/fileAudio2Icon/dist/voussoir-icon-icons-fileAudio2Icon.cjs.js"
     },
     "./icons/fileAxis3dIcon": {
+      "types": "./icons/fileAxis3dIcon/dist/voussoir-icon-icons-fileAxis3dIcon.cjs.js",
       "module": "./icons/fileAxis3dIcon/dist/voussoir-icon-icons-fileAxis3dIcon.esm.js",
       "default": "./icons/fileAxis3dIcon/dist/voussoir-icon-icons-fileAxis3dIcon.cjs.js"
     },
     "./icons/fileBadge2Icon": {
+      "types": "./icons/fileBadge2Icon/dist/voussoir-icon-icons-fileBadge2Icon.cjs.js",
       "module": "./icons/fileBadge2Icon/dist/voussoir-icon-icons-fileBadge2Icon.esm.js",
       "default": "./icons/fileBadge2Icon/dist/voussoir-icon-icons-fileBadge2Icon.cjs.js"
     },
     "./icons/fileCheck2Icon": {
+      "types": "./icons/fileCheck2Icon/dist/voussoir-icon-icons-fileCheck2Icon.cjs.js",
       "module": "./icons/fileCheck2Icon/dist/voussoir-icon-icons-fileCheck2Icon.esm.js",
       "default": "./icons/fileCheck2Icon/dist/voussoir-icon-icons-fileCheck2Icon.cjs.js"
     },
     "./icons/fileMinus2Icon": {
+      "types": "./icons/fileMinus2Icon/dist/voussoir-icon-icons-fileMinus2Icon.cjs.js",
       "module": "./icons/fileMinus2Icon/dist/voussoir-icon-icons-fileMinus2Icon.esm.js",
       "default": "./icons/fileMinus2Icon/dist/voussoir-icon-icons-fileMinus2Icon.cjs.js"
     },
     "./icons/fileOutputIcon": {
+      "types": "./icons/fileOutputIcon/dist/voussoir-icon-icons-fileOutputIcon.cjs.js",
       "module": "./icons/fileOutputIcon/dist/voussoir-icon-icons-fileOutputIcon.esm.js",
       "default": "./icons/fileOutputIcon/dist/voussoir-icon-icons-fileOutputIcon.cjs.js"
     },
     "./icons/fileSearchIcon": {
+      "types": "./icons/fileSearchIcon/dist/voussoir-icon-icons-fileSearchIcon.cjs.js",
       "module": "./icons/fileSearchIcon/dist/voussoir-icon-icons-fileSearchIcon.esm.js",
       "default": "./icons/fileSearchIcon/dist/voussoir-icon-icons-fileSearchIcon.cjs.js"
     },
     "./icons/fileVideo2Icon": {
+      "types": "./icons/fileVideo2Icon/dist/voussoir-icon-icons-fileVideo2Icon.cjs.js",
       "module": "./icons/fileVideo2Icon/dist/voussoir-icon-icons-fileVideo2Icon.esm.js",
       "default": "./icons/fileVideo2Icon/dist/voussoir-icon-icons-fileVideo2Icon.cjs.js"
     },
     "./icons/fileVolumeIcon": {
+      "types": "./icons/fileVolumeIcon/dist/voussoir-icon-icons-fileVolumeIcon.cjs.js",
       "module": "./icons/fileVolumeIcon/dist/voussoir-icon-icons-fileVolumeIcon.esm.js",
       "default": "./icons/fileVolumeIcon/dist/voussoir-icon-icons-fileVolumeIcon.cjs.js"
     },
     "./icons/flashlightIcon": {
+      "types": "./icons/flashlightIcon/dist/voussoir-icon-icons-flashlightIcon.cjs.js",
       "module": "./icons/flashlightIcon/dist/voussoir-icon-icons-flashlightIcon.esm.js",
       "default": "./icons/flashlightIcon/dist/voussoir-icon-icons-flashlightIcon.cjs.js"
     },
     "./icons/flaskRoundIcon": {
+      "types": "./icons/flaskRoundIcon/dist/voussoir-icon-icons-flaskRoundIcon.cjs.js",
       "module": "./icons/flaskRoundIcon/dist/voussoir-icon-icons-flaskRoundIcon.esm.js",
       "default": "./icons/flaskRoundIcon/dist/voussoir-icon-icons-flaskRoundIcon.cjs.js"
     },
     "./icons/folderCog2Icon": {
+      "types": "./icons/folderCog2Icon/dist/voussoir-icon-icons-folderCog2Icon.cjs.js",
       "module": "./icons/folderCog2Icon/dist/voussoir-icon-icons-folderCog2Icon.esm.js",
       "default": "./icons/folderCog2Icon/dist/voussoir-icon-icons-folderCog2Icon.cjs.js"
     },
     "./icons/folderDownIcon": {
+      "types": "./icons/folderDownIcon/dist/voussoir-icon-icons-folderDownIcon.cjs.js",
       "module": "./icons/folderDownIcon/dist/voussoir-icon-icons-folderDownIcon.esm.js",
       "default": "./icons/folderDownIcon/dist/voussoir-icon-icons-folderDownIcon.cjs.js"
     },
     "./icons/folderEditIcon": {
+      "types": "./icons/folderEditIcon/dist/voussoir-icon-icons-folderEditIcon.cjs.js",
       "module": "./icons/folderEditIcon/dist/voussoir-icon-icons-folderEditIcon.esm.js",
       "default": "./icons/folderEditIcon/dist/voussoir-icon-icons-folderEditIcon.cjs.js"
     },
     "./icons/folderLockIcon": {
+      "types": "./icons/folderLockIcon/dist/voussoir-icon-icons-folderLockIcon.cjs.js",
       "module": "./icons/folderLockIcon/dist/voussoir-icon-icons-folderLockIcon.esm.js",
       "default": "./icons/folderLockIcon/dist/voussoir-icon-icons-folderLockIcon.cjs.js"
     },
     "./icons/folderOpenIcon": {
+      "types": "./icons/folderOpenIcon/dist/voussoir-icon-icons-folderOpenIcon.cjs.js",
       "module": "./icons/folderOpenIcon/dist/voussoir-icon-icons-folderOpenIcon.esm.js",
       "default": "./icons/folderOpenIcon/dist/voussoir-icon-icons-folderOpenIcon.cjs.js"
     },
     "./icons/folderPlusIcon": {
+      "types": "./icons/folderPlusIcon/dist/voussoir-icon-icons-folderPlusIcon.cjs.js",
       "module": "./icons/folderPlusIcon/dist/voussoir-icon-icons-folderPlusIcon.esm.js",
       "default": "./icons/folderPlusIcon/dist/voussoir-icon-icons-folderPlusIcon.cjs.js"
     },
     "./icons/folderTreeIcon": {
+      "types": "./icons/folderTreeIcon/dist/voussoir-icon-icons-folderTreeIcon.cjs.js",
       "module": "./icons/folderTreeIcon/dist/voussoir-icon-icons-folderTreeIcon.esm.js",
       "default": "./icons/folderTreeIcon/dist/voussoir-icon-icons-folderTreeIcon.cjs.js"
     },
     "./icons/footprintsIcon": {
+      "types": "./icons/footprintsIcon/dist/voussoir-icon-icons-footprintsIcon.cjs.js",
       "module": "./icons/footprintsIcon/dist/voussoir-icon-icons-footprintsIcon.esm.js",
       "default": "./icons/footprintsIcon/dist/voussoir-icon-icons-footprintsIcon.cjs.js"
     },
     "./icons/gitCompareIcon": {
+      "types": "./icons/gitCompareIcon/dist/voussoir-icon-icons-gitCompareIcon.cjs.js",
       "module": "./icons/gitCompareIcon/dist/voussoir-icon-icons-gitCompareIcon.esm.js",
       "default": "./icons/gitCompareIcon/dist/voussoir-icon-icons-gitCompareIcon.cjs.js"
     },
     "./icons/glassWaterIcon": {
+      "types": "./icons/glassWaterIcon/dist/voussoir-icon-icons-glassWaterIcon.cjs.js",
       "module": "./icons/glassWaterIcon/dist/voussoir-icon-icons-glassWaterIcon.esm.js",
       "default": "./icons/glassWaterIcon/dist/voussoir-icon-icons-glassWaterIcon.cjs.js"
     },
     "./icons/headphonesIcon": {
+      "types": "./icons/headphonesIcon/dist/voussoir-icon-icons-headphonesIcon.cjs.js",
       "module": "./icons/headphonesIcon/dist/voussoir-icon-icons-headphonesIcon.esm.js",
       "default": "./icons/headphonesIcon/dist/voussoir-icon-icons-headphonesIcon.cjs.js"
     },
     "./icons/heartCrackIcon": {
+      "types": "./icons/heartCrackIcon/dist/voussoir-icon-icons-heartCrackIcon.cjs.js",
       "module": "./icons/heartCrackIcon/dist/voussoir-icon-icons-heartCrackIcon.esm.js",
       "default": "./icons/heartCrackIcon/dist/voussoir-icon-icons-heartCrackIcon.cjs.js"
     },
     "./icons/heartPulseIcon": {
+      "types": "./icons/heartPulseIcon/dist/voussoir-icon-icons-heartPulseIcon.cjs.js",
       "module": "./icons/heartPulseIcon/dist/voussoir-icon-icons-heartPulseIcon.esm.js",
       "default": "./icons/heartPulseIcon/dist/voussoir-icon-icons-heartPulseIcon.cjs.js"
     },
     "./icons/helpCircleIcon": {
+      "types": "./icons/helpCircleIcon/dist/voussoir-icon-icons-helpCircleIcon.cjs.js",
       "module": "./icons/helpCircleIcon/dist/voussoir-icon-icons-helpCircleIcon.esm.js",
       "default": "./icons/helpCircleIcon/dist/voussoir-icon-icons-helpCircleIcon.cjs.js"
     },
     "./icons/imageMinusIcon": {
+      "types": "./icons/imageMinusIcon/dist/voussoir-icon-icons-imageMinusIcon.cjs.js",
       "module": "./icons/imageMinusIcon/dist/voussoir-icon-icons-imageMinusIcon.esm.js",
       "default": "./icons/imageMinusIcon/dist/voussoir-icon-icons-imageMinusIcon.cjs.js"
     },
     "./icons/lampWallUpIcon": {
+      "types": "./icons/lampWallUpIcon/dist/voussoir-icon-icons-lampWallUpIcon.cjs.js",
       "module": "./icons/lampWallUpIcon/dist/voussoir-icon-icons-lampWallUpIcon.esm.js",
       "default": "./icons/lampWallUpIcon/dist/voussoir-icon-icons-lampWallUpIcon.cjs.js"
     },
     "./icons/layoutGridIcon": {
+      "types": "./icons/layoutGridIcon/dist/voussoir-icon-icons-layoutGridIcon.cjs.js",
       "module": "./icons/layoutGridIcon/dist/voussoir-icon-icons-layoutGridIcon.esm.js",
       "default": "./icons/layoutGridIcon/dist/voussoir-icon-icons-layoutGridIcon.cjs.js"
     },
     "./icons/layoutListIcon": {
+      "types": "./icons/layoutListIcon/dist/voussoir-icon-icons-layoutListIcon.cjs.js",
       "module": "./icons/layoutListIcon/dist/voussoir-icon-icons-layoutListIcon.esm.js",
       "default": "./icons/layoutListIcon/dist/voussoir-icon-icons-layoutListIcon.cjs.js"
     },
     "./icons/listChecksIcon": {
+      "types": "./icons/listChecksIcon/dist/voussoir-icon-icons-listChecksIcon.cjs.js",
       "module": "./icons/listChecksIcon/dist/voussoir-icon-icons-listChecksIcon.esm.js",
       "default": "./icons/listChecksIcon/dist/voussoir-icon-icons-listChecksIcon.cjs.js"
     },
     "./icons/mailSearchIcon": {
+      "types": "./icons/mailSearchIcon/dist/voussoir-icon-icons-mailSearchIcon.cjs.js",
       "module": "./icons/mailSearchIcon/dist/voussoir-icon-icons-mailSearchIcon.esm.js",
       "default": "./icons/mailSearchIcon/dist/voussoir-icon-icons-mailSearchIcon.cjs.js"
     },
     "./icons/microscopeIcon": {
+      "types": "./icons/microscopeIcon/dist/voussoir-icon-icons-microscopeIcon.cjs.js",
       "module": "./icons/microscopeIcon/dist/voussoir-icon-icons-microscopeIcon.esm.js",
       "default": "./icons/microscopeIcon/dist/voussoir-icon-icons-microscopeIcon.cjs.js"
     },
     "./icons/monitorOffIcon": {
+      "types": "./icons/monitorOffIcon/dist/voussoir-icon-icons-monitorOffIcon.cjs.js",
       "module": "./icons/monitorOffIcon/dist/voussoir-icon-icons-monitorOffIcon.esm.js",
       "default": "./icons/monitorOffIcon/dist/voussoir-icon-icons-monitorOffIcon.cjs.js"
     },
     "./icons/navigationIcon": {
+      "types": "./icons/navigationIcon/dist/voussoir-icon-icons-navigationIcon.cjs.js",
       "module": "./icons/navigationIcon/dist/voussoir-icon-icons-navigationIcon.esm.js",
       "default": "./icons/navigationIcon/dist/voussoir-icon-icons-navigationIcon.cjs.js"
     },
     "./icons/paintbrushIcon": {
+      "types": "./icons/paintbrushIcon/dist/voussoir-icon-icons-paintbrushIcon.cjs.js",
       "module": "./icons/paintbrushIcon/dist/voussoir-icon-icons-paintbrushIcon.esm.js",
       "default": "./icons/paintbrushIcon/dist/voussoir-icon-icons-paintbrushIcon.cjs.js"
     },
     "./icons/playCircleIcon": {
+      "types": "./icons/playCircleIcon/dist/voussoir-icon-icons-playCircleIcon.cjs.js",
       "module": "./icons/playCircleIcon/dist/voussoir-icon-icons-playCircleIcon.esm.js",
       "default": "./icons/playCircleIcon/dist/voussoir-icon-icons-playCircleIcon.cjs.js"
     },
     "./icons/plusCircleIcon": {
+      "types": "./icons/plusCircleIcon/dist/voussoir-icon-icons-plusCircleIcon.cjs.js",
       "module": "./icons/plusCircleIcon/dist/voussoir-icon-icons-plusCircleIcon.esm.js",
       "default": "./icons/plusCircleIcon/dist/voussoir-icon-icons-plusCircleIcon.cjs.js"
     },
     "./icons/plusSquareIcon": {
+      "types": "./icons/plusSquareIcon/dist/voussoir-icon-icons-plusSquareIcon.cjs.js",
       "module": "./icons/plusSquareIcon/dist/voussoir-icon-icons-plusSquareIcon.esm.js",
       "default": "./icons/plusSquareIcon/dist/voussoir-icon-icons-plusSquareIcon.cjs.js"
     },
     "./icons/refreshCcwIcon": {
+      "types": "./icons/refreshCcwIcon/dist/voussoir-icon-icons-refreshCcwIcon.cjs.js",
       "module": "./icons/refreshCcwIcon/dist/voussoir-icon-icons-refreshCcwIcon.esm.js",
       "default": "./icons/refreshCcwIcon/dist/voussoir-icon-icons-refreshCcwIcon.cjs.js"
     },
     "./icons/showerHeadIcon": {
+      "types": "./icons/showerHeadIcon/dist/voussoir-icon-icons-showerHeadIcon.cjs.js",
       "module": "./icons/showerHeadIcon/dist/voussoir-icon-icons-showerHeadIcon.esm.js",
       "default": "./icons/showerHeadIcon/dist/voussoir-icon-icons-showerHeadIcon.cjs.js"
     },
     "./icons/signalHighIcon": {
+      "types": "./icons/signalHighIcon/dist/voussoir-icon-icons-signalHighIcon.cjs.js",
       "module": "./icons/signalHighIcon/dist/voussoir-icon-icons-signalHighIcon.esm.js",
       "default": "./icons/signalHighIcon/dist/voussoir-icon-icons-signalHighIcon.cjs.js"
     },
     "./icons/signalZeroIcon": {
+      "types": "./icons/signalZeroIcon/dist/voussoir-icon-icons-signalZeroIcon.cjs.js",
       "module": "./icons/signalZeroIcon/dist/voussoir-icon-icons-signalZeroIcon.esm.js",
       "default": "./icons/signalZeroIcon/dist/voussoir-icon-icons-signalZeroIcon.cjs.js"
     },
     "./icons/smartphoneIcon": {
+      "types": "./icons/smartphoneIcon/dist/voussoir-icon-icons-smartphoneIcon.cjs.js",
       "module": "./icons/smartphoneIcon/dist/voussoir-icon-icons-smartphoneIcon.esm.js",
       "default": "./icons/smartphoneIcon/dist/voussoir-icon-icons-smartphoneIcon.cjs.js"
     },
     "./icons/stickyNoteIcon": {
+      "types": "./icons/stickyNoteIcon/dist/voussoir-icon-icons-stickyNoteIcon.cjs.js",
       "module": "./icons/stickyNoteIcon/dist/voussoir-icon-icons-stickyNoteIcon.esm.js",
       "default": "./icons/stickyNoteIcon/dist/voussoir-icon-icons-stickyNoteIcon.cjs.js"
     },
     "./icons/stopCircleIcon": {
+      "types": "./icons/stopCircleIcon/dist/voussoir-icon-icons-stopCircleIcon.cjs.js",
       "module": "./icons/stopCircleIcon/dist/voussoir-icon-icons-stopCircleIcon.esm.js",
       "default": "./icons/stopCircleIcon/dist/voussoir-icon-icons-stopCircleIcon.cjs.js"
     },
     "./icons/swissFrancIcon": {
+      "types": "./icons/swissFrancIcon/dist/voussoir-icon-icons-swissFrancIcon.cjs.js",
       "module": "./icons/swissFrancIcon/dist/voussoir-icon-icons-swissFrancIcon.esm.js",
       "default": "./icons/swissFrancIcon/dist/voussoir-icon-icons-swissFrancIcon.cjs.js"
     },
     "./icons/textCursorIcon": {
+      "types": "./icons/textCursorIcon/dist/voussoir-icon-icons-textCursorIcon.cjs.js",
       "module": "./icons/textCursorIcon/dist/voussoir-icon-icons-textCursorIcon.esm.js",
       "default": "./icons/textCursorIcon/dist/voussoir-icon-icons-textCursorIcon.cjs.js"
     },
     "./icons/thumbsDownIcon": {
+      "types": "./icons/thumbsDownIcon/dist/voussoir-icon-icons-thumbsDownIcon.cjs.js",
       "module": "./icons/thumbsDownIcon/dist/voussoir-icon-icons-thumbsDownIcon.esm.js",
       "default": "./icons/thumbsDownIcon/dist/voussoir-icon-icons-thumbsDownIcon.cjs.js"
     },
     "./icons/timerResetIcon": {
+      "types": "./icons/timerResetIcon/dist/voussoir-icon-icons-timerResetIcon.cjs.js",
       "module": "./icons/timerResetIcon/dist/voussoir-icon-icons-timerResetIcon.esm.js",
       "default": "./icons/timerResetIcon/dist/voussoir-icon-icons-timerResetIcon.cjs.js"
     },
     "./icons/toggleLeftIcon": {
+      "types": "./icons/toggleLeftIcon/dist/voussoir-icon-icons-toggleLeftIcon.cjs.js",
       "module": "./icons/toggleLeftIcon/dist/voussoir-icon-icons-toggleLeftIcon.esm.js",
       "default": "./icons/toggleLeftIcon/dist/voussoir-icon-icons-toggleLeftIcon.cjs.js"
     },
     "./icons/trendingUpIcon": {
+      "types": "./icons/trendingUpIcon/dist/voussoir-icon-icons-trendingUpIcon.cjs.js",
       "module": "./icons/trendingUpIcon/dist/voussoir-icon-icons-trendingUpIcon.esm.js",
       "default": "./icons/trendingUpIcon/dist/voussoir-icon-icons-trendingUpIcon.cjs.js"
     },
     "./icons/vibrateOffIcon": {
+      "types": "./icons/vibrateOffIcon/dist/voussoir-icon-icons-vibrateOffIcon.cjs.js",
       "module": "./icons/vibrateOffIcon/dist/voussoir-icon-icons-vibrateOffIcon.esm.js",
       "default": "./icons/vibrateOffIcon/dist/voussoir-icon-icons-vibrateOffIcon.cjs.js"
     },
     "./icons/alertCircleIcon": {
+      "types": "./icons/alertCircleIcon/dist/voussoir-icon-icons-alertCircleIcon.cjs.js",
       "module": "./icons/alertCircleIcon/dist/voussoir-icon-icons-alertCircleIcon.esm.js",
       "default": "./icons/alertCircleIcon/dist/voussoir-icon-icons-alertCircleIcon.cjs.js"
     },
     "./icons/alignCenterIcon": {
+      "types": "./icons/alignCenterIcon/dist/voussoir-icon-icons-alignCenterIcon.cjs.js",
       "module": "./icons/alignCenterIcon/dist/voussoir-icon-icons-alignCenterIcon.esm.js",
       "default": "./icons/alignCenterIcon/dist/voussoir-icon-icons-alignCenterIcon.cjs.js"
     },
     "./icons/arrowUpDownIcon": {
+      "types": "./icons/arrowUpDownIcon/dist/voussoir-icon-icons-arrowUpDownIcon.cjs.js",
       "module": "./icons/arrowUpDownIcon/dist/voussoir-icon-icons-arrowUpDownIcon.esm.js",
       "default": "./icons/arrowUpDownIcon/dist/voussoir-icon-icons-arrowUpDownIcon.cjs.js"
     },
     "./icons/arrowUpLeftIcon": {
+      "types": "./icons/arrowUpLeftIcon/dist/voussoir-icon-icons-arrowUpLeftIcon.cjs.js",
       "module": "./icons/arrowUpLeftIcon/dist/voussoir-icon-icons-arrowUpLeftIcon.esm.js",
       "default": "./icons/arrowUpLeftIcon/dist/voussoir-icon-icons-arrowUpLeftIcon.cjs.js"
     },
     "./icons/batteryFullIcon": {
+      "types": "./icons/batteryFullIcon/dist/voussoir-icon-icons-batteryFullIcon.cjs.js",
       "module": "./icons/batteryFullIcon/dist/voussoir-icon-icons-batteryFullIcon.esm.js",
       "default": "./icons/batteryFullIcon/dist/voussoir-icon-icons-batteryFullIcon.cjs.js"
     },
     "./icons/calendarOffIcon": {
+      "types": "./icons/calendarOffIcon/dist/voussoir-icon-icons-calendarOffIcon.cjs.js",
       "module": "./icons/calendarOffIcon/dist/voussoir-icon-icons-calendarOffIcon.esm.js",
       "default": "./icons/calendarOffIcon/dist/voussoir-icon-icons-calendarOffIcon.cjs.js"
     },
     "./icons/checkCircleIcon": {
+      "types": "./icons/checkCircleIcon/dist/voussoir-icon-icons-checkCircleIcon.cjs.js",
       "module": "./icons/checkCircleIcon/dist/voussoir-icon-icons-checkCircleIcon.esm.js",
       "default": "./icons/checkCircleIcon/dist/voussoir-icon-icons-checkCircleIcon.cjs.js"
     },
     "./icons/checkSquareIcon": {
+      "types": "./icons/checkSquareIcon/dist/voussoir-icon-icons-checkSquareIcon.cjs.js",
       "module": "./icons/checkSquareIcon/dist/voussoir-icon-icons-checkSquareIcon.esm.js",
       "default": "./icons/checkSquareIcon/dist/voussoir-icon-icons-checkSquareIcon.cjs.js"
     },
     "./icons/chevronDownIcon": {
+      "types": "./icons/chevronDownIcon/dist/voussoir-icon-icons-chevronDownIcon.cjs.js",
       "module": "./icons/chevronDownIcon/dist/voussoir-icon-icons-chevronDownIcon.esm.js",
       "default": "./icons/chevronDownIcon/dist/voussoir-icon-icons-chevronDownIcon.cjs.js"
     },
     "./icons/chevronLastIcon": {
+      "types": "./icons/chevronLastIcon/dist/voussoir-icon-icons-chevronLastIcon.cjs.js",
       "module": "./icons/chevronLastIcon/dist/voussoir-icon-icons-chevronLastIcon.esm.js",
       "default": "./icons/chevronLastIcon/dist/voussoir-icon-icons-chevronLastIcon.cjs.js"
     },
     "./icons/chevronLeftIcon": {
+      "types": "./icons/chevronLeftIcon/dist/voussoir-icon-icons-chevronLeftIcon.cjs.js",
       "module": "./icons/chevronLeftIcon/dist/voussoir-icon-icons-chevronLeftIcon.esm.js",
       "default": "./icons/chevronLeftIcon/dist/voussoir-icon-icons-chevronLeftIcon.cjs.js"
     },
     "./icons/codesandboxIcon": {
+      "types": "./icons/codesandboxIcon/dist/voussoir-icon-icons-codesandboxIcon.cjs.js",
       "module": "./icons/codesandboxIcon/dist/voussoir-icon-icons-codesandboxIcon.esm.js",
       "default": "./icons/codesandboxIcon/dist/voussoir-icon-icons-codesandboxIcon.cjs.js"
     },
     "./icons/curlyBracesIcon": {
+      "types": "./icons/curlyBracesIcon/dist/voussoir-icon-icons-curlyBracesIcon.cjs.js",
       "module": "./icons/curlyBracesIcon/dist/voussoir-icon-icons-curlyBracesIcon.esm.js",
       "default": "./icons/curlyBracesIcon/dist/voussoir-icon-icons-curlyBracesIcon.cjs.js"
     },
     "./icons/fastForwardIcon": {
+      "types": "./icons/fastForwardIcon/dist/voussoir-icon-icons-fastForwardIcon.cjs.js",
       "module": "./icons/fastForwardIcon/dist/voussoir-icon-icons-fastForwardIcon.esm.js",
       "default": "./icons/fastForwardIcon/dist/voussoir-icon-icons-fastForwardIcon.cjs.js"
     },
     "./icons/fileArchiveIcon": {
+      "types": "./icons/fileArchiveIcon/dist/voussoir-icon-icons-fileArchiveIcon.cjs.js",
       "module": "./icons/fileArchiveIcon/dist/voussoir-icon-icons-fileArchiveIcon.esm.js",
       "default": "./icons/fileArchiveIcon/dist/voussoir-icon-icons-fileArchiveIcon.cjs.js"
     },
     "./icons/fileSearch2Icon": {
+      "types": "./icons/fileSearch2Icon/dist/voussoir-icon-icons-fileSearch2Icon.cjs.js",
       "module": "./icons/fileSearch2Icon/dist/voussoir-icon-icons-fileSearch2Icon.esm.js",
       "default": "./icons/fileSearch2Icon/dist/voussoir-icon-icons-fileSearch2Icon.cjs.js"
     },
     "./icons/fileSymlinkIcon": {
+      "types": "./icons/fileSymlinkIcon/dist/voussoir-icon-icons-fileSymlinkIcon.cjs.js",
       "module": "./icons/fileSymlinkIcon/dist/voussoir-icon-icons-fileSymlinkIcon.esm.js",
       "default": "./icons/fileSymlinkIcon/dist/voussoir-icon-icons-fileSymlinkIcon.cjs.js"
     },
     "./icons/fileVolume2Icon": {
+      "types": "./icons/fileVolume2Icon/dist/voussoir-icon-icons-fileVolume2Icon.cjs.js",
       "module": "./icons/fileVolume2Icon/dist/voussoir-icon-icons-fileVolume2Icon.esm.js",
       "default": "./icons/fileVolume2Icon/dist/voussoir-icon-icons-fileVolume2Icon.cjs.js"
     },
     "./icons/fileWarningIcon": {
+      "types": "./icons/fileWarningIcon/dist/voussoir-icon-icons-fileWarningIcon.cjs.js",
       "module": "./icons/fileWarningIcon/dist/voussoir-icon-icons-fileWarningIcon.esm.js",
       "default": "./icons/fileWarningIcon/dist/voussoir-icon-icons-fileWarningIcon.cjs.js"
     },
     "./icons/fingerprintIcon": {
+      "types": "./icons/fingerprintIcon/dist/voussoir-icon-icons-fingerprintIcon.cjs.js",
       "module": "./icons/fingerprintIcon/dist/voussoir-icon-icons-fingerprintIcon.esm.js",
       "default": "./icons/fingerprintIcon/dist/voussoir-icon-icons-fingerprintIcon.cjs.js"
     },
     "./icons/folderCheckIcon": {
+      "types": "./icons/folderCheckIcon/dist/voussoir-icon-icons-folderCheckIcon.cjs.js",
       "module": "./icons/folderCheckIcon/dist/voussoir-icon-icons-folderCheckIcon.esm.js",
       "default": "./icons/folderCheckIcon/dist/voussoir-icon-icons-folderCheckIcon.cjs.js"
     },
     "./icons/folderClockIcon": {
+      "types": "./icons/folderClockIcon/dist/voussoir-icon-icons-folderClockIcon.cjs.js",
       "module": "./icons/folderClockIcon/dist/voussoir-icon-icons-folderClockIcon.esm.js",
       "default": "./icons/folderClockIcon/dist/voussoir-icon-icons-folderClockIcon.cjs.js"
     },
     "./icons/folderHeartIcon": {
+      "types": "./icons/folderHeartIcon/dist/voussoir-icon-icons-folderHeartIcon.cjs.js",
       "module": "./icons/folderHeartIcon/dist/voussoir-icon-icons-folderHeartIcon.esm.js",
       "default": "./icons/folderHeartIcon/dist/voussoir-icon-icons-folderHeartIcon.cjs.js"
     },
     "./icons/folderInputIcon": {
+      "types": "./icons/folderInputIcon/dist/voussoir-icon-icons-folderInputIcon.cjs.js",
       "module": "./icons/folderInputIcon/dist/voussoir-icon-icons-folderInputIcon.esm.js",
       "default": "./icons/folderInputIcon/dist/voussoir-icon-icons-folderInputIcon.cjs.js"
     },
     "./icons/folderMinusIcon": {
+      "types": "./icons/folderMinusIcon/dist/voussoir-icon-icons-folderMinusIcon.cjs.js",
       "module": "./icons/folderMinusIcon/dist/voussoir-icon-icons-folderMinusIcon.esm.js",
       "default": "./icons/folderMinusIcon/dist/voussoir-icon-icons-folderMinusIcon.cjs.js"
     },
     "./icons/helpingHandIcon": {
+      "types": "./icons/helpingHandIcon/dist/voussoir-icon-icons-helpingHandIcon.cjs.js",
       "module": "./icons/helpingHandIcon/dist/voussoir-icon-icons-helpingHandIcon.esm.js",
       "default": "./icons/helpingHandIcon/dist/voussoir-icon-icons-helpingHandIcon.cjs.js"
     },
     "./icons/highlighterIcon": {
+      "types": "./icons/highlighterIcon/dist/voussoir-icon-icons-highlighterIcon.cjs.js",
       "module": "./icons/highlighterIcon/dist/voussoir-icon-icons-highlighterIcon.esm.js",
       "default": "./icons/highlighterIcon/dist/voussoir-icon-icons-highlighterIcon.cjs.js"
     },
     "./icons/indianRupeeIcon": {
+      "types": "./icons/indianRupeeIcon/dist/voussoir-icon-icons-indianRupeeIcon.cjs.js",
       "module": "./icons/indianRupeeIcon/dist/voussoir-icon-icons-indianRupeeIcon.esm.js",
       "default": "./icons/indianRupeeIcon/dist/voussoir-icon-icons-indianRupeeIcon.cjs.js"
     },
     "./icons/japaneseYenIcon": {
+      "types": "./icons/japaneseYenIcon/dist/voussoir-icon-icons-japaneseYenIcon.cjs.js",
       "module": "./icons/japaneseYenIcon/dist/voussoir-icon-icons-japaneseYenIcon.esm.js",
       "default": "./icons/japaneseYenIcon/dist/voussoir-icon-icons-japaneseYenIcon.cjs.js"
     },
     "./icons/lampCeilingIcon": {
+      "types": "./icons/lampCeilingIcon/dist/voussoir-icon-icons-lampCeilingIcon.cjs.js",
       "module": "./icons/lampCeilingIcon/dist/voussoir-icon-icons-lampCeilingIcon.esm.js",
       "default": "./icons/lampCeilingIcon/dist/voussoir-icon-icons-lampCeilingIcon.cjs.js"
     },
     "./icons/lassoSelectIcon": {
+      "types": "./icons/lassoSelectIcon/dist/voussoir-icon-icons-lassoSelectIcon.cjs.js",
       "module": "./icons/lassoSelectIcon/dist/voussoir-icon-icons-lassoSelectIcon.esm.js",
       "default": "./icons/lassoSelectIcon/dist/voussoir-icon-icons-lassoSelectIcon.cjs.js"
     },
     "./icons/listOrderedIcon": {
+      "types": "./icons/listOrderedIcon/dist/voussoir-icon-icons-listOrderedIcon.cjs.js",
       "module": "./icons/listOrderedIcon/dist/voussoir-icon-icons-listOrderedIcon.esm.js",
       "default": "./icons/listOrderedIcon/dist/voussoir-icon-icons-listOrderedIcon.cjs.js"
     },
     "./icons/locateFixedIcon": {
+      "types": "./icons/locateFixedIcon/dist/voussoir-icon-icons-locateFixedIcon.cjs.js",
       "module": "./icons/locateFixedIcon/dist/voussoir-icon-icons-locateFixedIcon.esm.js",
       "default": "./icons/locateFixedIcon/dist/voussoir-icon-icons-locateFixedIcon.cjs.js"
     },
     "./icons/mailWarningIcon": {
+      "types": "./icons/mailWarningIcon/dist/voussoir-icon-icons-mailWarningIcon.cjs.js",
       "module": "./icons/mailWarningIcon/dist/voussoir-icon-icons-mailWarningIcon.esm.js",
       "default": "./icons/mailWarningIcon/dist/voussoir-icon-icons-mailWarningIcon.cjs.js"
     },
     "./icons/minusCircleIcon": {
+      "types": "./icons/minusCircleIcon/dist/voussoir-icon-icons-minusCircleIcon.cjs.js",
       "module": "./icons/minusCircleIcon/dist/voussoir-icon-icons-minusCircleIcon.esm.js",
       "default": "./icons/minusCircleIcon/dist/voussoir-icon-icons-minusCircleIcon.cjs.js"
     },
     "./icons/minusSquareIcon": {
+      "types": "./icons/minusSquareIcon/dist/voussoir-icon-icons-minusSquareIcon.cjs.js",
       "module": "./icons/minusSquareIcon/dist/voussoir-icon-icons-minusSquareIcon.esm.js",
       "default": "./icons/minusSquareIcon/dist/voussoir-icon-icons-minusSquareIcon.cjs.js"
     },
     "./icons/navigation2Icon": {
+      "types": "./icons/navigation2Icon/dist/voussoir-icon-icons-navigation2Icon.cjs.js",
       "module": "./icons/navigation2Icon/dist/voussoir-icon-icons-navigation2Icon.esm.js",
       "default": "./icons/navigation2Icon/dist/voussoir-icon-icons-navigation2Icon.cjs.js"
     },
     "./icons/packageOpenIcon": {
+      "types": "./icons/packageOpenIcon/dist/voussoir-icon-icons-packageOpenIcon.cjs.js",
       "module": "./icons/packageOpenIcon/dist/voussoir-icon-icons-packageOpenIcon.esm.js",
       "default": "./icons/packageOpenIcon/dist/voussoir-icon-icons-packageOpenIcon.cjs.js"
     },
     "./icons/packagePlusIcon": {
+      "types": "./icons/packagePlusIcon/dist/voussoir-icon-icons-packagePlusIcon.cjs.js",
       "module": "./icons/packagePlusIcon/dist/voussoir-icon-icons-packagePlusIcon.esm.js",
       "default": "./icons/packagePlusIcon/dist/voussoir-icon-icons-packagePlusIcon.cjs.js"
     },
     "./icons/paintBucketIcon": {
+      "types": "./icons/paintBucketIcon/dist/voussoir-icon-icons-paintBucketIcon.cjs.js",
       "module": "./icons/paintBucketIcon/dist/voussoir-icon-icons-paintBucketIcon.esm.js",
       "default": "./icons/paintBucketIcon/dist/voussoir-icon-icons-paintBucketIcon.cjs.js"
     },
     "./icons/paintbrush2Icon": {
+      "types": "./icons/paintbrush2Icon/dist/voussoir-icon-icons-paintbrush2Icon.cjs.js",
       "module": "./icons/paintbrush2Icon/dist/voussoir-icon-icons-paintbrush2Icon.esm.js",
       "default": "./icons/paintbrush2Icon/dist/voussoir-icon-icons-paintbrush2Icon.cjs.js"
     },
     "./icons/partyPopperIcon": {
+      "types": "./icons/partyPopperIcon/dist/voussoir-icon-icons-partyPopperIcon.cjs.js",
       "module": "./icons/partyPopperIcon/dist/voussoir-icon-icons-partyPopperIcon.esm.js",
       "default": "./icons/partyPopperIcon/dist/voussoir-icon-icons-partyPopperIcon.cjs.js"
     },
     "./icons/pauseCircleIcon": {
+      "types": "./icons/pauseCircleIcon/dist/voussoir-icon-icons-pauseCircleIcon.cjs.js",
       "module": "./icons/pauseCircleIcon/dist/voussoir-icon-icons-pauseCircleIcon.esm.js",
       "default": "./icons/pauseCircleIcon/dist/voussoir-icon-icons-pauseCircleIcon.cjs.js"
     },
     "./icons/phoneMissedIcon": {
+      "types": "./icons/phoneMissedIcon/dist/voussoir-icon-icons-phoneMissedIcon.cjs.js",
       "module": "./icons/phoneMissedIcon/dist/voussoir-icon-icons-phoneMissedIcon.esm.js",
       "default": "./icons/phoneMissedIcon/dist/voussoir-icon-icons-phoneMissedIcon.cjs.js"
     },
     "./icons/screenShareIcon": {
+      "types": "./icons/screenShareIcon/dist/voussoir-icon-icons-screenShareIcon.cjs.js",
       "module": "./icons/screenShareIcon/dist/voussoir-icon-icons-screenShareIcon.esm.js",
       "default": "./icons/screenShareIcon/dist/voussoir-icon-icons-screenShareIcon.cjs.js"
     },
     "./icons/serverCrashIcon": {
+      "types": "./icons/serverCrashIcon/dist/voussoir-icon-icons-serverCrashIcon.cjs.js",
       "module": "./icons/serverCrashIcon/dist/voussoir-icon-icons-serverCrashIcon.esm.js",
       "default": "./icons/serverCrashIcon/dist/voussoir-icon-icons-serverCrashIcon.cjs.js"
     },
     "./icons/shieldAlertIcon": {
+      "types": "./icons/shieldAlertIcon/dist/voussoir-icon-icons-shieldAlertIcon.cjs.js",
       "module": "./icons/shieldAlertIcon/dist/voussoir-icon-icons-shieldAlertIcon.esm.js",
       "default": "./icons/shieldAlertIcon/dist/voussoir-icon-icons-shieldAlertIcon.cjs.js"
     },
     "./icons/shieldCheckIcon": {
+      "types": "./icons/shieldCheckIcon/dist/voussoir-icon-icons-shieldCheckIcon.cjs.js",
       "module": "./icons/shieldCheckIcon/dist/voussoir-icon-icons-shieldCheckIcon.esm.js",
       "default": "./icons/shieldCheckIcon/dist/voussoir-icon-icons-shieldCheckIcon.cjs.js"
     },
     "./icons/shieldCloseIcon": {
+      "types": "./icons/shieldCloseIcon/dist/voussoir-icon-icons-shieldCloseIcon.cjs.js",
       "module": "./icons/shieldCloseIcon/dist/voussoir-icon-icons-shieldCloseIcon.esm.js",
       "default": "./icons/shieldCloseIcon/dist/voussoir-icon-icons-shieldCloseIcon.cjs.js"
     },
     "./icons/shoppingBagIcon": {
+      "types": "./icons/shoppingBagIcon/dist/voussoir-icon-icons-shoppingBagIcon.cjs.js",
       "module": "./icons/shoppingBagIcon/dist/voussoir-icon-icons-shoppingBagIcon.esm.js",
       "default": "./icons/shoppingBagIcon/dist/voussoir-icon-icons-shoppingBagIcon.cjs.js"
     },
     "./icons/sidebarOpenIcon": {
+      "types": "./icons/sidebarOpenIcon/dist/voussoir-icon-icons-sidebarOpenIcon.cjs.js",
       "module": "./icons/sidebarOpenIcon/dist/voussoir-icon-icons-sidebarOpenIcon.esm.js",
       "default": "./icons/sidebarOpenIcon/dist/voussoir-icon-icons-sidebarOpenIcon.cjs.js"
     },
     "./icons/skipForwardIcon": {
+      "types": "./icons/skipForwardIcon/dist/voussoir-icon-icons-skipForwardIcon.cjs.js",
       "module": "./icons/skipForwardIcon/dist/voussoir-icon-icons-skipForwardIcon.esm.js",
       "default": "./icons/skipForwardIcon/dist/voussoir-icon-icons-skipForwardIcon.cjs.js"
     },
     "./icons/stethoscopeIcon": {
+      "types": "./icons/stethoscopeIcon/dist/voussoir-icon-icons-stethoscopeIcon.cjs.js",
       "module": "./icons/stethoscopeIcon/dist/voussoir-icon-icons-stethoscopeIcon.esm.js",
       "default": "./icons/stethoscopeIcon/dist/voussoir-icon-icons-stethoscopeIcon.cjs.js"
     },
     "./icons/superscriptIcon": {
+      "types": "./icons/superscriptIcon/dist/voussoir-icon-icons-superscriptIcon.cjs.js",
       "module": "./icons/superscriptIcon/dist/voussoir-icon-icons-superscriptIcon.esm.js",
       "default": "./icons/superscriptIcon/dist/voussoir-icon-icons-superscriptIcon.cjs.js"
     },
     "./icons/thermometerIcon": {
+      "types": "./icons/thermometerIcon/dist/voussoir-icon-icons-thermometerIcon.cjs.js",
       "module": "./icons/thermometerIcon/dist/voussoir-icon-icons-thermometerIcon.esm.js",
       "default": "./icons/thermometerIcon/dist/voussoir-icon-icons-thermometerIcon.cjs.js"
     },
     "./icons/toggleRightIcon": {
+      "types": "./icons/toggleRightIcon/dist/voussoir-icon-icons-toggleRightIcon.cjs.js",
       "module": "./icons/toggleRightIcon/dist/voussoir-icon-icons-toggleRightIcon.esm.js",
       "default": "./icons/toggleRightIcon/dist/voussoir-icon-icons-toggleRightIcon.cjs.js"
     },
     "./icons/uploadCloudIcon": {
+      "types": "./icons/uploadCloudIcon/dist/voussoir-icon-icons-uploadCloudIcon.cjs.js",
       "module": "./icons/uploadCloudIcon/dist/voussoir-icon-icons-uploadCloudIcon.esm.js",
       "default": "./icons/uploadCloudIcon/dist/voussoir-icon-icons-uploadCloudIcon.cjs.js"
     },
     "./icons/utilityPoleIcon": {
+      "types": "./icons/utilityPoleIcon/dist/voussoir-icon-icons-utilityPoleIcon.cjs.js",
       "module": "./icons/utilityPoleIcon/dist/voussoir-icon-icons-utilityPoleIcon.esm.js",
       "default": "./icons/utilityPoleIcon/dist/voussoir-icon-icons-utilityPoleIcon.cjs.js"
     },
     "./icons/alertOctagonIcon": {
+      "types": "./icons/alertOctagonIcon/dist/voussoir-icon-icons-alertOctagonIcon.cjs.js",
       "module": "./icons/alertOctagonIcon/dist/voussoir-icon-icons-alertOctagonIcon.esm.js",
       "default": "./icons/alertOctagonIcon/dist/voussoir-icon-icons-alertOctagonIcon.cjs.js"
     },
     "./icons/alignJustifyIcon": {
+      "types": "./icons/alignJustifyIcon/dist/voussoir-icon-icons-alignJustifyIcon.cjs.js",
       "module": "./icons/alignJustifyIcon/dist/voussoir-icon-icons-alignJustifyIcon.esm.js",
       "default": "./icons/alignJustifyIcon/dist/voussoir-icon-icons-alignJustifyIcon.cjs.js"
     },
     "./icons/arrowBigDownIcon": {
+      "types": "./icons/arrowBigDownIcon/dist/voussoir-icon-icons-arrowBigDownIcon.cjs.js",
       "module": "./icons/arrowBigDownIcon/dist/voussoir-icon-icons-arrowBigDownIcon.esm.js",
       "default": "./icons/arrowBigDownIcon/dist/voussoir-icon-icons-arrowBigDownIcon.cjs.js"
     },
     "./icons/arrowBigLeftIcon": {
+      "types": "./icons/arrowBigLeftIcon/dist/voussoir-icon-icons-arrowBigLeftIcon.cjs.js",
       "module": "./icons/arrowBigLeftIcon/dist/voussoir-icon-icons-arrowBigLeftIcon.esm.js",
       "default": "./icons/arrowBigLeftIcon/dist/voussoir-icon-icons-arrowBigLeftIcon.cjs.js"
     },
     "./icons/arrowUpRightIcon": {
+      "types": "./icons/arrowUpRightIcon/dist/voussoir-icon-icons-arrowUpRightIcon.cjs.js",
       "module": "./icons/arrowUpRightIcon/dist/voussoir-icon-icons-arrowUpRightIcon.esm.js",
       "default": "./icons/arrowUpRightIcon/dist/voussoir-icon-icons-arrowUpRightIcon.cjs.js"
     },
     "./icons/baggageClaimIcon": {
+      "types": "./icons/baggageClaimIcon/dist/voussoir-icon-icons-baggageClaimIcon.cjs.js",
       "module": "./icons/baggageClaimIcon/dist/voussoir-icon-icons-baggageClaimIcon.esm.js",
       "default": "./icons/baggageClaimIcon/dist/voussoir-icon-icons-baggageClaimIcon.cjs.js"
     },
     "./icons/bluetoothOffIcon": {
+      "types": "./icons/bluetoothOffIcon/dist/voussoir-icon-icons-bluetoothOffIcon.cjs.js",
       "module": "./icons/bluetoothOffIcon/dist/voussoir-icon-icons-bluetoothOffIcon.esm.js",
       "default": "./icons/bluetoothOffIcon/dist/voussoir-icon-icons-bluetoothOffIcon.cjs.js"
     },
     "./icons/bookmarkPlusIcon": {
+      "types": "./icons/bookmarkPlusIcon/dist/voussoir-icon-icons-bookmarkPlusIcon.cjs.js",
       "module": "./icons/bookmarkPlusIcon/dist/voussoir-icon-icons-bookmarkPlusIcon.esm.js",
       "default": "./icons/bookmarkPlusIcon/dist/voussoir-icon-icons-bookmarkPlusIcon.cjs.js"
     },
     "./icons/brainCircuitIcon": {
+      "types": "./icons/brainCircuitIcon/dist/voussoir-icon-icons-brainCircuitIcon.cjs.js",
       "module": "./icons/brainCircuitIcon/dist/voussoir-icon-icons-brainCircuitIcon.esm.js",
       "default": "./icons/brainCircuitIcon/dist/voussoir-icon-icons-brainCircuitIcon.cjs.js"
     },
     "./icons/calendarDaysIcon": {
+      "types": "./icons/calendarDaysIcon/dist/voussoir-icon-icons-calendarDaysIcon.cjs.js",
       "module": "./icons/calendarDaysIcon/dist/voussoir-icon-icons-calendarDaysIcon.esm.js",
       "default": "./icons/calendarDaysIcon/dist/voussoir-icon-icons-calendarDaysIcon.cjs.js"
     },
     "./icons/calendarPlusIcon": {
+      "types": "./icons/calendarPlusIcon/dist/voussoir-icon-icons-calendarPlusIcon.cjs.js",
       "module": "./icons/calendarPlusIcon/dist/voussoir-icon-icons-calendarPlusIcon.esm.js",
       "default": "./icons/calendarPlusIcon/dist/voussoir-icon-icons-calendarPlusIcon.cjs.js"
     },
     "./icons/checkCircle2Icon": {
+      "types": "./icons/checkCircle2Icon/dist/voussoir-icon-icons-checkCircle2Icon.cjs.js",
       "module": "./icons/checkCircle2Icon/dist/voussoir-icon-icons-checkCircle2Icon.esm.js",
       "default": "./icons/checkCircle2Icon/dist/voussoir-icon-icons-checkCircle2Icon.cjs.js"
     },
     "./icons/chevronFirstIcon": {
+      "types": "./icons/chevronFirstIcon/dist/voussoir-icon-icons-chevronFirstIcon.cjs.js",
       "module": "./icons/chevronFirstIcon/dist/voussoir-icon-icons-chevronFirstIcon.esm.js",
       "default": "./icons/chevronFirstIcon/dist/voussoir-icon-icons-chevronFirstIcon.cjs.js"
     },
     "./icons/chevronRightIcon": {
+      "types": "./icons/chevronRightIcon/dist/voussoir-icon-icons-chevronRightIcon.cjs.js",
       "module": "./icons/chevronRightIcon/dist/voussoir-icon-icons-chevronRightIcon.esm.js",
       "default": "./icons/chevronRightIcon/dist/voussoir-icon-icons-chevronRightIcon.cjs.js"
     },
     "./icons/chevronsDownIcon": {
+      "types": "./icons/chevronsDownIcon/dist/voussoir-icon-icons-chevronsDownIcon.cjs.js",
       "module": "./icons/chevronsDownIcon/dist/voussoir-icon-icons-chevronsDownIcon.esm.js",
       "default": "./icons/chevronsDownIcon/dist/voussoir-icon-icons-chevronsDownIcon.cjs.js"
     },
     "./icons/chevronsLeftIcon": {
+      "types": "./icons/chevronsLeftIcon/dist/voussoir-icon-icons-chevronsLeftIcon.cjs.js",
       "module": "./icons/chevronsLeftIcon/dist/voussoir-icon-icons-chevronsLeftIcon.esm.js",
       "default": "./icons/chevronsLeftIcon/dist/voussoir-icon-icons-chevronsLeftIcon.cjs.js"
     },
     "./icons/cigaretteOffIcon": {
+      "types": "./icons/cigaretteOffIcon/dist/voussoir-icon-icons-cigaretteOffIcon.cjs.js",
       "module": "./icons/cigaretteOffIcon/dist/voussoir-icon-icons-cigaretteOffIcon.esm.js",
       "default": "./icons/cigaretteOffIcon/dist/voussoir-icon-icons-cigaretteOffIcon.cjs.js"
     },
     "./icons/clapperboardIcon": {
+      "types": "./icons/clapperboardIcon/dist/voussoir-icon-icons-clapperboardIcon.cjs.js",
       "module": "./icons/clapperboardIcon/dist/voussoir-icon-icons-clapperboardIcon.esm.js",
       "default": "./icons/clapperboardIcon/dist/voussoir-icon-icons-clapperboardIcon.cjs.js"
     },
     "./icons/cloudDrizzleIcon": {
+      "types": "./icons/cloudDrizzleIcon/dist/voussoir-icon-icons-cloudDrizzleIcon.cjs.js",
       "module": "./icons/cloudDrizzleIcon/dist/voussoir-icon-icons-cloudDrizzleIcon.esm.js",
       "default": "./icons/cloudDrizzleIcon/dist/voussoir-icon-icons-cloudDrizzleIcon.cjs.js"
     },
     "./icons/cloudSunRainIcon": {
+      "types": "./icons/cloudSunRainIcon/dist/voussoir-icon-icons-cloudSunRainIcon.cjs.js",
       "module": "./icons/cloudSunRainIcon/dist/voussoir-icon-icons-cloudSunRainIcon.esm.js",
       "default": "./icons/cloudSunRainIcon/dist/voussoir-icon-icons-cloudSunRainIcon.cjs.js"
     },
     "./icons/constructionIcon": {
+      "types": "./icons/constructionIcon/dist/voussoir-icon-icons-constructionIcon.cjs.js",
       "module": "./icons/constructionIcon/dist/voussoir-icon-icons-constructionIcon.esm.js",
       "default": "./icons/constructionIcon/dist/voussoir-icon-icons-constructionIcon.cjs.js"
     },
     "./icons/cornerLeftUpIcon": {
+      "types": "./icons/cornerLeftUpIcon/dist/voussoir-icon-icons-cornerLeftUpIcon.cjs.js",
       "module": "./icons/cornerLeftUpIcon/dist/voussoir-icon-icons-cornerLeftUpIcon.esm.js",
       "default": "./icons/cornerLeftUpIcon/dist/voussoir-icon-icons-cornerLeftUpIcon.cjs.js"
     },
     "./icons/cornerUpLeftIcon": {
+      "types": "./icons/cornerUpLeftIcon/dist/voussoir-icon-icons-cornerUpLeftIcon.cjs.js",
       "module": "./icons/cornerUpLeftIcon/dist/voussoir-icon-icons-cornerUpLeftIcon.esm.js",
       "default": "./icons/cornerUpLeftIcon/dist/voussoir-icon-icons-cornerUpLeftIcon.cjs.js"
     },
     "./icons/divideCircleIcon": {
+      "types": "./icons/divideCircleIcon/dist/voussoir-icon-icons-divideCircleIcon.cjs.js",
       "module": "./icons/divideCircleIcon/dist/voussoir-icon-icons-divideCircleIcon.esm.js",
       "default": "./icons/divideCircleIcon/dist/voussoir-icon-icons-divideCircleIcon.cjs.js"
     },
     "./icons/divideSquareIcon": {
+      "types": "./icons/divideSquareIcon/dist/voussoir-icon-icons-divideSquareIcon.cjs.js",
       "module": "./icons/divideSquareIcon/dist/voussoir-icon-icons-divideSquareIcon.esm.js",
       "default": "./icons/divideSquareIcon/dist/voussoir-icon-icons-divideSquareIcon.cjs.js"
     },
     "./icons/externalLinkIcon": {
+      "types": "./icons/externalLinkIcon/dist/voussoir-icon-icons-externalLinkIcon.cjs.js",
       "module": "./icons/externalLinkIcon/dist/voussoir-icon-icons-externalLinkIcon.esm.js",
       "default": "./icons/externalLinkIcon/dist/voussoir-icon-icons-externalLinkIcon.cjs.js"
     },
     "./icons/fileBarChartIcon": {
+      "types": "./icons/fileBarChartIcon/dist/voussoir-icon-icons-fileBarChartIcon.cjs.js",
       "module": "./icons/fileBarChartIcon/dist/voussoir-icon-icons-fileBarChartIcon.esm.js",
       "default": "./icons/fileBarChartIcon/dist/voussoir-icon-icons-fileBarChartIcon.cjs.js"
     },
     "./icons/filePieChartIcon": {
+      "types": "./icons/filePieChartIcon/dist/voussoir-icon-icons-filePieChartIcon.cjs.js",
       "module": "./icons/filePieChartIcon/dist/voussoir-icon-icons-filePieChartIcon.esm.js",
       "default": "./icons/filePieChartIcon/dist/voussoir-icon-icons-filePieChartIcon.cjs.js"
     },
     "./icons/fileQuestionIcon": {
+      "types": "./icons/fileQuestionIcon/dist/voussoir-icon-icons-fileQuestionIcon.cjs.js",
       "module": "./icons/fileQuestionIcon/dist/voussoir-icon-icons-fileQuestionIcon.esm.js",
       "default": "./icons/fileQuestionIcon/dist/voussoir-icon-icons-fileQuestionIcon.cjs.js"
     },
     "./icons/fileTerminalIcon": {
+      "types": "./icons/fileTerminalIcon/dist/voussoir-icon-icons-fileTerminalIcon.cjs.js",
       "module": "./icons/fileTerminalIcon/dist/voussoir-icon-icons-fileTerminalIcon.esm.js",
       "default": "./icons/fileTerminalIcon/dist/voussoir-icon-icons-fileTerminalIcon.cjs.js"
     },
     "./icons/flaskConicalIcon": {
+      "types": "./icons/flaskConicalIcon/dist/voussoir-icon-icons-flaskConicalIcon.cjs.js",
       "module": "./icons/flaskConicalIcon/dist/voussoir-icon-icons-flaskConicalIcon.esm.js",
       "default": "./icons/flaskConicalIcon/dist/voussoir-icon-icons-flaskConicalIcon.cjs.js"
     },
     "./icons/flipVerticalIcon": {
+      "types": "./icons/flipVerticalIcon/dist/voussoir-icon-icons-flipVerticalIcon.cjs.js",
       "module": "./icons/flipVerticalIcon/dist/voussoir-icon-icons-flipVerticalIcon.esm.js",
       "default": "./icons/flipVerticalIcon/dist/voussoir-icon-icons-flipVerticalIcon.cjs.js"
     },
     "./icons/folderClosedIcon": {
+      "types": "./icons/folderClosedIcon/dist/voussoir-icon-icons-folderClosedIcon.cjs.js",
       "module": "./icons/folderClosedIcon/dist/voussoir-icon-icons-folderClosedIcon.esm.js",
       "default": "./icons/folderClosedIcon/dist/voussoir-icon-icons-folderClosedIcon.cjs.js"
     },
     "./icons/folderOutputIcon": {
+      "types": "./icons/folderOutputIcon/dist/voussoir-icon-icons-folderOutputIcon.cjs.js",
       "module": "./icons/folderOutputIcon/dist/voussoir-icon-icons-folderOutputIcon.esm.js",
       "default": "./icons/folderOutputIcon/dist/voussoir-icon-icons-folderOutputIcon.cjs.js"
     },
     "./icons/folderSearchIcon": {
+      "types": "./icons/folderSearchIcon/dist/voussoir-icon-icons-folderSearchIcon.cjs.js",
       "module": "./icons/folderSearchIcon/dist/voussoir-icon-icons-folderSearchIcon.esm.js",
       "default": "./icons/folderSearchIcon/dist/voussoir-icon-icons-folderSearchIcon.cjs.js"
     },
     "./icons/gripVerticalIcon": {
+      "types": "./icons/gripVerticalIcon/dist/voussoir-icon-icons-gripVerticalIcon.cjs.js",
       "module": "./icons/gripVerticalIcon/dist/voussoir-icon-icons-gripVerticalIcon.esm.js",
       "default": "./icons/gripVerticalIcon/dist/voussoir-icon-icons-gripVerticalIcon.cjs.js"
     },
     "./icons/lampWallDownIcon": {
+      "types": "./icons/lampWallDownIcon/dist/voussoir-icon-icons-lampWallDownIcon.cjs.js",
       "module": "./icons/lampWallDownIcon/dist/voussoir-icon-icons-lampWallDownIcon.esm.js",
       "default": "./icons/lampWallDownIcon/dist/voussoir-icon-icons-lampWallDownIcon.cjs.js"
     },
     "./icons/lightbulbOffIcon": {
+      "types": "./icons/lightbulbOffIcon/dist/voussoir-icon-icons-lightbulbOffIcon.cjs.js",
       "module": "./icons/lightbulbOffIcon/dist/voussoir-icon-icons-lightbulbOffIcon.esm.js",
       "default": "./icons/lightbulbOffIcon/dist/voussoir-icon-icons-lightbulbOffIcon.cjs.js"
     },
     "./icons/mailQuestionIcon": {
+      "types": "./icons/mailQuestionIcon/dist/voussoir-icon-icons-mailQuestionIcon.cjs.js",
       "module": "./icons/mailQuestionIcon/dist/voussoir-icon-icons-mailQuestionIcon.esm.js",
       "default": "./icons/mailQuestionIcon/dist/voussoir-icon-icons-mailQuestionIcon.cjs.js"
     },
     "./icons/megaphoneOffIcon": {
+      "types": "./icons/megaphoneOffIcon/dist/voussoir-icon-icons-megaphoneOffIcon.cjs.js",
       "module": "./icons/megaphoneOffIcon/dist/voussoir-icon-icons-megaphoneOffIcon.esm.js",
       "default": "./icons/megaphoneOffIcon/dist/voussoir-icon-icons-megaphoneOffIcon.cjs.js"
     },
     "./icons/moreVerticalIcon": {
+      "types": "./icons/moreVerticalIcon/dist/voussoir-icon-icons-moreVerticalIcon.cjs.js",
       "module": "./icons/moreVerticalIcon/dist/voussoir-icon-icons-moreVerticalIcon.esm.js",
       "default": "./icons/moreVerticalIcon/dist/voussoir-icon-icons-moreVerticalIcon.cjs.js"
     },
     "./icons/mountainSnowIcon": {
+      "types": "./icons/mountainSnowIcon/dist/voussoir-icon-icons-mountainSnowIcon.cjs.js",
       "module": "./icons/mountainSnowIcon/dist/voussoir-icon-icons-mountainSnowIcon.esm.js",
       "default": "./icons/mountainSnowIcon/dist/voussoir-icon-icons-mountainSnowIcon.cjs.js"
     },
     "./icons/mousePointerIcon": {
+      "types": "./icons/mousePointerIcon/dist/voussoir-icon-icons-mousePointerIcon.cjs.js",
       "module": "./icons/mousePointerIcon/dist/voussoir-icon-icons-mousePointerIcon.esm.js",
       "default": "./icons/mousePointerIcon/dist/voussoir-icon-icons-mousePointerIcon.cjs.js"
     },
     "./icons/moveDiagonalIcon": {
+      "types": "./icons/moveDiagonalIcon/dist/voussoir-icon-icons-moveDiagonalIcon.cjs.js",
       "module": "./icons/moveDiagonalIcon/dist/voussoir-icon-icons-moveDiagonalIcon.esm.js",
       "default": "./icons/moveDiagonalIcon/dist/voussoir-icon-icons-moveDiagonalIcon.cjs.js"
     },
     "./icons/moveVerticalIcon": {
+      "types": "./icons/moveVerticalIcon/dist/voussoir-icon-icons-moveVerticalIcon.cjs.js",
       "module": "./icons/moveVerticalIcon/dist/voussoir-icon-icons-moveVerticalIcon.esm.js",
       "default": "./icons/moveVerticalIcon/dist/voussoir-icon-icons-moveVerticalIcon.cjs.js"
     },
     "./icons/packageCheckIcon": {
+      "types": "./icons/packageCheckIcon/dist/voussoir-icon-icons-packageCheckIcon.cjs.js",
       "module": "./icons/packageCheckIcon/dist/voussoir-icon-icons-packageCheckIcon.esm.js",
       "default": "./icons/packageCheckIcon/dist/voussoir-icon-icons-packageCheckIcon.cjs.js"
     },
     "./icons/packageMinusIcon": {
+      "types": "./icons/packageMinusIcon/dist/voussoir-icon-icons-packageMinusIcon.cjs.js",
       "module": "./icons/packageMinusIcon/dist/voussoir-icon-icons-packageMinusIcon.esm.js",
       "default": "./icons/packageMinusIcon/dist/voussoir-icon-icons-packageMinusIcon.cjs.js"
     },
     "./icons/pauseOctagonIcon": {
+      "types": "./icons/pauseOctagonIcon/dist/voussoir-icon-icons-pauseOctagonIcon.cjs.js",
       "module": "./icons/pauseOctagonIcon/dist/voussoir-icon-icons-pauseOctagonIcon.esm.js",
       "default": "./icons/pauseOctagonIcon/dist/voussoir-icon-icons-pauseOctagonIcon.cjs.js"
     },
     "./icons/refrigeratorIcon": {
+      "types": "./icons/refrigeratorIcon/dist/voussoir-icon-icons-refrigeratorIcon.cjs.js",
       "module": "./icons/refrigeratorIcon/dist/voussoir-icon-icons-refrigeratorIcon.esm.js",
       "default": "./icons/refrigeratorIcon/dist/voussoir-icon-icons-refrigeratorIcon.cjs.js"
     },
     "./icons/rockingChairIcon": {
+      "types": "./icons/rockingChairIcon/dist/voussoir-icon-icons-rockingChairIcon.cjs.js",
       "module": "./icons/rockingChairIcon/dist/voussoir-icon-icons-rockingChairIcon.esm.js",
       "default": "./icons/rockingChairIcon/dist/voussoir-icon-icons-rockingChairIcon.cjs.js"
     },
     "./icons/russianRubleIcon": {
+      "types": "./icons/russianRubleIcon/dist/voussoir-icon-icons-russianRubleIcon.cjs.js",
       "module": "./icons/russianRubleIcon/dist/voussoir-icon-icons-russianRubleIcon.esm.js",
       "default": "./icons/russianRubleIcon/dist/voussoir-icon-icons-russianRubleIcon.cjs.js"
     },
     "./icons/shoppingCartIcon": {
+      "types": "./icons/shoppingCartIcon/dist/voussoir-icon-icons-shoppingCartIcon.cjs.js",
       "module": "./icons/shoppingCartIcon/dist/voussoir-icon-icons-shoppingCartIcon.esm.js",
       "default": "./icons/shoppingCartIcon/dist/voussoir-icon-icons-shoppingCartIcon.cjs.js"
     },
     "./icons/sidebarCloseIcon": {
+      "types": "./icons/sidebarCloseIcon/dist/voussoir-icon-icons-sidebarCloseIcon.cjs.js",
       "module": "./icons/sidebarCloseIcon/dist/voussoir-icon-icons-sidebarCloseIcon.esm.js",
       "default": "./icons/sidebarCloseIcon/dist/voussoir-icon-icons-sidebarCloseIcon.cjs.js"
     },
     "./icons/signalMediumIcon": {
+      "types": "./icons/signalMediumIcon/dist/voussoir-icon-icons-signalMediumIcon.cjs.js",
       "module": "./icons/signalMediumIcon/dist/voussoir-icon-icons-signalMediumIcon.esm.js",
       "default": "./icons/signalMediumIcon/dist/voussoir-icon-icons-signalMediumIcon.cjs.js"
     },
     "./icons/switchCameraIcon": {
+      "types": "./icons/switchCameraIcon/dist/voussoir-icon-icons-switchCameraIcon.cjs.js",
       "module": "./icons/switchCameraIcon/dist/voussoir-icon-icons-switchCameraIcon.esm.js",
       "default": "./icons/switchCameraIcon/dist/voussoir-icon-icons-switchCameraIcon.cjs.js"
     },
     "./icons/towerControlIcon": {
+      "types": "./icons/towerControlIcon/dist/voussoir-icon-icons-towerControlIcon.cjs.js",
       "module": "./icons/towerControlIcon/dist/voussoir-icon-icons-towerControlIcon.esm.js",
       "default": "./icons/towerControlIcon/dist/voussoir-icon-icons-towerControlIcon.cjs.js"
     },
     "./icons/trendingDownIcon": {
+      "types": "./icons/trendingDownIcon/dist/voussoir-icon-icons-trendingDownIcon.cjs.js",
       "module": "./icons/trendingDownIcon/dist/voussoir-icon-icons-trendingDownIcon.esm.js",
       "default": "./icons/trendingDownIcon/dist/voussoir-icon-icons-trendingDownIcon.cjs.js"
     },
     "./icons/venetianMaskIcon": {
+      "types": "./icons/venetianMaskIcon/dist/voussoir-icon-icons-venetianMaskIcon.cjs.js",
       "module": "./icons/venetianMaskIcon/dist/voussoir-icon-icons-venetianMaskIcon.esm.js",
       "default": "./icons/venetianMaskIcon/dist/voussoir-icon-icons-venetianMaskIcon.cjs.js"
     },
     "./icons/accessibilityIcon": {
+      "types": "./icons/accessibilityIcon/dist/voussoir-icon-icons-accessibilityIcon.cjs.js",
       "module": "./icons/accessibilityIcon/dist/voussoir-icon-icons-accessibilityIcon.esm.js",
       "default": "./icons/accessibilityIcon/dist/voussoir-icon-icons-accessibilityIcon.cjs.js"
     },
     "./icons/alarmClockOffIcon": {
+      "types": "./icons/alarmClockOffIcon/dist/voussoir-icon-icons-alarmClockOffIcon.cjs.js",
       "module": "./icons/alarmClockOffIcon/dist/voussoir-icon-icons-alarmClockOffIcon.esm.js",
       "default": "./icons/alarmClockOffIcon/dist/voussoir-icon-icons-alarmClockOffIcon.cjs.js"
     },
     "./icons/alertTriangleIcon": {
+      "types": "./icons/alertTriangleIcon/dist/voussoir-icon-icons-alertTriangleIcon.cjs.js",
       "module": "./icons/alertTriangleIcon/dist/voussoir-icon-icons-alertTriangleIcon.esm.js",
       "default": "./icons/alertTriangleIcon/dist/voussoir-icon-icons-alertTriangleIcon.cjs.js"
     },
     "./icons/arrowBigRightIcon": {
+      "types": "./icons/arrowBigRightIcon/dist/voussoir-icon-icons-arrowBigRightIcon.cjs.js",
       "module": "./icons/arrowBigRightIcon/dist/voussoir-icon-icons-arrowBigRightIcon.esm.js",
       "default": "./icons/arrowBigRightIcon/dist/voussoir-icon-icons-arrowBigRightIcon.cjs.js"
     },
     "./icons/arrowDownLeftIcon": {
+      "types": "./icons/arrowDownLeftIcon/dist/voussoir-icon-icons-arrowDownLeftIcon.cjs.js",
       "module": "./icons/arrowDownLeftIcon/dist/voussoir-icon-icons-arrowDownLeftIcon.esm.js",
       "default": "./icons/arrowDownLeftIcon/dist/voussoir-icon-icons-arrowDownLeftIcon.cjs.js"
     },
     "./icons/arrowUpCircleIcon": {
+      "types": "./icons/arrowUpCircleIcon/dist/voussoir-icon-icons-arrowUpCircleIcon.cjs.js",
       "module": "./icons/arrowUpCircleIcon/dist/voussoir-icon-icons-arrowUpCircleIcon.esm.js",
       "default": "./icons/arrowUpCircleIcon/dist/voussoir-icon-icons-arrowUpCircleIcon.cjs.js"
     },
     "./icons/batteryMediumIcon": {
+      "types": "./icons/batteryMediumIcon/dist/voussoir-icon-icons-batteryMediumIcon.cjs.js",
       "module": "./icons/batteryMediumIcon/dist/voussoir-icon-icons-batteryMediumIcon.esm.js",
       "default": "./icons/batteryMediumIcon/dist/voussoir-icon-icons-batteryMediumIcon.cjs.js"
     },
     "./icons/bookOpenCheckIcon": {
+      "types": "./icons/bookOpenCheckIcon/dist/voussoir-icon-icons-bookOpenCheckIcon.cjs.js",
       "module": "./icons/bookOpenCheckIcon/dist/voussoir-icon-icons-bookOpenCheckIcon.esm.js",
       "default": "./icons/bookOpenCheckIcon/dist/voussoir-icon-icons-bookOpenCheckIcon.cjs.js"
     },
     "./icons/bookmarkMinusIcon": {
+      "types": "./icons/bookmarkMinusIcon/dist/voussoir-icon-icons-bookmarkMinusIcon.cjs.js",
       "module": "./icons/bookmarkMinusIcon/dist/voussoir-icon-icons-bookmarkMinusIcon.esm.js",
       "default": "./icons/bookmarkMinusIcon/dist/voussoir-icon-icons-bookmarkMinusIcon.cjs.js"
     },
     "./icons/calendarCheckIcon": {
+      "types": "./icons/calendarCheckIcon/dist/voussoir-icon-icons-calendarCheckIcon.cjs.js",
       "module": "./icons/calendarCheckIcon/dist/voussoir-icon-icons-calendarCheckIcon.esm.js",
       "default": "./icons/calendarCheckIcon/dist/voussoir-icon-icons-calendarCheckIcon.cjs.js"
     },
     "./icons/calendarClockIcon": {
+      "types": "./icons/calendarClockIcon/dist/voussoir-icon-icons-calendarClockIcon.cjs.js",
       "module": "./icons/calendarClockIcon/dist/voussoir-icon-icons-calendarClockIcon.esm.js",
       "default": "./icons/calendarClockIcon/dist/voussoir-icon-icons-calendarClockIcon.cjs.js"
     },
     "./icons/calendarHeartIcon": {
+      "types": "./icons/calendarHeartIcon/dist/voussoir-icon-icons-calendarHeartIcon.cjs.js",
       "module": "./icons/calendarHeartIcon/dist/voussoir-icon-icons-calendarHeartIcon.esm.js",
       "default": "./icons/calendarHeartIcon/dist/voussoir-icon-icons-calendarHeartIcon.cjs.js"
     },
     "./icons/calendarMinusIcon": {
+      "types": "./icons/calendarMinusIcon/dist/voussoir-icon-icons-calendarMinusIcon.cjs.js",
       "module": "./icons/calendarMinusIcon/dist/voussoir-icon-icons-calendarMinusIcon.esm.js",
       "default": "./icons/calendarMinusIcon/dist/voussoir-icon-icons-calendarMinusIcon.cjs.js"
     },
     "./icons/calendarRangeIcon": {
+      "types": "./icons/calendarRangeIcon/dist/voussoir-icon-icons-calendarRangeIcon.cjs.js",
       "module": "./icons/calendarRangeIcon/dist/voussoir-icon-icons-calendarRangeIcon.esm.js",
       "default": "./icons/calendarRangeIcon/dist/voussoir-icon-icons-calendarRangeIcon.cjs.js"
     },
     "./icons/chevronsRightIcon": {
+      "types": "./icons/chevronsRightIcon/dist/voussoir-icon-icons-chevronsRightIcon.cjs.js",
       "module": "./icons/chevronsRightIcon/dist/voussoir-icon-icons-chevronsRightIcon.esm.js",
       "default": "./icons/chevronsRightIcon/dist/voussoir-icon-icons-chevronsRightIcon.cjs.js"
     },
     "./icons/circleSlashedIcon": {
+      "types": "./icons/circleSlashedIcon/dist/voussoir-icon-icons-circleSlashedIcon.cjs.js",
       "module": "./icons/circleSlashedIcon/dist/voussoir-icon-icons-circleSlashedIcon.esm.js",
       "default": "./icons/circleSlashedIcon/dist/voussoir-icon-icons-circleSlashedIcon.cjs.js"
     },
     "./icons/clipboardCopyIcon": {
+      "types": "./icons/clipboardCopyIcon/dist/voussoir-icon-icons-clipboardCopyIcon.cjs.js",
       "module": "./icons/clipboardCopyIcon/dist/voussoir-icon-icons-clipboardCopyIcon.esm.js",
       "default": "./icons/clipboardCopyIcon/dist/voussoir-icon-icons-clipboardCopyIcon.cjs.js"
     },
     "./icons/clipboardEditIcon": {
+      "types": "./icons/clipboardEditIcon/dist/voussoir-icon-icons-clipboardEditIcon.cjs.js",
       "module": "./icons/clipboardEditIcon/dist/voussoir-icon-icons-clipboardEditIcon.esm.js",
       "default": "./icons/clipboardEditIcon/dist/voussoir-icon-icons-clipboardEditIcon.cjs.js"
     },
     "./icons/clipboardListIcon": {
+      "types": "./icons/clipboardListIcon/dist/voussoir-icon-icons-clipboardListIcon.cjs.js",
       "module": "./icons/clipboardListIcon/dist/voussoir-icon-icons-clipboardListIcon.esm.js",
       "default": "./icons/clipboardListIcon/dist/voussoir-icon-icons-clipboardListIcon.cjs.js"
     },
     "./icons/clipboardTypeIcon": {
+      "types": "./icons/clipboardTypeIcon/dist/voussoir-icon-icons-clipboardTypeIcon.cjs.js",
       "module": "./icons/clipboardTypeIcon/dist/voussoir-icon-icons-clipboardTypeIcon.esm.js",
       "default": "./icons/clipboardTypeIcon/dist/voussoir-icon-icons-clipboardTypeIcon.cjs.js"
     },
     "./icons/cloudMoonRainIcon": {
+      "types": "./icons/cloudMoonRainIcon/dist/voussoir-icon-icons-cloudMoonRainIcon.cjs.js",
       "module": "./icons/cloudMoonRainIcon/dist/voussoir-icon-icons-cloudMoonRainIcon.esm.js",
       "default": "./icons/cloudMoonRainIcon/dist/voussoir-icon-icons-cloudMoonRainIcon.cjs.js"
     },
     "./icons/cloudRainWindIcon": {
+      "types": "./icons/cloudRainWindIcon/dist/voussoir-icon-icons-cloudRainWindIcon.cjs.js",
       "module": "./icons/cloudRainWindIcon/dist/voussoir-icon-icons-cloudRainWindIcon.esm.js",
       "default": "./icons/cloudRainWindIcon/dist/voussoir-icon-icons-cloudRainWindIcon.cjs.js"
     },
     "./icons/conciergeBellIcon": {
+      "types": "./icons/conciergeBellIcon/dist/voussoir-icon-icons-conciergeBellIcon.cjs.js",
       "module": "./icons/conciergeBellIcon/dist/voussoir-icon-icons-conciergeBellIcon.esm.js",
       "default": "./icons/conciergeBellIcon/dist/voussoir-icon-icons-conciergeBellIcon.cjs.js"
     },
     "./icons/cornerRightUpIcon": {
+      "types": "./icons/cornerRightUpIcon/dist/voussoir-icon-icons-cornerRightUpIcon.cjs.js",
       "module": "./icons/cornerRightUpIcon/dist/voussoir-icon-icons-cornerRightUpIcon.esm.js",
       "default": "./icons/cornerRightUpIcon/dist/voussoir-icon-icons-cornerRightUpIcon.cjs.js"
     },
     "./icons/cornerUpRightIcon": {
+      "types": "./icons/cornerUpRightIcon/dist/voussoir-icon-icons-cornerUpRightIcon.cjs.js",
       "module": "./icons/cornerUpRightIcon/dist/voussoir-icon-icons-cornerUpRightIcon.esm.js",
       "default": "./icons/cornerUpRightIcon/dist/voussoir-icon-icons-cornerUpRightIcon.cjs.js"
     },
     "./icons/downloadCloudIcon": {
+      "types": "./icons/downloadCloudIcon/dist/voussoir-icon-icons-downloadCloudIcon.cjs.js",
       "module": "./icons/downloadCloudIcon/dist/voussoir-icon-icons-downloadCloudIcon.esm.js",
       "default": "./icons/downloadCloudIcon/dist/voussoir-icon-icons-downloadCloudIcon.cjs.js"
     },
     "./icons/fileBarChart2Icon": {
+      "types": "./icons/fileBarChart2Icon/dist/voussoir-icon-icons-fileBarChart2Icon.cjs.js",
       "module": "./icons/fileBarChart2Icon/dist/voussoir-icon-icons-fileBarChart2Icon.esm.js",
       "default": "./icons/fileBarChart2Icon/dist/voussoir-icon-icons-fileBarChart2Icon.cjs.js"
     },
     "./icons/fileLineChartIcon": {
+      "types": "./icons/fileLineChartIcon/dist/voussoir-icon-icons-fileLineChartIcon.cjs.js",
       "module": "./icons/fileLineChartIcon/dist/voussoir-icon-icons-fileLineChartIcon.esm.js",
       "default": "./icons/fileLineChartIcon/dist/voussoir-icon-icons-fileLineChartIcon.cjs.js"
     },
     "./icons/fileSignatureIcon": {
+      "types": "./icons/fileSignatureIcon/dist/voussoir-icon-icons-fileSignatureIcon.cjs.js",
       "module": "./icons/fileSignatureIcon/dist/voussoir-icon-icons-fileSignatureIcon.esm.js",
       "default": "./icons/fileSignatureIcon/dist/voussoir-icon-icons-fileSignatureIcon.cjs.js"
     },
     "./icons/flashlightOffIcon": {
+      "types": "./icons/flashlightOffIcon/dist/voussoir-icon-icons-flashlightOffIcon.cjs.js",
       "module": "./icons/flashlightOffIcon/dist/voussoir-icon-icons-flashlightOffIcon.esm.js",
       "default": "./icons/flashlightOffIcon/dist/voussoir-icon-icons-flashlightOffIcon.cjs.js"
     },
     "./icons/flipVertical2Icon": {
+      "types": "./icons/flipVertical2Icon/dist/voussoir-icon-icons-flipVertical2Icon.cjs.js",
       "module": "./icons/flipVertical2Icon/dist/voussoir-icon-icons-flipVertical2Icon.esm.js",
       "default": "./icons/flipVertical2Icon/dist/voussoir-icon-icons-flipVertical2Icon.cjs.js"
     },
     "./icons/folderArchiveIcon": {
+      "types": "./icons/folderArchiveIcon/dist/voussoir-icon-icons-folderArchiveIcon.cjs.js",
       "module": "./icons/folderArchiveIcon/dist/voussoir-icon-icons-folderArchiveIcon.esm.js",
       "default": "./icons/folderArchiveIcon/dist/voussoir-icon-icons-folderArchiveIcon.cjs.js"
     },
     "./icons/folderSearch2Icon": {
+      "types": "./icons/folderSearch2Icon/dist/voussoir-icon-icons-folderSearch2Icon.cjs.js",
       "module": "./icons/folderSearch2Icon/dist/voussoir-icon-icons-folderSearch2Icon.esm.js",
       "default": "./icons/folderSearch2Icon/dist/voussoir-icon-icons-folderSearch2Icon.cjs.js"
     },
     "./icons/folderSymlinkIcon": {
+      "types": "./icons/folderSymlinkIcon/dist/voussoir-icon-icons-folderSymlinkIcon.cjs.js",
       "module": "./icons/folderSymlinkIcon/dist/voussoir-icon-icons-folderSymlinkIcon.esm.js",
       "default": "./icons/folderSymlinkIcon/dist/voussoir-icon-icons-folderSymlinkIcon.cjs.js"
     },
     "./icons/gitBranchPlusIcon": {
+      "types": "./icons/gitBranchPlusIcon/dist/voussoir-icon-icons-gitBranchPlusIcon.cjs.js",
       "module": "./icons/gitBranchPlusIcon/dist/voussoir-icon-icons-gitBranchPlusIcon.esm.js",
       "default": "./icons/gitBranchPlusIcon/dist/voussoir-icon-icons-gitBranchPlusIcon.cjs.js"
     },
     "./icons/graduationCapIcon": {
+      "types": "./icons/graduationCapIcon/dist/voussoir-icon-icons-graduationCapIcon.cjs.js",
       "module": "./icons/graduationCapIcon/dist/voussoir-icon-icons-graduationCapIcon.esm.js",
       "default": "./icons/graduationCapIcon/dist/voussoir-icon-icons-graduationCapIcon.cjs.js"
     },
     "./icons/messageCircleIcon": {
+      "types": "./icons/messageCircleIcon/dist/voussoir-icon-icons-messageCircleIcon.cjs.js",
       "module": "./icons/messageCircleIcon/dist/voussoir-icon-icons-messageCircleIcon.esm.js",
       "default": "./icons/messageCircleIcon/dist/voussoir-icon-icons-messageCircleIcon.cjs.js"
     },
     "./icons/messageSquareIcon": {
+      "types": "./icons/messageSquareIcon/dist/voussoir-icon-icons-messageSquareIcon.cjs.js",
       "module": "./icons/messageSquareIcon/dist/voussoir-icon-icons-messageSquareIcon.esm.js",
       "default": "./icons/messageSquareIcon/dist/voussoir-icon-icons-messageSquareIcon.cjs.js"
     },
     "./icons/mousePointer2Icon": {
+      "types": "./icons/mousePointer2Icon/dist/voussoir-icon-icons-mousePointer2Icon.cjs.js",
       "module": "./icons/mousePointer2Icon/dist/voussoir-icon-icons-mousePointer2Icon.esm.js",
       "default": "./icons/mousePointer2Icon/dist/voussoir-icon-icons-mousePointer2Icon.cjs.js"
     },
     "./icons/moveDiagonal2Icon": {
+      "types": "./icons/moveDiagonal2Icon/dist/voussoir-icon-icons-moveDiagonal2Icon.cjs.js",
       "module": "./icons/moveDiagonal2Icon/dist/voussoir-icon-icons-moveDiagonal2Icon.esm.js",
       "default": "./icons/moveDiagonal2Icon/dist/voussoir-icon-icons-moveDiagonal2Icon.cjs.js"
     },
     "./icons/navigationOffIcon": {
+      "types": "./icons/navigationOffIcon/dist/voussoir-icon-icons-navigationOffIcon.cjs.js",
       "module": "./icons/navigationOffIcon/dist/voussoir-icon-icons-navigationOffIcon.esm.js",
       "default": "./icons/navigationOffIcon/dist/voussoir-icon-icons-navigationOffIcon.cjs.js"
     },
     "./icons/packageSearchIcon": {
+      "types": "./icons/packageSearchIcon/dist/voussoir-icon-icons-packageSearchIcon.cjs.js",
       "module": "./icons/packageSearchIcon/dist/voussoir-icon-icons-packageSearchIcon.esm.js",
       "default": "./icons/packageSearchIcon/dist/voussoir-icon-icons-packageSearchIcon.cjs.js"
     },
     "./icons/parkingCircleIcon": {
+      "types": "./icons/parkingCircleIcon/dist/voussoir-icon-icons-parkingCircleIcon.cjs.js",
       "module": "./icons/parkingCircleIcon/dist/voussoir-icon-icons-parkingCircleIcon.esm.js",
       "default": "./icons/parkingCircleIcon/dist/voussoir-icon-icons-parkingCircleIcon.cjs.js"
     },
     "./icons/parkingSquareIcon": {
+      "types": "./icons/parkingSquareIcon/dist/voussoir-icon-icons-parkingSquareIcon.cjs.js",
       "module": "./icons/parkingSquareIcon/dist/voussoir-icon-icons-parkingSquareIcon.esm.js",
       "default": "./icons/parkingSquareIcon/dist/voussoir-icon-icons-parkingSquareIcon.cjs.js"
     },
     "./icons/phoneIncomingIcon": {
+      "types": "./icons/phoneIncomingIcon/dist/voussoir-icon-icons-phoneIncomingIcon.cjs.js",
       "module": "./icons/phoneIncomingIcon/dist/voussoir-icon-icons-phoneIncomingIcon.esm.js",
       "default": "./icons/phoneIncomingIcon/dist/voussoir-icon-icons-phoneIncomingIcon.cjs.js"
     },
     "./icons/phoneOutgoingIcon": {
+      "types": "./icons/phoneOutgoingIcon/dist/voussoir-icon-icons-phoneOutgoingIcon.cjs.js",
       "module": "./icons/phoneOutgoingIcon/dist/voussoir-icon-icons-phoneOutgoingIcon.esm.js",
       "default": "./icons/phoneOutgoingIcon/dist/voussoir-icon-icons-phoneOutgoingIcon.cjs.js"
     },
     "./icons/poundSterlingIcon": {
+      "types": "./icons/poundSterlingIcon/dist/voussoir-icon-icons-poundSterlingIcon.cjs.js",
       "module": "./icons/poundSterlingIcon/dist/voussoir-icon-icons-poundSterlingIcon.esm.js",
       "default": "./icons/poundSterlingIcon/dist/voussoir-icon-icons-poundSterlingIcon.cjs.js"
     },
     "./icons/radioReceiverIcon": {
+      "types": "./icons/radioReceiverIcon/dist/voussoir-icon-icons-radioReceiverIcon.cjs.js",
       "module": "./icons/radioReceiverIcon/dist/voussoir-icon-icons-radioReceiverIcon.esm.js",
       "default": "./icons/radioReceiverIcon/dist/voussoir-icon-icons-radioReceiverIcon.cjs.js"
     },
     "./icons/smartphoneNfcIcon": {
+      "types": "./icons/smartphoneNfcIcon/dist/voussoir-icon-icons-smartphoneNfcIcon.cjs.js",
       "module": "./icons/smartphoneNfcIcon/dist/voussoir-icon-icons-smartphoneNfcIcon.esm.js",
       "default": "./icons/smartphoneNfcIcon/dist/voussoir-icon-icons-smartphoneNfcIcon.cjs.js"
     },
     "./icons/strikethroughIcon": {
+      "types": "./icons/strikethroughIcon/dist/voussoir-icon-icons-strikethroughIcon.cjs.js",
       "module": "./icons/strikethroughIcon/dist/voussoir-icon-icons-strikethroughIcon.esm.js",
       "default": "./icons/strikethroughIcon/dist/voussoir-icon-icons-strikethroughIcon.cjs.js"
     },
     "./icons/treeDeciduousIcon": {
+      "types": "./icons/treeDeciduousIcon/dist/voussoir-icon-icons-treeDeciduousIcon.cjs.js",
       "module": "./icons/treeDeciduousIcon/dist/voussoir-icon-icons-treeDeciduousIcon.esm.js",
       "default": "./icons/treeDeciduousIcon/dist/voussoir-icon-icons-treeDeciduousIcon.cjs.js"
     },
     "./icons/archiveRestoreIcon": {
+      "types": "./icons/archiveRestoreIcon/dist/voussoir-icon-icons-archiveRestoreIcon.cjs.js",
       "module": "./icons/archiveRestoreIcon/dist/voussoir-icon-icons-archiveRestoreIcon.esm.js",
       "default": "./icons/archiveRestoreIcon/dist/voussoir-icon-icons-archiveRestoreIcon.cjs.js"
     },
     "./icons/arrowDownRightIcon": {
+      "types": "./icons/arrowDownRightIcon/dist/voussoir-icon-icons-arrowDownRightIcon.cjs.js",
       "module": "./icons/arrowDownRightIcon/dist/voussoir-icon-icons-arrowDownRightIcon.esm.js",
       "default": "./icons/arrowDownRightIcon/dist/voussoir-icon-icons-arrowDownRightIcon.cjs.js"
     },
     "./icons/arrowLeftRightIcon": {
+      "types": "./icons/arrowLeftRightIcon/dist/voussoir-icon-icons-arrowLeftRightIcon.cjs.js",
       "module": "./icons/arrowLeftRightIcon/dist/voussoir-icon-icons-arrowLeftRightIcon.esm.js",
       "default": "./icons/arrowLeftRightIcon/dist/voussoir-icon-icons-arrowLeftRightIcon.cjs.js"
     },
     "./icons/batteryWarningIcon": {
+      "types": "./icons/batteryWarningIcon/dist/voussoir-icon-icons-batteryWarningIcon.cjs.js",
       "module": "./icons/batteryWarningIcon/dist/voussoir-icon-icons-batteryWarningIcon.esm.js",
       "default": "./icons/batteryWarningIcon/dist/voussoir-icon-icons-batteryWarningIcon.cjs.js"
     },
     "./icons/calendarCheck2Icon": {
+      "types": "./icons/calendarCheck2Icon/dist/voussoir-icon-icons-calendarCheck2Icon.cjs.js",
       "module": "./icons/calendarCheck2Icon/dist/voussoir-icon-icons-calendarCheck2Icon.esm.js",
       "default": "./icons/calendarCheck2Icon/dist/voussoir-icon-icons-calendarCheck2Icon.cjs.js"
     },
     "./icons/calendarSearchIcon": {
+      "types": "./icons/calendarSearchIcon/dist/voussoir-icon-icons-calendarSearchIcon.cjs.js",
       "module": "./icons/calendarSearchIcon/dist/voussoir-icon-icons-calendarSearchIcon.esm.js",
       "default": "./icons/calendarSearchIcon/dist/voussoir-icon-icons-calendarSearchIcon.cjs.js"
     },
     "./icons/chevronsDownUpIcon": {
+      "types": "./icons/chevronsDownUpIcon/dist/voussoir-icon-icons-chevronsDownUpIcon.cjs.js",
       "module": "./icons/chevronsDownUpIcon/dist/voussoir-icon-icons-chevronsDownUpIcon.esm.js",
       "default": "./icons/chevronsDownUpIcon/dist/voussoir-icon-icons-chevronsDownUpIcon.cjs.js"
     },
     "./icons/chevronsUpDownIcon": {
+      "types": "./icons/chevronsUpDownIcon/dist/voussoir-icon-icons-chevronsUpDownIcon.cjs.js",
       "module": "./icons/chevronsUpDownIcon/dist/voussoir-icon-icons-chevronsUpDownIcon.esm.js",
       "default": "./icons/chevronsUpDownIcon/dist/voussoir-icon-icons-chevronsUpDownIcon.cjs.js"
     },
     "./icons/circleEllipsisIcon": {
+      "types": "./icons/circleEllipsisIcon/dist/voussoir-icon-icons-circleEllipsisIcon.cjs.js",
       "module": "./icons/circleEllipsisIcon/dist/voussoir-icon-icons-circleEllipsisIcon.esm.js",
       "default": "./icons/circleEllipsisIcon/dist/voussoir-icon-icons-circleEllipsisIcon.cjs.js"
     },
     "./icons/clipboardCheckIcon": {
+      "types": "./icons/clipboardCheckIcon/dist/voussoir-icon-icons-clipboardCheckIcon.cjs.js",
       "module": "./icons/clipboardCheckIcon/dist/voussoir-icon-icons-clipboardCheckIcon.esm.js",
       "default": "./icons/clipboardCheckIcon/dist/voussoir-icon-icons-clipboardCheckIcon.cjs.js"
     },
     "./icons/cloudLightningIcon": {
+      "types": "./icons/cloudLightningIcon/dist/voussoir-icon-icons-cloudLightningIcon.cjs.js",
       "module": "./icons/cloudLightningIcon/dist/voussoir-icon-icons-cloudLightningIcon.esm.js",
       "default": "./icons/cloudLightningIcon/dist/voussoir-icon-icons-cloudLightningIcon.cjs.js"
     },
     "./icons/cornerDownLeftIcon": {
+      "types": "./icons/cornerDownLeftIcon/dist/voussoir-icon-icons-cornerDownLeftIcon.cjs.js",
       "module": "./icons/cornerDownLeftIcon/dist/voussoir-icon-icons-cornerDownLeftIcon.esm.js",
       "default": "./icons/cornerDownLeftIcon/dist/voussoir-icon-icons-cornerDownLeftIcon.cjs.js"
     },
     "./icons/cornerLeftDownIcon": {
+      "types": "./icons/cornerLeftDownIcon/dist/voussoir-icon-icons-cornerLeftDownIcon.cjs.js",
       "module": "./icons/cornerLeftDownIcon/dist/voussoir-icon-icons-cornerLeftDownIcon.esm.js",
       "default": "./icons/cornerLeftDownIcon/dist/voussoir-icon-icons-cornerLeftDownIcon.cjs.js"
     },
     "./icons/databaseBackupIcon": {
+      "types": "./icons/databaseBackupIcon/dist/voussoir-icon-icons-databaseBackupIcon.cjs.js",
       "module": "./icons/databaseBackupIcon/dist/voussoir-icon-icons-databaseBackupIcon.esm.js",
       "default": "./icons/databaseBackupIcon/dist/voussoir-icon-icons-databaseBackupIcon.cjs.js"
     },
     "./icons/flipHorizontalIcon": {
+      "types": "./icons/flipHorizontalIcon/dist/voussoir-icon-icons-flipHorizontalIcon.cjs.js",
       "module": "./icons/flipHorizontalIcon/dist/voussoir-icon-icons-flipHorizontalIcon.esm.js",
       "default": "./icons/flipHorizontalIcon/dist/voussoir-icon-icons-flipHorizontalIcon.cjs.js"
     },
     "./icons/functionSquareIcon": {
+      "types": "./icons/functionSquareIcon/dist/voussoir-icon-icons-functionSquareIcon.cjs.js",
       "module": "./icons/functionSquareIcon/dist/voussoir-icon-icons-functionSquareIcon.esm.js",
       "default": "./icons/functionSquareIcon/dist/voussoir-icon-icons-functionSquareIcon.cjs.js"
     },
     "./icons/gitPullRequestIcon": {
+      "types": "./icons/gitPullRequestIcon/dist/voussoir-icon-icons-gitPullRequestIcon.cjs.js",
       "module": "./icons/gitPullRequestIcon/dist/voussoir-icon-icons-gitPullRequestIcon.esm.js",
       "default": "./icons/gitPullRequestIcon/dist/voussoir-icon-icons-gitPullRequestIcon.cjs.js"
     },
     "./icons/gripHorizontalIcon": {
+      "types": "./icons/gripHorizontalIcon/dist/voussoir-icon-icons-gripHorizontalIcon.cjs.js",
       "module": "./icons/gripHorizontalIcon/dist/voussoir-icon-icons-gripHorizontalIcon.esm.js",
       "default": "./icons/gripHorizontalIcon/dist/voussoir-icon-icons-gripHorizontalIcon.cjs.js"
     },
     "./icons/heartHandshakeIcon": {
+      "types": "./icons/heartHandshakeIcon/dist/voussoir-icon-icons-heartHandshakeIcon.cjs.js",
       "module": "./icons/heartHandshakeIcon/dist/voussoir-icon-icons-heartHandshakeIcon.esm.js",
       "default": "./icons/heartHandshakeIcon/dist/voussoir-icon-icons-heartHandshakeIcon.cjs.js"
     },
     "./icons/layoutTemplateIcon": {
+      "types": "./icons/layoutTemplateIcon/dist/voussoir-icon-icons-layoutTemplateIcon.cjs.js",
       "module": "./icons/layoutTemplateIcon/dist/voussoir-icon-icons-layoutTemplateIcon.esm.js",
       "default": "./icons/layoutTemplateIcon/dist/voussoir-icon-icons-layoutTemplateIcon.cjs.js"
     },
     "./icons/monitorSpeakerIcon": {
+      "types": "./icons/monitorSpeakerIcon/dist/voussoir-icon-icons-monitorSpeakerIcon.cjs.js",
       "module": "./icons/monitorSpeakerIcon/dist/voussoir-icon-icons-monitorSpeakerIcon.esm.js",
       "default": "./icons/monitorSpeakerIcon/dist/voussoir-icon-icons-monitorSpeakerIcon.cjs.js"
     },
     "./icons/moreHorizontalIcon": {
+      "types": "./icons/moreHorizontalIcon/dist/voussoir-icon-icons-moreHorizontalIcon.cjs.js",
       "module": "./icons/moreHorizontalIcon/dist/voussoir-icon-icons-moreHorizontalIcon.esm.js",
       "default": "./icons/moreHorizontalIcon/dist/voussoir-icon-icons-moreHorizontalIcon.cjs.js"
     },
     "./icons/moveHorizontalIcon": {
+      "types": "./icons/moveHorizontalIcon/dist/voussoir-icon-icons-moveHorizontalIcon.cjs.js",
       "module": "./icons/moveHorizontalIcon/dist/voussoir-icon-icons-moveHorizontalIcon.esm.js",
       "default": "./icons/moveHorizontalIcon/dist/voussoir-icon-icons-moveHorizontalIcon.cjs.js"
     },
     "./icons/navigation2OffIcon": {
+      "types": "./icons/navigation2OffIcon/dist/voussoir-icon-icons-navigation2OffIcon.cjs.js",
       "module": "./icons/navigation2OffIcon/dist/voussoir-icon-icons-navigation2OffIcon.esm.js",
       "default": "./icons/navigation2OffIcon/dist/voussoir-icon-icons-navigation2OffIcon.cjs.js"
     },
     "./icons/personStandingIcon": {
+      "types": "./icons/personStandingIcon/dist/voussoir-icon-icons-personStandingIcon.cjs.js",
       "module": "./icons/personStandingIcon/dist/voussoir-icon-icons-personStandingIcon.esm.js",
       "default": "./icons/personStandingIcon/dist/voussoir-icon-icons-personStandingIcon.cjs.js"
     },
     "./icons/phoneForwardedIcon": {
+      "types": "./icons/phoneForwardedIcon/dist/voussoir-icon-icons-phoneForwardedIcon.cjs.js",
       "module": "./icons/phoneForwardedIcon/dist/voussoir-icon-icons-phoneForwardedIcon.esm.js",
       "default": "./icons/phoneForwardedIcon/dist/voussoir-icon-icons-phoneForwardedIcon.cjs.js"
     },
     "./icons/screenShareOffIcon": {
+      "types": "./icons/screenShareOffIcon/dist/voussoir-icon-icons-screenShareOffIcon.cjs.js",
       "module": "./icons/screenShareOffIcon/dist/voussoir-icon-icons-screenShareOffIcon.esm.js",
       "default": "./icons/screenShareOffIcon/dist/voussoir-icon-icons-screenShareOffIcon.cjs.js"
     },
     "./icons/terminalSquareIcon": {
+      "types": "./icons/terminalSquareIcon/dist/voussoir-icon-icons-terminalSquareIcon.cjs.js",
       "module": "./icons/terminalSquareIcon/dist/voussoir-icon-icons-terminalSquareIcon.esm.js",
       "default": "./icons/terminalSquareIcon/dist/voussoir-icon-icons-terminalSquareIcon.cjs.js"
     },
     "./icons/thermometerSunIcon": {
+      "types": "./icons/thermometerSunIcon/dist/voussoir-icon-icons-thermometerSunIcon.cjs.js",
       "module": "./icons/thermometerSunIcon/dist/voussoir-icon-icons-thermometerSunIcon.esm.js",
       "default": "./icons/thermometerSunIcon/dist/voussoir-icon-icons-thermometerSunIcon.cjs.js"
     },
     "./icons/arrowDownCircleIcon": {
+      "types": "./icons/arrowDownCircleIcon/dist/voussoir-icon-icons-arrowDownCircleIcon.cjs.js",
       "module": "./icons/arrowDownCircleIcon/dist/voussoir-icon-icons-arrowDownCircleIcon.esm.js",
       "default": "./icons/arrowDownCircleIcon/dist/voussoir-icon-icons-arrowDownCircleIcon.cjs.js"
     },
     "./icons/arrowLeftCircleIcon": {
+      "types": "./icons/arrowLeftCircleIcon/dist/voussoir-icon-icons-arrowLeftCircleIcon.cjs.js",
       "module": "./icons/arrowLeftCircleIcon/dist/voussoir-icon-icons-arrowLeftCircleIcon.esm.js",
       "default": "./icons/arrowLeftCircleIcon/dist/voussoir-icon-icons-arrowLeftCircleIcon.cjs.js"
     },
     "./icons/batteryChargingIcon": {
+      "types": "./icons/batteryChargingIcon/dist/voussoir-icon-icons-batteryChargingIcon.cjs.js",
       "module": "./icons/batteryChargingIcon/dist/voussoir-icon-icons-batteryChargingIcon.esm.js",
       "default": "./icons/batteryChargingIcon/dist/voussoir-icon-icons-batteryChargingIcon.cjs.js"
     },
     "./icons/cornerDownRightIcon": {
+      "types": "./icons/cornerDownRightIcon/dist/voussoir-icon-icons-cornerDownRightIcon.cjs.js",
       "module": "./icons/cornerDownRightIcon/dist/voussoir-icon-icons-cornerDownRightIcon.esm.js",
       "default": "./icons/cornerDownRightIcon/dist/voussoir-icon-icons-cornerDownRightIcon.cjs.js"
     },
     "./icons/cornerRightDownIcon": {
+      "types": "./icons/cornerRightDownIcon/dist/voussoir-icon-icons-cornerRightDownIcon.cjs.js",
       "module": "./icons/cornerRightDownIcon/dist/voussoir-icon-icons-cornerRightDownIcon.esm.js",
       "default": "./icons/cornerRightDownIcon/dist/voussoir-icon-icons-cornerRightDownIcon.cjs.js"
     },
     "./icons/creativeCommonsIcon": {
+      "types": "./icons/creativeCommonsIcon/dist/voussoir-icon-icons-creativeCommonsIcon.cjs.js",
       "module": "./icons/creativeCommonsIcon/dist/voussoir-icon-icons-creativeCommonsIcon.esm.js",
       "default": "./icons/creativeCommonsIcon/dist/voussoir-icon-icons-creativeCommonsIcon.cjs.js"
     },
     "./icons/fileSpreadsheetIcon": {
+      "types": "./icons/fileSpreadsheetIcon/dist/voussoir-icon-icons-fileSpreadsheetIcon.cjs.js",
       "module": "./icons/fileSpreadsheetIcon/dist/voussoir-icon-icons-fileSpreadsheetIcon.esm.js",
       "default": "./icons/fileSpreadsheetIcon/dist/voussoir-icon-icons-fileSpreadsheetIcon.cjs.js"
     },
     "./icons/flaskConicalOffIcon": {
+      "types": "./icons/flaskConicalOffIcon/dist/voussoir-icon-icons-flaskConicalOffIcon.cjs.js",
       "module": "./icons/flaskConicalOffIcon/dist/voussoir-icon-icons-flaskConicalOffIcon.esm.js",
       "default": "./icons/flaskConicalOffIcon/dist/voussoir-icon-icons-flaskConicalOffIcon.cjs.js"
     },
     "./icons/flipHorizontal2Icon": {
+      "types": "./icons/flipHorizontal2Icon/dist/voussoir-icon-icons-flipHorizontal2Icon.cjs.js",
       "module": "./icons/flipHorizontal2Icon/dist/voussoir-icon-icons-flipHorizontal2Icon.esm.js",
       "default": "./icons/flipHorizontal2Icon/dist/voussoir-icon-icons-flipHorizontal2Icon.cjs.js"
     },
     "./icons/layoutDashboardIcon": {
+      "types": "./icons/layoutDashboardIcon/dist/voussoir-icon-icons-layoutDashboardIcon.cjs.js",
       "module": "./icons/layoutDashboardIcon/dist/voussoir-icon-icons-layoutDashboardIcon.esm.js",
       "default": "./icons/layoutDashboardIcon/dist/voussoir-icon-icons-layoutDashboardIcon.cjs.js"
     },
     "./icons/stretchVerticalIcon": {
+      "types": "./icons/stretchVerticalIcon/dist/voussoir-icon-icons-stretchVerticalIcon.cjs.js",
       "module": "./icons/stretchVerticalIcon/dist/voussoir-icon-icons-stretchVerticalIcon.esm.js",
       "default": "./icons/stretchVerticalIcon/dist/voussoir-icon-icons-stretchVerticalIcon.cjs.js"
     },
     "./icons/textCursorInputIcon": {
+      "types": "./icons/textCursorInputIcon/dist/voussoir-icon-icons-textCursorInputIcon.cjs.js",
       "module": "./icons/textCursorInputIcon/dist/voussoir-icon-icons-textCursorInputIcon.esm.js",
       "default": "./icons/textCursorInputIcon/dist/voussoir-icon-icons-textCursorInputIcon.cjs.js"
     },
     "./icons/utensilsCrossedIcon": {
+      "types": "./icons/utensilsCrossedIcon/dist/voussoir-icon-icons-utensilsCrossedIcon.cjs.js",
       "module": "./icons/utensilsCrossedIcon/dist/voussoir-icon-icons-utensilsCrossedIcon.esm.js",
       "default": "./icons/utensilsCrossedIcon/dist/voussoir-icon-icons-utensilsCrossedIcon.cjs.js"
     },
     "./icons/alignEndVerticalIcon": {
+      "types": "./icons/alignEndVerticalIcon/dist/voussoir-icon-icons-alignEndVerticalIcon.cjs.js",
       "module": "./icons/alignEndVerticalIcon/dist/voussoir-icon-icons-alignEndVerticalIcon.esm.js",
       "default": "./icons/alignEndVerticalIcon/dist/voussoir-icon-icons-alignEndVerticalIcon.cjs.js"
     },
     "./icons/arrowRightCircleIcon": {
+      "types": "./icons/arrowRightCircleIcon/dist/voussoir-icon-icons-arrowRightCircleIcon.cjs.js",
       "module": "./icons/arrowRightCircleIcon/dist/voussoir-icon-icons-arrowRightCircleIcon.esm.js",
       "default": "./icons/arrowRightCircleIcon/dist/voussoir-icon-icons-arrowRightCircleIcon.cjs.js"
     },
     "./icons/flagTriangleLeftIcon": {
+      "types": "./icons/flagTriangleLeftIcon/dist/voussoir-icon-icons-flagTriangleLeftIcon.cjs.js",
       "module": "./icons/flagTriangleLeftIcon/dist/voussoir-icon-icons-flagTriangleLeftIcon.esm.js",
       "default": "./icons/flagTriangleLeftIcon/dist/voussoir-icon-icons-flagTriangleLeftIcon.cjs.js"
     },
     "./icons/parkingCircleOffIcon": {
+      "types": "./icons/parkingCircleOffIcon/dist/voussoir-icon-icons-parkingCircleOffIcon.cjs.js",
       "module": "./icons/parkingCircleOffIcon/dist/voussoir-icon-icons-parkingCircleOffIcon.esm.js",
       "default": "./icons/parkingCircleOffIcon/dist/voussoir-icon-icons-parkingCircleOffIcon.cjs.js"
     },
     "./icons/parkingSquareOffIcon": {
+      "types": "./icons/parkingSquareOffIcon/dist/voussoir-icon-icons-parkingSquareOffIcon.cjs.js",
       "module": "./icons/parkingSquareOffIcon/dist/voussoir-icon-icons-parkingSquareOffIcon.esm.js",
       "default": "./icons/parkingSquareOffIcon/dist/voussoir-icon-icons-parkingSquareOffIcon.cjs.js"
     },
     "./icons/pictureInPictureIcon": {
+      "types": "./icons/pictureInPictureIcon/dist/voussoir-icon-icons-pictureInPictureIcon.cjs.js",
       "module": "./icons/pictureInPictureIcon/dist/voussoir-icon-icons-pictureInPictureIcon.esm.js",
       "default": "./icons/pictureInPictureIcon/dist/voussoir-icon-icons-pictureInPictureIcon.cjs.js"
     },
     "./icons/removeFormattingIcon": {
+      "types": "./icons/removeFormattingIcon/dist/voussoir-icon-icons-removeFormattingIcon.cjs.js",
       "module": "./icons/removeFormattingIcon/dist/voussoir-icon-icons-removeFormattingIcon.esm.js",
       "default": "./icons/removeFormattingIcon/dist/voussoir-icon-icons-removeFormattingIcon.cjs.js"
     },
     "./icons/chevronsLeftRightIcon": {
+      "types": "./icons/chevronsLeftRightIcon/dist/voussoir-icon-icons-chevronsLeftRightIcon.cjs.js",
       "module": "./icons/chevronsLeftRightIcon/dist/voussoir-icon-icons-chevronsLeftRightIcon.esm.js",
       "default": "./icons/chevronsLeftRightIcon/dist/voussoir-icon-icons-chevronsLeftRightIcon.cjs.js"
     },
     "./icons/chevronsRightLeftIcon": {
+      "types": "./icons/chevronsRightLeftIcon/dist/voussoir-icon-icons-chevronsRightLeftIcon.cjs.js",
       "module": "./icons/chevronsRightLeftIcon/dist/voussoir-icon-icons-chevronsRightLeftIcon.esm.js",
       "default": "./icons/chevronsRightLeftIcon/dist/voussoir-icon-icons-chevronsRightLeftIcon.cjs.js"
     },
     "./icons/flagTriangleRightIcon": {
+      "types": "./icons/flagTriangleRightIcon/dist/voussoir-icon-icons-flagTriangleRightIcon.cjs.js",
       "module": "./icons/flagTriangleRightIcon/dist/voussoir-icon-icons-flagTriangleRightIcon.esm.js",
       "default": "./icons/flagTriangleRightIcon/dist/voussoir-icon-icons-flagTriangleRightIcon.cjs.js"
     },
     "./icons/monitorSmartphoneIcon": {
+      "types": "./icons/monitorSmartphoneIcon/dist/voussoir-icon-icons-monitorSmartphoneIcon.cjs.js",
       "module": "./icons/monitorSmartphoneIcon/dist/voussoir-icon-icons-monitorSmartphoneIcon.esm.js",
       "default": "./icons/monitorSmartphoneIcon/dist/voussoir-icon-icons-monitorSmartphoneIcon.cjs.js"
     },
     "./icons/mousePointerClickIcon": {
+      "types": "./icons/mousePointerClickIcon/dist/voussoir-icon-icons-mousePointerClickIcon.cjs.js",
       "module": "./icons/mousePointerClickIcon/dist/voussoir-icon-icons-mousePointerClickIcon.esm.js",
       "default": "./icons/mousePointerClickIcon/dist/voussoir-icon-icons-mousePointerClickIcon.cjs.js"
     },
     "./icons/pictureInPicture2Icon": {
+      "types": "./icons/pictureInPicture2Icon/dist/voussoir-icon-icons-pictureInPicture2Icon.cjs.js",
       "module": "./icons/pictureInPicture2Icon/dist/voussoir-icon-icons-pictureInPicture2Icon.esm.js",
       "default": "./icons/pictureInPicture2Icon/dist/voussoir-icon-icons-pictureInPicture2Icon.cjs.js"
     },
     "./icons/rectangleVerticalIcon": {
+      "types": "./icons/rectangleVerticalIcon/dist/voussoir-icon-icons-rectangleVerticalIcon.cjs.js",
       "module": "./icons/rectangleVerticalIcon/dist/voussoir-icon-icons-rectangleVerticalIcon.esm.js",
       "default": "./icons/rectangleVerticalIcon/dist/voussoir-icon-icons-rectangleVerticalIcon.cjs.js"
     },
     "./icons/separatorVerticalIcon": {
+      "types": "./icons/separatorVerticalIcon/dist/voussoir-icon-icons-separatorVerticalIcon.cjs.js",
       "module": "./icons/separatorVerticalIcon/dist/voussoir-icon-icons-separatorVerticalIcon.esm.js",
       "default": "./icons/separatorVerticalIcon/dist/voussoir-icon-icons-separatorVerticalIcon.cjs.js"
     },
     "./icons/slidersHorizontalIcon": {
+      "types": "./icons/slidersHorizontalIcon/dist/voussoir-icon-icons-slidersHorizontalIcon.cjs.js",
       "module": "./icons/slidersHorizontalIcon/dist/voussoir-icon-icons-slidersHorizontalIcon.esm.js",
       "default": "./icons/slidersHorizontalIcon/dist/voussoir-icon-icons-slidersHorizontalIcon.cjs.js"
     },
     "./icons/stretchHorizontalIcon": {
+      "types": "./icons/stretchHorizontalIcon/dist/voussoir-icon-icons-stretchHorizontalIcon.cjs.js",
       "module": "./icons/stretchHorizontalIcon/dist/voussoir-icon-icons-stretchHorizontalIcon.esm.js",
       "default": "./icons/stretchHorizontalIcon/dist/voussoir-icon-icons-stretchHorizontalIcon.cjs.js"
     },
     "./icons/alignEndHorizontalIcon": {
+      "types": "./icons/alignEndHorizontalIcon/dist/voussoir-icon-icons-alignEndHorizontalIcon.cjs.js",
       "module": "./icons/alignEndHorizontalIcon/dist/voussoir-icon-icons-alignEndHorizontalIcon.esm.js",
       "default": "./icons/alignEndHorizontalIcon/dist/voussoir-icon-icons-alignEndHorizontalIcon.cjs.js"
     },
     "./icons/alignStartVerticalIcon": {
+      "types": "./icons/alignStartVerticalIcon/dist/voussoir-icon-icons-alignStartVerticalIcon.cjs.js",
       "module": "./icons/alignStartVerticalIcon/dist/voussoir-icon-icons-alignStartVerticalIcon.esm.js",
       "default": "./icons/alignStartVerticalIcon/dist/voussoir-icon-icons-alignStartVerticalIcon.cjs.js"
     },
     "./icons/barChartHorizontalIcon": {
+      "types": "./icons/barChartHorizontalIcon/dist/voussoir-icon-icons-barChartHorizontalIcon.cjs.js",
       "module": "./icons/barChartHorizontalIcon/dist/voussoir-icon-icons-barChartHorizontalIcon.esm.js",
       "default": "./icons/barChartHorizontalIcon/dist/voussoir-icon-icons-barChartHorizontalIcon.cjs.js"
     },
     "./icons/bluetoothConnectedIcon": {
+      "types": "./icons/bluetoothConnectedIcon/dist/voussoir-icon-icons-bluetoothConnectedIcon.cjs.js",
       "module": "./icons/bluetoothConnectedIcon/dist/voussoir-icon-icons-bluetoothConnectedIcon.esm.js",
       "default": "./icons/bluetoothConnectedIcon/dist/voussoir-icon-icons-bluetoothConnectedIcon.cjs.js"
     },
     "./icons/bluetoothSearchingIcon": {
+      "types": "./icons/bluetoothSearchingIcon/dist/voussoir-icon-icons-bluetoothSearchingIcon.cjs.js",
       "module": "./icons/bluetoothSearchingIcon/dist/voussoir-icon-icons-bluetoothSearchingIcon.esm.js",
       "default": "./icons/bluetoothSearchingIcon/dist/voussoir-icon-icons-bluetoothSearchingIcon.cjs.js"
     },
     "./icons/clipboardSignatureIcon": {
+      "types": "./icons/clipboardSignatureIcon/dist/voussoir-icon-icons-clipboardSignatureIcon.cjs.js",
       "module": "./icons/clipboardSignatureIcon/dist/voussoir-icon-icons-clipboardSignatureIcon.esm.js",
       "default": "./icons/clipboardSignatureIcon/dist/voussoir-icon-icons-clipboardSignatureIcon.cjs.js"
     },
     "./icons/smartphoneChargingIcon": {
+      "types": "./icons/smartphoneChargingIcon/dist/voussoir-icon-icons-smartphoneChargingIcon.cjs.js",
       "module": "./icons/smartphoneChargingIcon/dist/voussoir-icon-icons-smartphoneChargingIcon.esm.js",
       "default": "./icons/smartphoneChargingIcon/dist/voussoir-icon-icons-smartphoneChargingIcon.cjs.js"
     },
     "./icons/alignCenterVerticalIcon": {
+      "types": "./icons/alignCenterVerticalIcon/dist/voussoir-icon-icons-alignCenterVerticalIcon.cjs.js",
       "module": "./icons/alignCenterVerticalIcon/dist/voussoir-icon-icons-alignCenterVerticalIcon.esm.js",
       "default": "./icons/alignCenterVerticalIcon/dist/voussoir-icon-icons-alignCenterVerticalIcon.cjs.js"
     },
     "./icons/gitPullRequestDraftIcon": {
+      "types": "./icons/gitPullRequestDraftIcon/dist/voussoir-icon-icons-gitPullRequestDraftIcon.cjs.js",
       "module": "./icons/gitPullRequestDraftIcon/dist/voussoir-icon-icons-gitPullRequestDraftIcon.esm.js",
       "default": "./icons/gitPullRequestDraftIcon/dist/voussoir-icon-icons-gitPullRequestDraftIcon.cjs.js"
     },
     "./icons/rectangleHorizontalIcon": {
+      "types": "./icons/rectangleHorizontalIcon/dist/voussoir-icon-icons-rectangleHorizontalIcon.cjs.js",
       "module": "./icons/rectangleHorizontalIcon/dist/voussoir-icon-icons-rectangleHorizontalIcon.esm.js",
       "default": "./icons/rectangleHorizontalIcon/dist/voussoir-icon-icons-rectangleHorizontalIcon.cjs.js"
     },
     "./icons/separatorHorizontalIcon": {
+      "types": "./icons/separatorHorizontalIcon/dist/voussoir-icon-icons-separatorHorizontalIcon.cjs.js",
       "module": "./icons/separatorHorizontalIcon/dist/voussoir-icon-icons-separatorHorizontalIcon.esm.js",
       "default": "./icons/separatorHorizontalIcon/dist/voussoir-icon-icons-separatorHorizontalIcon.cjs.js"
     },
     "./icons/splitSquareVerticalIcon": {
+      "types": "./icons/splitSquareVerticalIcon/dist/voussoir-icon-icons-splitSquareVerticalIcon.cjs.js",
       "module": "./icons/splitSquareVerticalIcon/dist/voussoir-icon-icons-splitSquareVerticalIcon.esm.js",
       "default": "./icons/splitSquareVerticalIcon/dist/voussoir-icon-icons-splitSquareVerticalIcon.cjs.js"
     },
     "./icons/alignStartHorizontalIcon": {
+      "types": "./icons/alignStartHorizontalIcon/dist/voussoir-icon-icons-alignStartHorizontalIcon.cjs.js",
       "module": "./icons/alignStartHorizontalIcon/dist/voussoir-icon-icons-alignStartHorizontalIcon.esm.js",
       "default": "./icons/alignStartHorizontalIcon/dist/voussoir-icon-icons-alignStartHorizontalIcon.cjs.js"
     },
     "./icons/gitPullRequestClosedIcon": {
+      "types": "./icons/gitPullRequestClosedIcon/dist/voussoir-icon-icons-gitPullRequestClosedIcon.cjs.js",
       "module": "./icons/gitPullRequestClosedIcon/dist/voussoir-icon-icons-gitPullRequestClosedIcon.esm.js",
       "default": "./icons/gitPullRequestClosedIcon/dist/voussoir-icon-icons-gitPullRequestClosedIcon.cjs.js"
     },
     "./icons/thermometerSnowflakeIcon": {
+      "types": "./icons/thermometerSnowflakeIcon/dist/voussoir-icon-icons-thermometerSnowflakeIcon.cjs.js",
       "module": "./icons/thermometerSnowflakeIcon/dist/voussoir-icon-icons-thermometerSnowflakeIcon.esm.js",
       "default": "./icons/thermometerSnowflakeIcon/dist/voussoir-icon-icons-thermometerSnowflakeIcon.cjs.js"
     },
     "./icons/alignCenterHorizontalIcon": {
+      "types": "./icons/alignCenterHorizontalIcon/dist/voussoir-icon-icons-alignCenterHorizontalIcon.cjs.js",
       "module": "./icons/alignCenterHorizontalIcon/dist/voussoir-icon-icons-alignCenterHorizontalIcon.esm.js",
       "default": "./icons/alignCenterHorizontalIcon/dist/voussoir-icon-icons-alignCenterHorizontalIcon.cjs.js"
     },
     "./icons/splitSquareHorizontalIcon": {
+      "types": "./icons/splitSquareHorizontalIcon/dist/voussoir-icon-icons-splitSquareHorizontalIcon.cjs.js",
       "module": "./icons/splitSquareHorizontalIcon/dist/voussoir-icon-icons-splitSquareHorizontalIcon.esm.js",
       "default": "./icons/splitSquareHorizontalIcon/dist/voussoir-icon-icons-splitSquareHorizontalIcon.cjs.js"
     },
     "./icons/alignVerticalJustifyEndIcon": {
+      "types": "./icons/alignVerticalJustifyEndIcon/dist/voussoir-icon-icons-alignVerticalJustifyEndIcon.cjs.js",
       "module": "./icons/alignVerticalJustifyEndIcon/dist/voussoir-icon-icons-alignVerticalJustifyEndIcon.esm.js",
       "default": "./icons/alignVerticalJustifyEndIcon/dist/voussoir-icon-icons-alignVerticalJustifyEndIcon.cjs.js"
     },
     "./icons/alignVerticalSpaceAroundIcon": {
+      "types": "./icons/alignVerticalSpaceAroundIcon/dist/voussoir-icon-icons-alignVerticalSpaceAroundIcon.cjs.js",
       "module": "./icons/alignVerticalSpaceAroundIcon/dist/voussoir-icon-icons-alignVerticalSpaceAroundIcon.esm.js",
       "default": "./icons/alignVerticalSpaceAroundIcon/dist/voussoir-icon-icons-alignVerticalSpaceAroundIcon.cjs.js"
     },
     "./icons/alignHorizontalJustifyEndIcon": {
+      "types": "./icons/alignHorizontalJustifyEndIcon/dist/voussoir-icon-icons-alignHorizontalJustifyEndIcon.cjs.js",
       "module": "./icons/alignHorizontalJustifyEndIcon/dist/voussoir-icon-icons-alignHorizontalJustifyEndIcon.esm.js",
       "default": "./icons/alignHorizontalJustifyEndIcon/dist/voussoir-icon-icons-alignHorizontalJustifyEndIcon.cjs.js"
     },
     "./icons/alignVerticalJustifyStartIcon": {
+      "types": "./icons/alignVerticalJustifyStartIcon/dist/voussoir-icon-icons-alignVerticalJustifyStartIcon.cjs.js",
       "module": "./icons/alignVerticalJustifyStartIcon/dist/voussoir-icon-icons-alignVerticalJustifyStartIcon.esm.js",
       "default": "./icons/alignVerticalJustifyStartIcon/dist/voussoir-icon-icons-alignVerticalJustifyStartIcon.cjs.js"
     },
     "./icons/alignVerticalSpaceBetweenIcon": {
+      "types": "./icons/alignVerticalSpaceBetweenIcon/dist/voussoir-icon-icons-alignVerticalSpaceBetweenIcon.cjs.js",
       "module": "./icons/alignVerticalSpaceBetweenIcon/dist/voussoir-icon-icons-alignVerticalSpaceBetweenIcon.esm.js",
       "default": "./icons/alignVerticalSpaceBetweenIcon/dist/voussoir-icon-icons-alignVerticalSpaceBetweenIcon.cjs.js"
     },
     "./icons/alignHorizontalSpaceAroundIcon": {
+      "types": "./icons/alignHorizontalSpaceAroundIcon/dist/voussoir-icon-icons-alignHorizontalSpaceAroundIcon.cjs.js",
       "module": "./icons/alignHorizontalSpaceAroundIcon/dist/voussoir-icon-icons-alignHorizontalSpaceAroundIcon.esm.js",
       "default": "./icons/alignHorizontalSpaceAroundIcon/dist/voussoir-icon-icons-alignHorizontalSpaceAroundIcon.cjs.js"
     },
     "./icons/alignVerticalDistributeEndIcon": {
+      "types": "./icons/alignVerticalDistributeEndIcon/dist/voussoir-icon-icons-alignVerticalDistributeEndIcon.cjs.js",
       "module": "./icons/alignVerticalDistributeEndIcon/dist/voussoir-icon-icons-alignVerticalDistributeEndIcon.esm.js",
       "default": "./icons/alignVerticalDistributeEndIcon/dist/voussoir-icon-icons-alignVerticalDistributeEndIcon.cjs.js"
     },
     "./icons/alignVerticalJustifyCenterIcon": {
+      "types": "./icons/alignVerticalJustifyCenterIcon/dist/voussoir-icon-icons-alignVerticalJustifyCenterIcon.cjs.js",
       "module": "./icons/alignVerticalJustifyCenterIcon/dist/voussoir-icon-icons-alignVerticalJustifyCenterIcon.esm.js",
       "default": "./icons/alignVerticalJustifyCenterIcon/dist/voussoir-icon-icons-alignVerticalJustifyCenterIcon.cjs.js"
     },
     "./icons/alignHorizontalJustifyStartIcon": {
+      "types": "./icons/alignHorizontalJustifyStartIcon/dist/voussoir-icon-icons-alignHorizontalJustifyStartIcon.cjs.js",
       "module": "./icons/alignHorizontalJustifyStartIcon/dist/voussoir-icon-icons-alignHorizontalJustifyStartIcon.esm.js",
       "default": "./icons/alignHorizontalJustifyStartIcon/dist/voussoir-icon-icons-alignHorizontalJustifyStartIcon.cjs.js"
     },
     "./icons/alignHorizontalSpaceBetweenIcon": {
+      "types": "./icons/alignHorizontalSpaceBetweenIcon/dist/voussoir-icon-icons-alignHorizontalSpaceBetweenIcon.cjs.js",
       "module": "./icons/alignHorizontalSpaceBetweenIcon/dist/voussoir-icon-icons-alignHorizontalSpaceBetweenIcon.esm.js",
       "default": "./icons/alignHorizontalSpaceBetweenIcon/dist/voussoir-icon-icons-alignHorizontalSpaceBetweenIcon.cjs.js"
     },
     "./icons/alignHorizontalDistributeEndIcon": {
+      "types": "./icons/alignHorizontalDistributeEndIcon/dist/voussoir-icon-icons-alignHorizontalDistributeEndIcon.cjs.js",
       "module": "./icons/alignHorizontalDistributeEndIcon/dist/voussoir-icon-icons-alignHorizontalDistributeEndIcon.esm.js",
       "default": "./icons/alignHorizontalDistributeEndIcon/dist/voussoir-icon-icons-alignHorizontalDistributeEndIcon.cjs.js"
     },
     "./icons/alignHorizontalJustifyCenterIcon": {
+      "types": "./icons/alignHorizontalJustifyCenterIcon/dist/voussoir-icon-icons-alignHorizontalJustifyCenterIcon.cjs.js",
       "module": "./icons/alignHorizontalJustifyCenterIcon/dist/voussoir-icon-icons-alignHorizontalJustifyCenterIcon.esm.js",
       "default": "./icons/alignHorizontalJustifyCenterIcon/dist/voussoir-icon-icons-alignHorizontalJustifyCenterIcon.cjs.js"
     },
     "./icons/alignVerticalDistributeStartIcon": {
+      "types": "./icons/alignVerticalDistributeStartIcon/dist/voussoir-icon-icons-alignVerticalDistributeStartIcon.cjs.js",
       "module": "./icons/alignVerticalDistributeStartIcon/dist/voussoir-icon-icons-alignVerticalDistributeStartIcon.esm.js",
       "default": "./icons/alignVerticalDistributeStartIcon/dist/voussoir-icon-icons-alignVerticalDistributeStartIcon.cjs.js"
     },
     "./icons/alignVerticalDistributeCenterIcon": {
+      "types": "./icons/alignVerticalDistributeCenterIcon/dist/voussoir-icon-icons-alignVerticalDistributeCenterIcon.cjs.js",
       "module": "./icons/alignVerticalDistributeCenterIcon/dist/voussoir-icon-icons-alignVerticalDistributeCenterIcon.esm.js",
       "default": "./icons/alignVerticalDistributeCenterIcon/dist/voussoir-icon-icons-alignVerticalDistributeCenterIcon.cjs.js"
     },
     "./icons/alignHorizontalDistributeStartIcon": {
+      "types": "./icons/alignHorizontalDistributeStartIcon/dist/voussoir-icon-icons-alignHorizontalDistributeStartIcon.cjs.js",
       "module": "./icons/alignHorizontalDistributeStartIcon/dist/voussoir-icon-icons-alignHorizontalDistributeStartIcon.esm.js",
       "default": "./icons/alignHorizontalDistributeStartIcon/dist/voussoir-icon-icons-alignHorizontalDistributeStartIcon.cjs.js"
     },
     "./icons/alignHorizontalDistributeCenterIcon": {
+      "types": "./icons/alignHorizontalDistributeCenterIcon/dist/voussoir-icon-icons-alignHorizontalDistributeCenterIcon.cjs.js",
       "module": "./icons/alignHorizontalDistributeCenterIcon/dist/voussoir-icon-icons-alignHorizontalDistributeCenterIcon.esm.js",
       "default": "./icons/alignHorizontalDistributeCenterIcon/dist/voussoir-icon-icons-alignHorizontalDistributeCenterIcon.cjs.js"
     },

--- a/design-system/packages/image/package.json
+++ b/design-system/packages/image/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-image.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-image.cjs.js",
       "module": "./dist/voussoir-image.esm.js",
       "default": "./dist/voussoir-image.cjs.js"
     },

--- a/design-system/packages/layout/package.json
+++ b/design-system/packages/layout/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-layout.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-layout.cjs.js",
       "module": "./dist/voussoir-layout.esm.js",
       "default": "./dist/voussoir-layout.cjs.js"
     },

--- a/design-system/packages/link/package.json
+++ b/design-system/packages/link/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-link.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-link.cjs.js",
       "module": "./dist/voussoir-link.esm.js",
       "default": "./dist/voussoir-link.cjs.js"
     },

--- a/design-system/packages/list-view/package.json
+++ b/design-system/packages/list-view/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-list-view.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-list-view.cjs.js",
       "module": "./dist/voussoir-list-view.esm.js",
       "default": "./dist/voussoir-list-view.cjs.js"
     },

--- a/design-system/packages/listbox/package.json
+++ b/design-system/packages/listbox/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-listbox.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-listbox.cjs.js",
       "module": "./dist/voussoir-listbox.esm.js",
       "default": "./dist/voussoir-listbox.cjs.js"
     },

--- a/design-system/packages/menu/package.json
+++ b/design-system/packages/menu/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-menu.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-menu.cjs.js",
       "module": "./dist/voussoir-menu.esm.js",
       "default": "./dist/voussoir-menu.cjs.js"
     },

--- a/design-system/packages/nav-list/package.json
+++ b/design-system/packages/nav-list/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-nav-list.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-nav-list.cjs.js",
       "module": "./dist/voussoir-nav-list.esm.js",
       "default": "./dist/voussoir-nav-list.cjs.js"
     },

--- a/design-system/packages/next/package.json
+++ b/design-system/packages/next/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-next.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-next.cjs.js",
       "module": "./dist/voussoir-next.esm.js",
       "default": "./dist/voussoir-next.cjs.js"
     },

--- a/design-system/packages/notice/package.json
+++ b/design-system/packages/notice/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-notice.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-notice.cjs.js",
       "module": "./dist/voussoir-notice.esm.js",
       "default": "./dist/voussoir-notice.cjs.js"
     },

--- a/design-system/packages/number-field/package.json
+++ b/design-system/packages/number-field/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-number-field.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-number-field.cjs.js",
       "module": "./dist/voussoir-number-field.esm.js",
       "default": "./dist/voussoir-number-field.cjs.js"
     },

--- a/design-system/packages/overlays/package.json
+++ b/design-system/packages/overlays/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-overlays.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-overlays.cjs.js",
       "module": "./dist/voussoir-overlays.esm.js",
       "default": "./dist/voussoir-overlays.cjs.js"
     },

--- a/design-system/packages/picker/package.json
+++ b/design-system/packages/picker/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-picker.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-picker.cjs.js",
       "module": "./dist/voussoir-picker.esm.js",
       "default": "./dist/voussoir-picker.cjs.js"
     },

--- a/design-system/packages/progress/package.json
+++ b/design-system/packages/progress/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-progress.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-progress.cjs.js",
       "module": "./dist/voussoir-progress.esm.js",
       "default": "./dist/voussoir-progress.cjs.js"
     },

--- a/design-system/packages/radio/package.json
+++ b/design-system/packages/radio/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-radio.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-radio.cjs.js",
       "module": "./dist/voussoir-radio.esm.js",
       "default": "./dist/voussoir-radio.cjs.js"
     },

--- a/design-system/packages/search-field/package.json
+++ b/design-system/packages/search-field/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-search-field.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-search-field.cjs.js",
       "module": "./dist/voussoir-search-field.esm.js",
       "default": "./dist/voussoir-search-field.cjs.js"
     },

--- a/design-system/packages/slots/package.json
+++ b/design-system/packages/slots/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-slots.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-slots.cjs.js",
       "module": "./dist/voussoir-slots.esm.js",
       "default": "./dist/voussoir-slots.cjs.js"
     },

--- a/design-system/packages/ssr/package.json
+++ b/design-system/packages/ssr/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-ssr.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-ssr.cjs.js",
       "module": "./dist/voussoir-ssr.esm.js",
       "default": "./dist/voussoir-ssr.cjs.js"
     },

--- a/design-system/packages/style/package.json
+++ b/design-system/packages/style/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-style.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-style.cjs.js",
       "module": "./dist/voussoir-style.esm.js",
       "default": "./dist/voussoir-style.cjs.js"
     },

--- a/design-system/packages/switch/package.json
+++ b/design-system/packages/switch/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-switch.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-switch.cjs.js",
       "module": "./dist/voussoir-switch.esm.js",
       "default": "./dist/voussoir-switch.cjs.js"
     },

--- a/design-system/packages/table/package.json
+++ b/design-system/packages/table/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-table.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-table.cjs.js",
       "module": "./dist/voussoir-table.esm.js",
       "default": "./dist/voussoir-table.cjs.js"
     },

--- a/design-system/packages/tabs/package.json
+++ b/design-system/packages/tabs/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-tabs.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-tabs.cjs.js",
       "module": "./dist/voussoir-tabs.esm.js",
       "default": "./dist/voussoir-tabs.cjs.js"
     },

--- a/design-system/packages/test-utils/package.json
+++ b/design-system/packages/test-utils/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-test-utils.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-test-utils.cjs.js",
       "module": "./dist/voussoir-test-utils.esm.js",
       "default": "./dist/voussoir-test-utils.cjs.js"
     },

--- a/design-system/packages/text-field/package.json
+++ b/design-system/packages/text-field/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-text-field.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-text-field.cjs.js",
       "module": "./dist/voussoir-text-field.esm.js",
       "default": "./dist/voussoir-text-field.cjs.js"
     },

--- a/design-system/packages/toast/package.json
+++ b/design-system/packages/toast/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-toast.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-toast.cjs.js",
       "module": "./dist/voussoir-toast.esm.js",
       "default": "./dist/voussoir-toast.cjs.js"
     },

--- a/design-system/packages/tooltip/package.json
+++ b/design-system/packages/tooltip/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-tooltip.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-tooltip.cjs.js",
       "module": "./dist/voussoir-tooltip.esm.js",
       "default": "./dist/voussoir-tooltip.cjs.js"
     },

--- a/design-system/packages/types/package.json
+++ b/design-system/packages/types/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-types.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-types.cjs.js",
       "module": "./dist/voussoir-types.esm.js",
       "default": "./dist/voussoir-types.cjs.js"
     },

--- a/design-system/packages/typography/package.json
+++ b/design-system/packages/typography/package.json
@@ -7,6 +7,7 @@
   "module": "dist/voussoir-typography.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-typography.cjs.js",
       "module": "./dist/voussoir-typography.esm.js",
       "default": "./dist/voussoir-typography.cjs.js"
     },

--- a/design-system/packages/utils/package.json
+++ b/design-system/packages/utils/package.json
@@ -7,10 +7,12 @@
   "module": "dist/voussoir-utils.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/voussoir-utils.cjs.js",
       "module": "./dist/voussoir-utils.esm.js",
       "default": "./dist/voussoir-utils.cjs.js"
     },
     "./ts": {
+      "types": "./ts/dist/voussoir-utils-ts.cjs.js",
       "module": "./ts/dist/voussoir-utils-ts.esm.js",
       "default": "./ts/dist/voussoir-utils-ts.cjs.js"
     },

--- a/keystatic/app/test/page.tsx
+++ b/keystatic/app/test/page.tsx
@@ -2,37 +2,29 @@
 import { createReader } from '@keystatic/core/reader';
 import localConfig from '../../local-config';
 
+function time() {
+  const start = performance.now();
+  return () => {
+    const end = performance.now();
+    return end - start;
+  };
+}
+
 export default async function Page() {
   const reader = createReader('../packages/keystatic/test-data', localConfig);
-  const slugs = await reader.collections.posts.list();
+  const endFirst = time();
+  const entries = await reader.collections.posts.all();
+  const firstTime = endFirst();
+  const endSecond = time();
+  await reader.collections.posts.all();
+  const secondTime = endSecond();
   return (
     <div>
-      <ul>
-        {slugs.map(slug => (
-          <li key={slug}>{slug}</li>
-        ))}
-      </ul>
-      {await Promise.all(
-        slugs.map(async slug => {
-          const item = await reader.collections.posts.read(slug);
-          if (!item) return null;
-          return (
-            <div key={slug}>
-              <pre>
-                {JSON.stringify(
-                  {
-                    title: item.title,
-                    authors: item.authors.map(x => x.name),
-                    content: await item.content(),
-                  },
-                  null,
-                  2
-                )}
-              </pre>
-            </div>
-          );
-        })
-      )}
+      <div>
+        <p>first: {firstTime}</p>
+        <p>second: {secondTime}</p>
+      </div>
+      <pre>{JSON.stringify(entries, null, 2)}</pre>
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@changesets/changelog-github": "^0.4.5",
     "@changesets/cli": "^2.23.0",
     "@manypkg/cli": "^0.19.1",
-    "@preconstruct/cli": "^2.5.0",
+    "@preconstruct/cli": "^2.6.3",
     "@testing-library/dom": "^8.20.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
@@ -75,6 +75,9 @@
       "design-system/packages/*",
       "packages/*"
     ],
-    "exports": true
+    "exports": true,
+    "___experimentalFlags_WILL_CHANGE_IN_PATCH": {
+      "importsConditions": true
+    }
   }
 }

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -9,14 +9,17 @@
   },
   "exports": {
     "./ui": {
+      "types": "./ui/dist/keystatic-astro-ui.cjs.js",
       "module": "./ui/dist/keystatic-astro-ui.esm.js",
       "default": "./ui/dist/keystatic-astro-ui.cjs.js"
     },
     "./api": {
+      "types": "./api/dist/keystatic-astro-api.cjs.js",
       "module": "./api/dist/keystatic-astro-api.esm.js",
       "default": "./api/dist/keystatic-astro-api.cjs.js"
     },
     ".": {
+      "types": "./dist/keystatic-astro.cjs.js",
       "module": "./dist/keystatic-astro.esm.js",
       "default": "./dist/keystatic-astro.cjs.js"
     },

--- a/packages/keystatic/package.json
+++ b/packages/keystatic/package.json
@@ -9,28 +9,58 @@
   },
   "exports": {
     "./ui": {
+      "types": "./ui/dist/keystatic-core-ui.cjs.js",
+      "react-server": {
+        "module": "./ui/dist/keystatic-core-ui.react-server.esm.js",
+        "default": "./ui/dist/keystatic-core-ui.react-server.cjs.js"
+      },
       "module": "./ui/dist/keystatic-core-ui.esm.js",
       "default": "./ui/dist/keystatic-core-ui.cjs.js"
     },
     ".": {
+      "types": "./dist/keystatic-core.cjs.js",
+      "react-server": {
+        "module": "./dist/keystatic-core.react-server.esm.js",
+        "default": "./dist/keystatic-core.react-server.cjs.js"
+      },
       "module": "./dist/keystatic-core.esm.js",
       "default": "./dist/keystatic-core.cjs.js"
     },
-    "./reader": {
-      "module": "./reader/dist/keystatic-core-reader.esm.js",
-      "default": "./reader/dist/keystatic-core-reader.cjs.js"
-    },
     "./api/utils": {
+      "types": "./api/utils/dist/keystatic-core-api-utils.cjs.js",
+      "react-server": {
+        "module": "./api/utils/dist/keystatic-core-api-utils.react-server.esm.js",
+        "default": "./api/utils/dist/keystatic-core-api-utils.react-server.cjs.js"
+      },
       "module": "./api/utils/dist/keystatic-core-api-utils.esm.js",
       "default": "./api/utils/dist/keystatic-core-api-utils.cjs.js"
     },
     "./renderer": {
+      "types": "./renderer/dist/keystatic-core-renderer.cjs.js",
+      "react-server": {
+        "module": "./renderer/dist/keystatic-core-renderer.react-server.esm.js",
+        "default": "./renderer/dist/keystatic-core-renderer.react-server.cjs.js"
+      },
       "module": "./renderer/dist/keystatic-core-renderer.esm.js",
       "default": "./renderer/dist/keystatic-core-renderer.cjs.js"
     },
     "./api/generic": {
+      "types": "./api/generic/dist/keystatic-core-api-generic.cjs.js",
+      "react-server": {
+        "module": "./api/generic/dist/keystatic-core-api-generic.react-server.esm.js",
+        "default": "./api/generic/dist/keystatic-core-api-generic.react-server.cjs.js"
+      },
       "module": "./api/generic/dist/keystatic-core-api-generic.esm.js",
       "default": "./api/generic/dist/keystatic-core-api-generic.cjs.js"
+    },
+    "./reader": {
+      "types": "./reader/dist/keystatic-core-reader.cjs.js",
+      "react-server": {
+        "module": "./reader/dist/keystatic-core-reader.react-server.esm.js",
+        "default": "./reader/dist/keystatic-core-reader.react-server.cjs.js"
+      },
+      "module": "./reader/dist/keystatic-core-reader.esm.js",
+      "default": "./reader/dist/keystatic-core-reader.cjs.js"
     },
     "./package.json": "./package.json"
   },
@@ -166,7 +196,7 @@
       "index.ts",
       "api/generic.ts",
       "api/utils.ts",
-      "reader.ts",
+      "reader/index.ts",
       "renderer.tsx",
       "ui.tsx"
     ]
@@ -177,6 +207,12 @@
     "addTypename": false,
     "scalars": {
       "GitObjectID": "string"
+    }
+  },
+  "imports": {
+    "#react-cache-in-react-server": {
+      "react-server": "./src/reader/react-server-cache.ts",
+      "default": "./src/reader/noop-cache.ts"
     }
   }
 }

--- a/packages/keystatic/src/reader/index.ts
+++ b/packages/keystatic/src/reader/index.ts
@@ -1,4 +1,4 @@
-import { Collection, Config, Glob, Singleton } from './config';
+import { Collection, Config, Glob, Singleton } from '../config';
 import {
   ComponentSchema,
   fields,
@@ -6,7 +6,7 @@ import {
   SlugFormField,
   ValueForReading,
   ValueForReadingDeep,
-} from './form/api';
+} from '../form/api';
 import fs from 'fs/promises';
 import nodePath from 'path';
 import {
@@ -19,13 +19,14 @@ import {
   getSingletonFormat,
   getSingletonPath,
   getSlugGlobForCollection,
-} from './app/path-utils';
-import { parseProps } from './form/parse-props';
-import { loadDataFile } from './app/required-files';
-import { getValueAtPropPath } from './form/props-value';
+} from '../app/path-utils';
+import { parseProps } from '../form/parse-props';
+import { loadDataFile } from '../app/required-files';
+import { getValueAtPropPath } from '../form/props-value';
 import { Dirent } from 'fs';
-import { ReadonlyPropPath } from './form/fields/document/DocumentEditor/component-blocks/utils';
-import { formatFormDataError } from './form/errors';
+import { ReadonlyPropPath } from '../form/fields/document/DocumentEditor/component-blocks/utils';
+import { formatFormDataError } from '../form/errors';
+import { cache } from '#react-cache-in-react-server';
 
 type EntryReaderOpts = { resolveLinkedFiles?: boolean };
 
@@ -220,7 +221,7 @@ async function getAllEntries(
   ).flat();
 }
 
-async function listCollection(
+const listCollection = cache(async function listCollection(
   repoPath: string,
   collectionPath: string,
   glob: Glob,
@@ -269,7 +270,7 @@ async function listCollection(
       })
     )
   ).flat();
-}
+});
 
 function collectionReader(
   repoPath: string,
@@ -328,7 +329,7 @@ function collectionReader(
   };
 }
 
-async function readItem(
+const readItem = cache(async function readItem(
   rootSchema: ComponentSchema,
   formatInfo: FormatInfo,
   itemDir: string,
@@ -416,7 +417,7 @@ async function readItem(
   }
 
   return validated;
-}
+});
 
 function singletonReader(
   repoPath: string,

--- a/packages/keystatic/src/reader/noop-cache.ts
+++ b/packages/keystatic/src/reader/noop-cache.ts
@@ -1,0 +1,3 @@
+export function cache<Func extends (...args: any[]) => any>(func: Func): Func {
+  return func;
+}

--- a/packages/keystatic/src/reader/react-server-cache.ts
+++ b/packages/keystatic/src/reader/react-server-cache.ts
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { cache as noopCache } from './noop-cache';
+
+// we conditionally using it since it's not actually in stable react releases yet
+// (though it should be unnecessary since this file is only imported in react-server environments anyway)
+// it's a function because some tools try to be smart with accessing things on namespace imports
+// and error at build time if you try to read an export that doesn't exist on a namespace object
+function getCache(react: any): typeof noopCache {
+  return react.cache ?? noopCache;
+}
+
+export const cache: typeof noopCache = getCache(React);

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -9,18 +9,22 @@
   },
   "exports": {
     "./api": {
+      "types": "./api/dist/keystatic-next-api.cjs.js",
       "module": "./api/dist/keystatic-next-api.esm.js",
       "default": "./api/dist/keystatic-next-api.cjs.js"
     },
     "./ui/app": {
+      "types": "./ui/app/dist/keystatic-next-ui-app.cjs.js",
       "module": "./ui/app/dist/keystatic-next-ui-app.esm.js",
       "default": "./ui/app/dist/keystatic-next-ui-app.cjs.js"
     },
     "./ui/pages": {
+      "types": "./ui/pages/dist/keystatic-next-ui-pages.cjs.js",
       "module": "./ui/pages/dist/keystatic-next-ui-pages.esm.js",
       "default": "./ui/pages/dist/keystatic-next-ui-pages.cjs.js"
     },
     "./reader-refresh": {
+      "types": "./reader-refresh/dist/keystatic-next-reader-refresh.cjs.js",
       "module": "./reader-refresh/dist/keystatic-next-reader-refresh.esm.js",
       "default": "./reader-refresh/dist/keystatic-next-reader-refresh.cjs.js"
     },

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -9,10 +9,12 @@
   },
   "exports": {
     "./ui": {
+      "types": "./ui/dist/keystatic-remix-ui.cjs.js",
       "module": "./ui/dist/keystatic-remix-ui.esm.js",
       "default": "./ui/dist/keystatic-remix-ui.cjs.js"
     },
     "./api": {
+      "types": "./api/dist/keystatic-remix-api.cjs.js",
       "module": "./api/dist/keystatic-remix-api.esm.js",
       "default": "./api/dist/keystatic-remix-api.cjs.js"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
       '@changesets/changelog-github': ^0.4.5
       '@changesets/cli': ^2.23.0
       '@manypkg/cli': ^0.19.1
-      '@preconstruct/cli': ^2.5.0
+      '@preconstruct/cli': ^2.6.3
       '@testing-library/dom': ^8.20.0
       '@testing-library/jest-dom': ^5.16.5
       '@testing-library/react': ^13.4.0
@@ -48,7 +48,7 @@ importers:
       '@changesets/changelog-github': 0.4.8
       '@changesets/cli': 2.26.0
       '@manypkg/cli': 0.19.2
-      '@preconstruct/cli': 2.5.0
+      '@preconstruct/cli': 2.6.3
       '@testing-library/dom': 8.20.0
       '@testing-library/jest-dom': 5.16.5
       '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y
@@ -5894,8 +5894,8 @@ packages:
       webpack: 5.75.0_esbuild@0.14.54
     dev: true
 
-  /@preconstruct/cli/2.5.0:
-    resolution: {integrity: sha512-EIpiKdSS2KD3hvSKMftJB8jY36YNYoe1+v2u3UcLY0kutqSpxfh/kBKaYmLvXmBQhBo21ccYARB8itwFLOVKjw==}
+  /@preconstruct/cli/2.6.3:
+    resolution: {integrity: sha512-mdS6UrCyL9oFe/hXtMNnBWayU/RRxqDztAnEX8YAQXNBhPbB2X8mF5J5Ob7+WRqeHcYNCRODx+qWGK0d7+6i3A==}
     hasBin: true
     dependencies:
       '@babel/code-frame': 7.18.6
@@ -5935,6 +5935,7 @@ packages:
       semver: 7.3.8
       terser: 5.16.9
       v8-compile-cache: 2.3.0
+      zod: 3.21.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -12378,7 +12379,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.6
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -12402,7 +12403,7 @@ packages:
       minipass-pipeline: 1.2.4
       mkdirp: 1.0.4
       p-map: 4.0.0
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 3.0.2
       ssri: 8.0.1
       tar: 6.1.13
@@ -21104,13 +21105,15 @@ packages:
     engines: {node: '>= 0.6.0'}
     dev: true
 
-  /promise-inflight/1.0.1:
+  /promise-inflight/1.0.1_bluebird@3.7.2:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
     peerDependencies:
       bluebird: '*'
     peerDependenciesMeta:
       bluebird:
         optional: true
+    dependencies:
+      bluebird: 3.7.2
     dev: true
 
   /promise.allsettled/1.0.6:


### PR DESCRIPTION
This is so that you can for example load the same entry in two different server component subtrees and have it only actually load the entry once.

To make it happen only in server component environments, this is using the new `importsConditions` experimental flag in Preconstruct.