### PR TITLE
Add prerender export statement on Astro Integration docs

### DIFF
--- a/docs/src/content/pages/installation-astro.mdoc
+++ b/docs/src/content/pages/installation-astro.mdoc
@@ -218,6 +218,9 @@ const reader = createReader(process.cwd(), keystaticConfig)
 
 // 2. Read the "Homepage" singleton
 const homepageData = await reader.singletons.homepage.read()
+
+// 3. Statically generate this page on build time
+export const prerender = true
 ---
 ```
 


### PR DESCRIPTION
Integration :
Astro v2.6.3

Deployment :
Vercel + Astro Vercel Adapter

Keystatic storage :
Github

Expect :
Display contents generated by Keystatic on Astro pages

Current result :
Content not displayed on my production site

Description :
I am following [Keystatic + Astro Integration Guide](https://keystatic.com/docs/installation-astro) on fresh project and the basic functionality works fine especially in my local.
Have created a Homepage singleton and insert some text value on it and generated `/content` folder in my project.
But when deployed to Vercel then checking the production site, the Keystatic content which is `{homepageData.headline}` is not shown as in local one.

Possible solution :
On this documentation section [Displaying Keystatic content on the frontend](https://keystatic.com/docs/installation-astro#displaying-keystatic-content-on-the-frontend)
We might need to add `prerender` export statement based on [Astro SSR Docs](https://docs.astro.build/en/guides/server-side-rendering/#enabling-ssr-in-your-project) and  [keystatic-template-astro](https://github.com/Thinkmill/keystatic-template-astro/blob/f897f22f6e6f159aea16251b3976a671ec86470c/src/pages/index.astro#L8) example

So, instead of:

```javascript
---
// src/pages/index.astro
import { createReader } from '@keystatic/core/reader'
import keystaticConfig from '../../keystatic.config'

// 1. Create a reader
const reader = createReader(process.cwd(), keystaticConfig)

// 2. Read the "Homepage" singleton
const homepageData = await reader.singletons.homepage.read()
---
```


We may need to add that export statement too like this:

```javascript
---
// src/pages/index.astro
import { createReader } from '@keystatic/core/reader'
import keystaticConfig from '../../keystatic.config'

// 1. Create a reader
const reader = createReader(process.cwd(), keystaticConfig)

// 2. Read the "Homepage" singleton
const homepageData = await reader.singletons.homepage.read()

// 3. Statically generate this page on build time
export const prerender = true
---
```

In my case after adding this, now the Keystatic generated contents can be shown correctly in my production site (index.astro) page.