### PR TITLE
Bugfixes Astro guide 

### DIFF
--- a/docs/src/content/pages/installation-astro.mdoc
+++ b/docs/src/content/pages/installation-astro.mdoc
@@ -209,6 +209,7 @@ Inside of the site's homepage, let's use that API to get the `headline` field va
 ---
 // src/pages/index.astro
 import { createReader } from '@keystatic/core/reader'
+import keystaticConfig from '../../keystatic.config'
 
 // 1. Create a reader
 const reader = createReader(process.cwd(), keystaticConfig)

--- a/docs/src/content/pages/installation-astro.mdoc
+++ b/docs/src/content/pages/installation-astro.mdoc
@@ -100,6 +100,12 @@ import { Keystatic } from '../../../keystatic.page'
 <Keystatic client:only />
 ```
 
+Next, start up Astro's integrated server:
+
+```
+npm run dev -- --host
+```
+
 Great! So now, we should be able to visit the `/keystatic` router in the browser.
 
 **Oh no.**

--- a/docs/src/content/pages/installation-astro.mdoc
+++ b/docs/src/content/pages/installation-astro.mdoc
@@ -103,7 +103,7 @@ import { Keystatic } from '../../../keystatic.page'
 Next, start up Astro's integrated server:
 
 ```
-npm run dev -- --host
+npm run dev
 ```
 
 Great! So now, we should be able to visit the `/keystatic` router in the browser.


### PR DESCRIPTION
Without Astro's ´-- --host´flag keystatic won't display at localhost:3000/keystatic and throws multiple react errors. Using the flag fixes the problem.

Without importing keystaticConfig in the ´Displaying Keystatic content on the frontend ´section you get a reference error as keystaticConfig is undefined in the file.