### PR TITLE
Add the frontmatter triple ticks in Astro guide import

### DIFF
--- a/docs/src/content/pages/installation-astro.mdoc
+++ b/docs/src/content/pages/installation-astro.mdoc
@@ -94,8 +94,10 @@ export const Keystatic = makePage(keystaticConfig)
 Now, we can import that file in our `keystatic/[...params].astro` page, and mount the component on the clientside only:
 
 ```jsx
+---
 // src/pages/keystatic/[...params].astro
 import { Keystatic } from '../../../keystatic.page'
+---
 
 <Keystatic client:only />
 ```


### PR DESCRIPTION
One of the code examples (docs) in the Astro integration guide is missing the frontmatter backticks, making it invalid code in a `.astro` file.