### PR TITLE
Experimental new editor

### DIFF
--- a/.changeset/early-goats-search.md
+++ b/.changeset/early-goats-search.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Add experimental new editor for testing

--- a/.changeset/silent-glasses-judge.md
+++ b/.changeset/silent-glasses-judge.md
@@ -1,0 +1,5 @@
+---
+'@voussoir/overlays': patch
+---
+
+Render non-elements inside `OpenTransition` instead of rendering null

--- a/design-system/packages/overlays/src/OpenTransition.tsx
+++ b/design-system/packages/overlays/src/OpenTransition.tsx
@@ -12,8 +12,10 @@ export function OpenTransition(props: OpenTransitionProps) {
   return (
     <Transition timeout={{ enter: 0, exit: 320 }} {...props}>
       {state =>
-        Children.map(children, child =>
-          cloneValidElement(child, { isOpen: state === 'entered' })
+        Children.map(
+          children,
+          child =>
+            cloneValidElement(child, { isOpen: state === 'entered' }) ?? child
         )
       }
     </Transition>

--- a/keystatic/local-config.tsx
+++ b/keystatic/local-config.tsx
@@ -6,6 +6,7 @@ import {
   component,
   NotEditable,
 } from '@keystatic/core';
+import { __experimental_markdoc_field } from '@keystatic/core/form/fields/markdoc';
 import { NoteToolbar, Note } from './note';
 
 const description = 'Some description';
@@ -321,6 +322,7 @@ export default config({
           description,
           collection: 'posts',
         }),
+        markdoc: __experimental_markdoc_field({ label: 'Markdoc', config: {} }),
       },
     }),
   },

--- a/keystatic/tsconfig.json
+++ b/keystatic/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "esnext",
+    "types": ["node", "jest"]
+  },
+  "include": ["**/*"],
+  "exclude": ["**/dist/**/*", "**/node_modules/**/*"]
+}

--- a/packages/keystatic/form/fields/markdoc/package.json
+++ b/packages/keystatic/form/fields/markdoc/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/keystatic-core-form-fields-markdoc.cjs.js",
+  "module": "dist/keystatic-core-form-fields-markdoc.esm.js"
+}

--- a/packages/keystatic/jest-setup.ts
+++ b/packages/keystatic/jest-setup.ts
@@ -1,3 +1,5 @@
+import '@testing-library/jest-dom';
+
 import { TextDecoder, TextEncoder } from 'util';
 
 // not sure why these aren't in jest's jsdom environment?

--- a/packages/keystatic/package.json
+++ b/packages/keystatic/package.json
@@ -62,6 +62,15 @@
       "module": "./reader/dist/keystatic-core-reader.esm.js",
       "default": "./reader/dist/keystatic-core-reader.cjs.js"
     },
+    "./form/fields/markdoc": {
+      "types": "./form/fields/markdoc/dist/keystatic-core-form-fields-markdoc.cjs.js",
+      "react-server": {
+        "module": "./form/fields/markdoc/dist/keystatic-core-form-fields-markdoc.react-server.esm.js",
+        "default": "./form/fields/markdoc/dist/keystatic-core-form-fields-markdoc.react-server.cjs.js"
+      },
+      "module": "./form/fields/markdoc/dist/keystatic-core-form-fields-markdoc.esm.js",
+      "default": "./form/fields/markdoc/dist/keystatic-core-form-fields-markdoc.cjs.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/keystatic-core.cjs.js",
@@ -71,7 +80,8 @@
     "api",
     "reader",
     "renderer",
-    "ui"
+    "ui",
+    "form"
   ],
   "scripts": {
     "setup": "ts-gql build && tsx scripts/l10n.ts && tsx scripts/build-prism.ts",
@@ -84,21 +94,26 @@
     "@braintree/sanitize-url": "^6.0.2",
     "@emotion/css": "^11.9.0",
     "@emotion/weak-memoize": "^0.3.0",
+    "@floating-ui/react": "^0.24.0",
     "@hapi/iron": "^7.0.0",
     "@markdoc/markdoc": "^0.3.0",
     "@react-aria/focus": "^3.12.1",
     "@react-aria/i18n": "^3.7.1",
     "@react-aria/interactions": "^3.15.1",
     "@react-aria/overlays": "^3.12.0",
+    "@react-aria/selection": "^3.12.0",
     "@react-aria/utils": "^3.17.0",
     "@react-aria/visually-hidden": "^3.6.1",
     "@react-stately/collections": "^3.5.0",
     "@react-stately/list": "^3.6.0",
     "@react-stately/overlays": "^3.4.3",
+    "@react-stately/utils": "^3.5.1",
+    "@react-types/shared": "^3.18.0",
     "@sindresorhus/slugify": "^1.1.2",
     "@ts-gql/tag": "^0.7.0",
     "@types/node": "16.11.13",
     "@types/react": "^18.2.8",
+    "@types/react-dom": "^18.0.11",
     "@urql/core": "^4.0.4",
     "@urql/exchange-auth": "^2.1.0",
     "@urql/exchange-graphcache": "^6.0.1",
@@ -142,6 +157,7 @@
     "apply-ref": "^1.0.0",
     "cookie": "^0.5.0",
     "emery": "^1.4.1",
+    "escape-string-regexp": "^4.0.0",
     "fast-deep-equal": "^3.1.3",
     "graphql": "^16.6.0",
     "ignore": "^5.2.4",
@@ -159,6 +175,13 @@
     "minimatch": "^7.1.0",
     "pretty-format": "^29.0.1",
     "prismjs": "^1.29.0",
+    "prosemirror-commands": "^1.5.1",
+    "prosemirror-history": "^1.3.0",
+    "prosemirror-keymap": "^1.2.1",
+    "prosemirror-model": "^1.19.0",
+    "prosemirror-state": "^1.4.2",
+    "prosemirror-transform": "^1.7.1",
+    "prosemirror-view": "^1.30.2",
     "scroll-into-view-if-needed": "^3.0.3",
     "slate": "^0.91.4",
     "slate-history": "^0.86.0",
@@ -168,6 +191,7 @@
     "zod": "^3.20.2"
   },
   "devDependencies": {
+    "@testing-library/user-event": "^14.4.3",
     "@ts-gql/compiler": "^0.16.1",
     "@ts-gql/eslint-plugin": "^0.8.5",
     "@ts-gql/next": "^17.0.0",
@@ -183,6 +207,7 @@
     "outdent": "^0.8.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-element-to-jsx-string": "^15.0.0",
     "signal-exit": "^3.0.7",
     "tsx": "^3.8.0",
     "typescript": "^5.1.3"
@@ -198,7 +223,8 @@
       "api/utils.ts",
       "reader/index.ts",
       "renderer.tsx",
-      "ui.tsx"
+      "ui.tsx",
+      "form/fields/markdoc/index.tsx"
     ]
   },
   "ts-gql": {

--- a/packages/keystatic/src/form/fields/markdoc/editor/Toolbar.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/Toolbar.tsx
@@ -1,0 +1,515 @@
+import { ReactElement, ReactNode, useMemo } from 'react';
+
+import { ActionGroup, Item } from '@voussoir/action-group';
+import { ActionButton } from '@voussoir/button';
+import { plusIcon } from '@voussoir/icon/icons/plusIcon';
+import { chevronDownIcon } from '@voussoir/icon/icons/chevronDownIcon';
+import { codeIcon } from '@voussoir/icon/icons/codeIcon';
+import { boldIcon } from '@voussoir/icon/icons/boldIcon';
+import { removeFormattingIcon } from '@voussoir/icon/icons/removeFormattingIcon';
+import { typeIcon } from '@voussoir/icon/icons/typeIcon';
+import { italicIcon } from '@voussoir/icon/icons/italicIcon';
+import { strikethroughIcon } from '@voussoir/icon/icons/strikethroughIcon';
+import { Icon } from '@voussoir/icon';
+import { Flex } from '@voussoir/layout';
+import { MenuTrigger, Menu } from '@voussoir/menu';
+import { css, tokenSchema } from '@voussoir/style';
+import { Text, Kbd } from '@voussoir/typography';
+import { Tooltip, TooltipTrigger } from '@voussoir/tooltip';
+
+// import { ToolbarSeparator } from './primitives';
+import { Picker } from '@voussoir/picker';
+// import { tableIcon } from '@voussoir/icon/icons/tableIcon';
+import { Command, EditorState, TextSelection } from 'prosemirror-state';
+import {
+  useEditorDispatchCommand,
+  useEditorSchema,
+  useEditorState,
+} from './editor-view';
+import { minusIcon } from '@voussoir/icon/icons/minusIcon';
+import { setBlockType, toggleMark, wrapIn } from 'prosemirror-commands';
+import { MarkType, NodeType } from 'prosemirror-model';
+import { quoteIcon } from '@voussoir/icon/icons/quoteIcon';
+import { listIcon } from '@voussoir/icon/icons/listIcon';
+import { listOrderedIcon } from '@voussoir/icon/icons/listOrderedIcon';
+import { toggleList } from './lists';
+import { insertNode, toggleCodeBlock } from './commands/misc';
+
+function EditorToolbarButton(props: {
+  children: ReactNode;
+  'aria-label': string;
+  isSelected?: (editorState: EditorState) => boolean;
+  isDisabled?: (editorState: EditorState) => boolean;
+  command: Command;
+}) {
+  const state = useEditorState();
+  const runCommand = useEditorDispatchCommand();
+  const isSelected = props.isSelected?.(state);
+  const isDisabled = !props.command(state) || props.isDisabled?.(state);
+  return useMemo(
+    () => (
+      <ActionButton
+        prominence="low"
+        isSelected={isSelected}
+        isDisabled={isDisabled}
+        onPress={() => {
+          runCommand(props.command);
+        }}
+        aria-label={props['aria-label']}
+        aria-pressed={isSelected}
+      >
+        {props.children}
+      </ActionButton>
+    ),
+    [isDisabled, isSelected, props, runCommand]
+  );
+}
+
+// export const tableButton = (
+//   <TooltipTrigger>
+//     <EditorToolbarButton command={() => {}}>
+//       <Icon src={tableIcon} />
+//     </EditorToolbarButton>
+//     <TableButton />
+//     <Tooltip>
+//       <Text>Table</Text>
+//     </Tooltip>
+//   </TooltipTrigger>
+// );
+
+export function Toolbar() {
+  const { nodes } = useEditorSchema();
+  return (
+    <ToolbarContainer>
+      <ToolbarScrollArea>
+        <HeadingMenu headingType={nodes.heading} />
+        <InlineMarks />
+        <ListButtons />
+        <ToolbarGroup>
+          <TooltipTrigger>
+            <EditorToolbarButton
+              command={insertNode(nodes.divider)}
+              aria-label="Divider"
+            >
+              <Icon src={minusIcon} />
+            </EditorToolbarButton>
+            <Tooltip>
+              <Text>Divider</Text>
+              <Kbd>---</Kbd>
+            </Tooltip>
+          </TooltipTrigger>
+          <TooltipTrigger>
+            <EditorToolbarButton
+              aria-label="Quote"
+              command={wrapIn(nodes.blockquote)}
+            >
+              <Icon src={quoteIcon} />
+            </EditorToolbarButton>
+            <Tooltip>
+              <Text>Quote</Text>
+              <Kbd>{'>⎵'}</Kbd>
+            </Tooltip>
+          </TooltipTrigger>
+          <TooltipTrigger>
+            <EditorToolbarButton
+              aria-label="Code block"
+              command={toggleCodeBlock(nodes.code_block, nodes.paragraph)}
+              isSelected={(state: EditorState) => {
+                let hasCodeBlock = false;
+                for (const range of state.selection.ranges) {
+                  state.doc.nodesBetween(
+                    range.$from.pos,
+                    range.$to.pos,
+                    node => {
+                      if (node.type === nodes.code_block) {
+                        hasCodeBlock = true;
+                      }
+                    }
+                  );
+                  if (hasCodeBlock) break;
+                }
+                return hasCodeBlock;
+              }}
+            >
+              <Icon src={codeIcon} />
+            </EditorToolbarButton>
+            <Tooltip>
+              <Text>Code block</Text>
+              <Kbd>```</Kbd>
+            </Tooltip>
+          </TooltipTrigger>
+        </ToolbarGroup>
+      </ToolbarScrollArea>
+      <InsertBlockMenu />
+    </ToolbarContainer>
+  );
+}
+
+/** Group buttons together that don't fit into an `ActionGroup` semantically. */
+const ToolbarGroup = ({ children }: { children: ReactNode }) => {
+  return <Flex gap="regular">{children}</Flex>;
+};
+
+const ToolbarContainer = ({ children }: { children: ReactNode }) => {
+  return (
+    <Flex
+      minWidth={0}
+      backgroundColor="canvas"
+      borderTopStartRadius="medium"
+      borderTopEndRadius="medium"
+      // NOTE: sticky behavior needs to be kept in sync with the app's header
+      insetTop={`calc(${tokenSchema.size.element.xlarge} - ${tokenSchema.size.border.regular})`}
+      position="sticky"
+      zIndex={2}
+    >
+      {children}
+      <Flex
+        role="presentation" // dividing line
+        borderBottom="muted"
+        position="absolute"
+        insetX="medium"
+        insetBottom={0}
+      />
+    </Flex>
+  );
+};
+
+const ToolbarScrollArea = (props: { children: ReactNode }) => {
+  return (
+    <Flex
+      // borderRadius="regular"
+      // backgroundColor="surfaceSecondary"
+      padding="regular"
+      paddingEnd="medium"
+      gap="large"
+      flex
+      minWidth={0}
+      UNSAFE_className={css({
+        msOverflowStyle: 'none' /* for Internet Explorer, Edge */,
+        scrollbarWidth: 'none' /* for Firefox */,
+        overflowX: 'auto',
+
+        /* for Chrome, Safari, and Opera */
+        '&::-webkit-scrollbar': {
+          display: 'none',
+        },
+      })}
+      {...props}
+    />
+  );
+};
+
+type HeadingState = 'normal' | 1 | 2 | 3 | 4 | 5 | 6;
+const headingMenuVals = new Map<string | number, HeadingState>([
+  ['normal', 'normal'],
+  ['1', 1],
+  ['2', 2],
+  ['3', 3],
+  ['4', 4],
+  ['5', 5],
+  ['6', 6],
+]);
+
+type HeadingItem = { name: string; id: string | number };
+
+function getHeadingMenuState(
+  state: EditorState,
+  headingType: NodeType,
+  paragraphType: NodeType
+): HeadingState | 'disabled' {
+  let activeLevel: HeadingState | 'disabled' | undefined;
+  for (const range of state.selection.ranges) {
+    state.doc.nodesBetween(range.$from.pos, range.$to.pos, node => {
+      if (node.type === headingType) {
+        const level = node.attrs.level;
+        if (activeLevel === undefined) {
+          activeLevel = level;
+        } else if (activeLevel !== level) {
+          activeLevel = 'disabled';
+        }
+      }
+      if (node.type === paragraphType) {
+        if (activeLevel === undefined) {
+          activeLevel = 'normal';
+        } else if (activeLevel !== 'normal') {
+          activeLevel = 'disabled';
+        }
+      }
+    });
+    if (activeLevel === 'disabled') {
+      break;
+    }
+  }
+  return activeLevel ?? 'disabled';
+}
+
+const HeadingMenu = (props: { headingType: NodeType }) => {
+  const { nodes } = useEditorSchema();
+  const items = useMemo(() => {
+    let resolvedItems: HeadingItem[] = [{ name: 'Paragraph', id: 'normal' }];
+    [1, 2, 3, 4, 5, 6].forEach(level => {
+      resolvedItems.push({ name: `Heading ${level}`, id: level.toString() });
+    });
+    return resolvedItems;
+  }, []);
+  const state = useEditorState();
+  const menuState = getHeadingMenuState(
+    state,
+    props.headingType,
+    nodes.paragraph
+  );
+  const runCommand = useEditorDispatchCommand();
+
+  return useMemo(
+    () => (
+      <Picker
+        flexShrink={0}
+        width="scale.1700"
+        prominence="low"
+        aria-label="Text block"
+        items={items}
+        isDisabled={menuState === 'disabled'}
+        selectedKey={menuState === 'disabled' ? 'normal' : menuState.toString()}
+        onSelectionChange={selected => {
+          let key = headingMenuVals.get(selected);
+          if (key === 'normal') {
+            runCommand(setBlockType(nodes.paragraph));
+          } else if (key) {
+            runCommand(
+              setBlockType(props.headingType, {
+                level: parseInt(key as any),
+              })
+            );
+          }
+        }}
+      >
+        {item => <Item key={item.id}>{item.name}</Item>}
+      </Picker>
+    ),
+    [items, menuState, nodes.paragraph, props.headingType, runCommand]
+  );
+};
+
+function InsertBlockMenu() {
+  return (
+    <MenuTrigger align="end">
+      <TooltipTrigger>
+        <ActionButton marginY="regular" marginEnd="medium">
+          <Icon src={plusIcon} />
+          <Icon src={chevronDownIcon} />
+        </ActionButton>
+        <Tooltip>
+          <Text>Insert</Text>
+          <Kbd>/</Kbd>
+        </Tooltip>
+      </TooltipTrigger>
+      <Menu
+        onAction={() => {
+          // insertComponentBlock(editor, componentBlocks, key as string);
+        }}
+        items={[['a', { label: 'something' }]] as const}
+      >
+        {([key, item]) => <Item key={key}>{item.label}</Item>}
+      </Menu>
+    </MenuTrigger>
+  );
+}
+
+const isMarkActive = (markType: MarkType) => (state: EditorState) => {
+  if (state.selection instanceof TextSelection && state.selection.empty) {
+    if (!state.selection.$cursor) return false;
+    return !!markType.isInSet(
+      state.storedMarks || state.selection.$cursor.marks()
+    );
+  }
+  for (const range of state.selection.ranges) {
+    if (state.doc.rangeHasMark(range.$from.pos, range.$to.pos, markType)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+function InlineMarks() {
+  const state = useEditorState();
+  const schema = useEditorSchema();
+  const inlineMarks = useMemo(() => {
+    const marks: {
+      key: string;
+      label: string;
+      icon: ReactElement;
+      shortcut?: string;
+      command: Command;
+      isSelected: (state: EditorState) => boolean;
+    }[] = [];
+    if (schema.marks.bold) {
+      marks.push({
+        key: 'bold',
+        label: 'Bold',
+        icon: boldIcon,
+        shortcut: `B`,
+        command: toggleMark(schema.marks.bold),
+        isSelected: isMarkActive(schema.marks.bold),
+      });
+    }
+
+    if (schema.marks.italic) {
+      marks.push({
+        key: 'italic',
+        label: 'Italic',
+        icon: italicIcon,
+        shortcut: `I`,
+        command: toggleMark(schema.marks.italic),
+        isSelected: isMarkActive(schema.marks.italic),
+      });
+    }
+    if (schema.marks.strikethrough) {
+      marks.push({
+        key: 'strikethrough',
+        label: 'Strikethrough',
+        icon: strikethroughIcon,
+        command: toggleMark(schema.marks.strikethrough),
+        isSelected: isMarkActive(schema.marks.strikethrough),
+      });
+    }
+    if (schema.marks.code) {
+      marks.push({
+        key: 'code',
+        label: 'Code',
+        icon: codeIcon,
+        command: toggleMark(schema.marks.code),
+        isSelected: isMarkActive(schema.marks.code),
+      });
+    }
+
+    marks.push({
+      key: 'clearFormatting',
+      label: 'Clear formatting',
+      icon: removeFormattingIcon,
+      command: () => false,
+      isSelected: () => false,
+    });
+    return marks;
+  }, [schema]);
+  const selectedKeys = useMemoStringified(
+    inlineMarks.filter(val => val.isSelected(state)).map(val => val.key)
+  );
+  const disabledKeys = useMemoStringified(
+    inlineMarks.filter(val => !val.command(state)).map(val => val.key)
+  );
+  const runCommand = useEditorDispatchCommand();
+  return useMemo(() => {
+    return (
+      <ActionGroup
+        UNSAFE_className={css({
+          minWidth: `calc(${tokenSchema.size.element.medium} * 4)`,
+        })}
+        prominence="low"
+        density="compact"
+        buttonLabelBehavior="hide"
+        overflowMode="collapse"
+        summaryIcon={<Icon src={typeIcon} />}
+        items={inlineMarks}
+        selectionMode="multiple"
+        selectedKeys={selectedKeys}
+        disabledKeys={disabledKeys}
+        onAction={key => {
+          const command = inlineMarks.find(mark => mark.key === key)?.command;
+          if (command) {
+            runCommand(command);
+          }
+        }}
+      >
+        {item => {
+          return (
+            <Item key={item.key} textValue={item.label}>
+              <Text>{item.label}</Text>
+              {'shortcut' in item && <Kbd meta>{item.shortcut}</Kbd>}
+              <Icon src={item.icon} />
+            </Item>
+          );
+        }}
+      </ActionGroup>
+    );
+  }, [disabledKeys, inlineMarks, runCommand, selectedKeys]);
+}
+
+function useMemoStringified<T>(value: T): T {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => value, [JSON.stringify(value)]);
+}
+
+// function canInsert(state: EditorState, nodeType: NodeType) {
+//   let $from = state.selection.$from;
+//   for (let d = $from.depth; d >= 0; d--) {
+//     let index = $from.index(d);
+//     if ($from.node(d).canReplaceWith(index, index, nodeType)) return true;
+//   }
+//   return false;
+// }
+
+function ListButtons() {
+  const state = useEditorState();
+  const schema = useEditorSchema();
+  const dispatchCommand = useEditorDispatchCommand();
+
+  const canWrapInOrderedList =
+    !!schema.nodes.ordered_list && toggleList(schema.nodes.ordered_list)(state);
+  const canWrapInUnorderedList =
+    !!schema.nodes.unordered_list &&
+    toggleList(schema.nodes.unordered_list)(state);
+
+  return useMemo(() => {
+    return (
+      <ActionGroup
+        flexShrink={0}
+        aria-label="Lists"
+        selectionMode="single"
+        buttonLabelBehavior="hide"
+        density="compact"
+        prominence="low"
+        disabledKeys={[
+          canWrapInOrderedList && 'ordered',
+          canWrapInUnorderedList && 'unordered',
+        ].filter(removeFalse)}
+        summaryIcon={<Icon src={listIcon} />}
+        selectedKeys={[]}
+        // selectedKeys={selectedKeys}
+        onAction={key => {
+          const format = key as 'ordered' | 'unordered';
+          const type = schema.nodes[`${format}_list`];
+          if (type) {
+            console.log('yes');
+            dispatchCommand(toggleList(type));
+          }
+        }}
+        items={[
+          !!schema.nodes.unordered_list && {
+            label: 'Bullet List',
+            key: 'unordered',
+            shortcut: '-',
+            icon: listIcon,
+          },
+          !!schema.nodes.unordered_list && {
+            label: 'Numbered List',
+            key: 'ordered',
+            shortcut: '1.',
+            icon: listOrderedIcon,
+          },
+        ].filter(removeFalse)}
+      >
+        {item => (
+          <Item textValue={`${item.label} (${item.shortcut})`}>
+            <Icon src={item.icon} />
+            <Text>{item.label}</Text>
+            <Kbd>{item.shortcut}</Kbd>
+          </Item>
+        )}
+      </ActionGroup>
+    );
+  }, [canWrapInOrderedList, canWrapInUnorderedList, dispatchCommand, schema]);
+}
+
+function removeFalse<T>(val: T): val is Exclude<T, false> {
+  return val !== false;
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/attributes/index.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/attributes/index.ts
@@ -1,0 +1,184 @@
+// https://github.com/ProseMirror/prosemirror-gapcursor/blob/bbbee7d483754310f63f3b18d81f5a1da1250234/src/index.ts
+import { keydownHandler, keymap } from 'prosemirror-keymap';
+import {
+  NodeSelection,
+  Plugin,
+  EditorState,
+  Transaction,
+  AllSelection,
+} from 'prosemirror-state';
+import { EditorView, NodeViewConstructor } from 'prosemirror-view';
+
+import { css } from '@voussoir/style';
+import { undo, redo } from 'prosemirror-history';
+import { StepMap } from 'prosemirror-transform';
+import { getAttributeType } from './schema';
+import { selectAll } from 'prosemirror-commands';
+
+export function attributes(): Plugin {
+  return new Plugin({
+    props: {
+      handleKeyDown,
+      nodeViews: {
+        attribute: attributeNodeView,
+      },
+      handleClick(view, pos, event) {
+        if (
+          event.target instanceof HTMLElement &&
+          event.target.dataset.tagName
+        ) {
+          const { state } = view;
+          const $pos = state.doc.resolve(pos);
+          const index = $pos.index(-2);
+          const tagPos = state.doc.resolve(pos).posAtIndex(index, -2);
+          view.dispatch(
+            state.tr.setSelection(NodeSelection.create(state.doc, tagPos))
+          );
+          return true;
+        }
+        return false;
+      },
+    },
+  });
+}
+
+const attributeNodeView: NodeViewConstructor = (node, outerView, getPos) => {
+  const dom = document.createElement('span');
+  dom.className = css({
+    border: '1px black solid',
+    display: 'inline-block',
+    marginInline: 4,
+    '& .ProseMirror': {
+      outline: 'none',
+    },
+  });
+  const attributeKey = document.createElement('span');
+  attributeKey.textContent =
+    node.attrs.key === 'id'
+      ? '#'
+      : node.attrs.key === 'class'
+      ? '.'
+      : `${node.attrs.key}=`;
+  attributeKey.className = css({ paddingInline: 8 });
+  dom.appendChild(attributeKey);
+  const inner = document.createElement('span');
+  inner.className = css({ minWidth: 50, display: 'inline-block' });
+  dom.appendChild(inner);
+
+  const innerView = new EditorView(inner, {
+    state: EditorState.create({
+      doc: node,
+      plugins: [
+        keymap({
+          'Mod-z': () => undo(outerView.state, outerView.dispatch),
+          'Mod-y': () => redo(outerView.state, outerView.dispatch),
+          Escape: () => {
+            outerView.focus();
+            outerView.dispatch(
+              outerView.state.tr.setSelection(
+                NodeSelection.create(outerView.state.doc, getPos()!)
+              )
+            );
+            return true;
+          },
+          'Mod-a': selectAll,
+          Backspace: state => {
+            if (state.selection instanceof AllSelection) {
+              const pos = getPos()!;
+              outerView.dispatch(
+                outerView.state.tr.delete(pos, pos + node.nodeSize)
+              );
+              outerView.focus();
+              return true;
+            }
+            return false;
+          },
+        }),
+      ],
+    }),
+    dispatchTransaction: (tr: Transaction) => {
+      let { state, transactions } = innerView.state.applyTransaction(tr);
+      innerView.updateState(state);
+      if (!tr.getMeta('fromOutside')) {
+        let outerTr = outerView.state.tr,
+          offsetMap = StepMap.offset(getPos()! + 1);
+        for (let i = 0; i < transactions.length; i++) {
+          let steps = transactions[i].steps;
+          for (let j = 0; j < steps.length; j++) {
+            outerTr.step(steps[j].map(offsetMap)!);
+          }
+        }
+        if (outerTr.docChanged) outerView.dispatch(outerTr);
+      }
+    },
+    handleDOMEvents: {
+      mousedown: () => {
+        if (outerView.hasFocus()) innerView?.focus();
+      },
+    },
+  });
+  domNodeToEditorView.set(dom, innerView);
+  return {
+    dom,
+    selectNode() {
+      dom.classList.add('ProseMirror-selectednode');
+    },
+    deselectNode() {
+      dom.classList.remove('ProseMirror-selectednode');
+    },
+    update(newNode) {
+      if (!node.sameMarkup(newNode)) return false;
+      node = newNode;
+      if (innerView) {
+        let { state } = innerView;
+        let start = newNode.content.findDiffStart(state.doc.content);
+        if (start != null) {
+          let { a: endA, b: endB } = newNode.content.findDiffEnd(
+            state.doc.content
+          )!;
+          let overlap = start - Math.min(endA, endB);
+          if (overlap > 0) {
+            endA += overlap;
+            endB += overlap;
+          }
+          innerView.dispatch(
+            state.tr
+              .replace(start, endB, newNode.slice(start, endA))
+              .setMeta('fromOutside', true)
+          );
+        }
+      }
+      return true;
+    },
+    destroy() {
+      innerView.destroy();
+      dom.textContent = '';
+    },
+
+    stopEvent(event) {
+      return innerView.dom.contains(event.target as Node);
+    },
+    ignoreMutation() {
+      return true;
+    },
+  };
+};
+
+const handleKeyDown = keydownHandler({
+  Enter: (state, dispatch, view) => {
+    if (
+      state.selection instanceof NodeSelection &&
+      state.selection.node.type === getAttributeType(state.schema)
+    ) {
+      if (!view) return true;
+      const node = view.nodeDOM(state.selection.$from.pos);
+      if (!node) return true;
+      const editorView = domNodeToEditorView.get(node);
+      editorView?.focus();
+      return true;
+    }
+    return false;
+  },
+});
+
+export const domNodeToEditorView = new WeakMap<Node, EditorView>();

--- a/packages/keystatic/src/form/fields/markdoc/editor/attributes/new-attribute.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/attributes/new-attribute.tsx
@@ -1,0 +1,156 @@
+import { matchSorter } from 'match-sorter';
+import { Command, NodeSelection, Transaction } from 'prosemirror-state';
+import { useMemo } from 'react';
+import {
+  addAutocompleteDecoration,
+  removeAutocompleteDecoration,
+  wrapCommandAfterRemovingAutocompleteDecoration,
+} from '../autocomplete/decoration';
+import {
+  useEditorViewRef,
+  useEditorState,
+  useEditorDispatchCommand,
+} from '../editor-view';
+import { Item } from '../new-primitives';
+import { InputRule } from '../inputrules/inputrules';
+import { useEditorKeydownListener } from '../keydown';
+import { EditorAutocomplete } from '../autocomplete/autocomplete';
+import { ResolvedPos } from 'prosemirror-model';
+import { getAttributeType } from './schema';
+import { getEditorSchema } from '../schema';
+import { globalAttributes } from '@markdoc/markdoc';
+import { domNodeToEditorView } from '.';
+
+type AttributeItem = {
+  key: string;
+  extra: string | undefined;
+  command: Command;
+};
+
+export const attributeMenuInputRule: InputRule = {
+  pattern: /(?:^|\s)%$/,
+  handler(state, _match, _start, end) {
+    return addNewAttributeAutocompleteDecoration(state.tr, end - 1, end);
+  },
+};
+
+function getDeepestAncestorAttributeSchema(pos: ResolvedPos) {
+  for (let depth = pos.depth; depth >= 0; depth--) {
+    const node = pos.node(depth);
+    if (node.type.name === 'paragraph' || node.type.name === 'heading') {
+      return node as typeof node & { type: { name: 'paragraph' | 'heading' } };
+    }
+  }
+}
+
+export function addNewAttributeAutocompleteDecoration(
+  tr: Transaction,
+  from: number,
+  to: number
+): Transaction {
+  return addAutocompleteDecoration(
+    tr,
+    NewAttributeMenu,
+    from,
+    to,
+    /^(?:[a-zA-Z][-_a-zA-Z0-9]*)?$/
+  );
+}
+
+function childRenderer(item: AttributeItem) {
+  return (
+    <Item key={item.key} textValue={item.key}>
+      {item.key}
+    </Item>
+  );
+}
+
+function addAttribute(key: string): Command {
+  return (state, dispatch, view) => {
+    if (dispatch) {
+      const tr = state.tr;
+      tr.insert(
+        state.selection.from,
+        getAttributeType(state.schema).createAndFill({ key })!
+      );
+      tr.setSelection(new NodeSelection(tr.doc.resolve(state.selection.from)));
+      dispatch(tr);
+      Promise.resolve().then(() => {
+        const node = view?.nodeDOM(view?.state.selection.from);
+        if (!node) return;
+        domNodeToEditorView.get(node)?.focus();
+      });
+    }
+    return true;
+  };
+}
+
+function NewAttributeMenu(props: { query: string; from: number; to: number }) {
+  const viewRef = useEditorViewRef();
+  const dispatchCommand = useEditorDispatchCommand();
+  const editorState = useEditorState();
+  const ancestorNodeAllowingAttributes = getDeepestAncestorAttributeSchema(
+    editorState.doc.resolve(props.from)
+  );
+  const options = useMemo(
+    () =>
+      matchSorter(
+        ((): AttributeItem[] => {
+          if (!ancestorNodeAllowingAttributes?.type) return [];
+          const attributes = {
+            ...globalAttributes,
+            ...getEditorSchema(ancestorNodeAllowingAttributes.type.schema)
+              .markdocConfig?.nodes?.[ancestorNodeAllowingAttributes.type.name]
+              ?.attributes,
+          };
+          return Object.keys(attributes).map(key => ({
+            key,
+            extra: key === 'id' ? '#' : key === 'class' ? '.' : undefined,
+            command: addAttribute(key),
+          }));
+        })(),
+        props.query,
+        {
+          keys: ['key', 'extra'],
+        }
+      ),
+    [props.query, ancestorNodeAllowingAttributes?.type]
+  );
+
+  useEditorKeydownListener(event => {
+    if (event.key !== ' ') return false;
+    if (options.length === 1) {
+      dispatchCommand(
+        wrapCommandAfterRemovingAutocompleteDecoration(
+          addAttribute(options[0].key)
+        )
+      );
+      return true;
+    }
+    if (options.length === 0) {
+      viewRef.current?.dispatch(removeAutocompleteDecoration(editorState.tr));
+    }
+    return false;
+  });
+  return (
+    <EditorAutocomplete
+      from={props.from}
+      to={props.to}
+      aria-label="New attribute"
+      items={options}
+      children={childRenderer}
+      onEscape={() => {
+        viewRef.current?.dispatch(removeAutocompleteDecoration(editorState.tr));
+      }}
+      onAction={key => {
+        const option = options.find(option => option.key === key);
+        if (!option) return;
+        dispatchCommand(
+          wrapCommandAfterRemovingAutocompleteDecoration(
+            addAttribute(option.key)
+          )
+        );
+      }}
+    />
+  );
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/attributes/schema.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/attributes/schema.ts
@@ -1,0 +1,117 @@
+import { css } from '@voussoir/style';
+import { EditorNodeSpec } from '../schema';
+import { Schema } from 'prosemirror-model';
+import { weakMemoize } from '../utils';
+
+export const getAttributeType = weakMemoize(function getAttributesType(
+  schema: Schema
+) {
+  for (const node of Object.values(schema.nodes)) {
+    if (node.spec === attributeSchema.attribute) {
+      return node;
+    }
+  }
+  throw new Error('No attributes node found in the schema');
+});
+
+export const attributeSchema = {
+  attribute: {
+    attrs: {
+      key: {},
+    },
+    content: 'attribute_expression',
+    inline: true,
+    atom: true,
+    toDOM(node) {
+      return [
+        'span',
+        { class: css({ border: '1px black solid' }), contenteditable: false },
+        [
+          'span',
+          {
+            'data-attr':
+              node.attrs.key === 'id'
+                ? '#'
+                : node.attrs.key === 'class'
+                ? '.'
+                : `${node.attrs.key}=`,
+            class: css({ content: 'attr(data-attr)' }),
+          },
+        ],
+        [
+          'span',
+          { class: css({ minWidth: 50, width: 50, display: 'inline-block' }) },
+          0,
+        ],
+      ];
+    },
+  },
+  attribute_string: {
+    group: 'attribute_expression',
+    content: 'text*',
+    marks: '',
+    toDOM() {
+      return ['span', { class: css({ color: 'green' }) }, 0];
+    },
+  },
+  attribute_null: {
+    group: 'attribute_expression',
+    toDOM() {
+      return ['span', { class: css({ color: 'lightsteelblue' }) }, 'null'];
+    },
+  },
+  attribute_true: {
+    group: 'attribute_expression',
+    toDOM() {
+      return ['span', { class: css({ color: 'lightsteelblue' }) }, 'true'];
+    },
+  },
+  attribute_false: {
+    group: 'attribute_expression',
+    toDOM() {
+      return ['span', { class: css({ color: 'lightsteelblue' }) }, 'false'];
+    },
+  },
+  attribute_number: {
+    group: 'attribute_expression',
+    content: 'text*',
+    marks: '',
+    toDOM() {
+      return ['span', { class: css({ color: 'lightsteelblue' }) }, 'null'];
+    },
+  },
+  attribute_variable: {
+    group: 'attribute_expression',
+    content: 'text*',
+    marks: '',
+    toDOM() {
+      return [
+        'span',
+        { class: css({ color: 'lightsteelblue' }) },
+        '$',
+        ['span', 0],
+      ];
+    },
+  },
+  attribute_object: {
+    group: 'attribute_expression',
+    content: 'attribute*',
+    marks: '',
+    toDOM() {
+      return [
+        'span',
+        [
+          'span',
+          { class: css({ color: 'green' }), contenteditable: false },
+          '{',
+        ],
+        ['span', 0],
+        [
+          'span',
+          { class: css({ color: 'green' }), contenteditable: false },
+          '}',
+        ],
+      ];
+    },
+  },
+} satisfies Record<string, EditorNodeSpec>;

--- a/packages/keystatic/src/form/fields/markdoc/editor/autocomplete/autocomplete.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/autocomplete/autocomplete.tsx
@@ -1,0 +1,74 @@
+import {
+  EditorListboxProps,
+  EditorPopover,
+  VirtualElement,
+  useEditorListbox,
+} from '../new-primitives';
+import { useMemo, useState } from 'react';
+import {
+  useEditorViewRef,
+  useLayoutEffectWithEditorUpdated,
+} from '../editor-view';
+import { useEditorKeydownListener } from '../keydown';
+
+export function EditorAutocomplete<Item extends object>(
+  props: Omit<EditorListboxProps<Item>, 'listenerRef'> & {
+    from: number;
+    to: number;
+  }
+) {
+  const viewRef = useEditorViewRef();
+  const [referenceElement, setReferenceElement] = useState<VirtualElement>({
+    getBoundingClientRect() {
+      const coords = viewRef.current!.coordsAtPos(props.from, props.to);
+      return {
+        x: coords.left,
+        y: coords.top,
+        width: coords.right - coords.left,
+        height: coords.bottom - coords.top,
+        top: coords.top,
+        right: coords.right,
+        bottom: coords.bottom,
+        left: coords.left,
+      };
+    },
+  });
+  useLayoutEffectWithEditorUpdated(() => {
+    const node = viewRef.current!.domAtPos(props.from).node;
+    const contextElement = node instanceof Element ? node : node.parentElement;
+    setReferenceElement(prevState => {
+      return prevState.contextElement === contextElement
+        ? prevState
+        : {
+            getBoundingClientRect: prevState.getBoundingClientRect,
+            contextElement: contextElement ?? undefined,
+          };
+    });
+  });
+  const listenerRef = useMemo(() => {
+    return {
+      get current() {
+        return viewRef.current?.dom ?? null;
+      },
+    };
+  }, [viewRef]);
+  const { keydownListener, listbox } = useEditorListbox({
+    listenerRef,
+    ...props,
+    UNSAFE_style: { width: 320, ...props.UNSAFE_style },
+  });
+  useEditorKeydownListener(event => {
+    keydownListener(event);
+    return event.defaultPrevented;
+  });
+  return (
+    <EditorPopover
+      reference={referenceElement}
+      placement="bottom-start"
+      adaptToViewport="stretch"
+      minWidth="element.medium"
+    >
+      {listbox}
+    </EditorPopover>
+  );
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/autocomplete/decoration.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/autocomplete/decoration.tsx
@@ -1,0 +1,221 @@
+import weakMemoize from '@emotion/weak-memoize';
+import { css, tokenSchema } from '@voussoir/style';
+import {
+  Command,
+  EditorState,
+  Plugin,
+  PluginKey,
+  Selection,
+  Transaction,
+} from 'prosemirror-state';
+import type { EditorView } from 'prosemirror-view';
+import { Decoration, DecorationSet } from 'prosemirror-view';
+import { ReactNode } from 'react';
+import { useEditorState } from '../editor-view';
+
+const key = new PluginKey<AutocompleteDecorationState>(
+  'AutocompleteDecoration'
+);
+
+function hasSelectionInDecorations(
+  selection: Selection,
+  decorations: DecorationSet
+) {
+  return decorations.find(selection.from, selection.to).length > 0;
+}
+
+type AutocompleteMenu = (props: {
+  query: string;
+  from: number;
+  to: number;
+}) => ReactNode;
+
+type AutocompleteDecorationState =
+  | {
+      kind: 'active';
+      trigger: string;
+      pattern: RegExp | undefined;
+      decorations: DecorationSet;
+      component: AutocompleteMenu;
+    }
+  | { kind: 'inactive' };
+
+const inactiveDecorationState: AutocompleteDecorationState = {
+  kind: 'inactive',
+};
+
+type AddAutocompleteDecoration = {
+  action: 'add';
+  from: number;
+  to: number;
+  pattern: RegExp | undefined;
+  menu: AutocompleteMenu;
+};
+
+const getStateWithoutAutocompleteDecoration = weakMemoize(
+  (state: EditorState) => {
+    const tr = removeAutocompleteDecorationAndContent(state);
+    if (!tr) {
+      return { state };
+    }
+    return { state: state.apply(tr), tr };
+  }
+);
+
+export function wrapCommandAfterRemovingAutocompleteDecoration(
+  command: Command
+): Command {
+  return (stateWithInsertMenuText, dispatch, view): boolean => {
+    const { state, tr } = getStateWithoutAutocompleteDecoration(
+      stateWithInsertMenuText
+    );
+    if (!tr) return false;
+    if (dispatch) dispatch(tr);
+    return command(state, dispatch, view);
+  };
+}
+
+type RemoveAutocompleteDecoration = { action: 'remove' };
+
+export type AutocompleteTrMeta =
+  | AddAutocompleteDecoration
+  | RemoveAutocompleteDecoration;
+
+export function addAutocompleteDecoration(
+  tr: Transaction,
+  menu: AutocompleteMenu,
+  from: number,
+  to: number,
+  pattern: RegExp | undefined
+) {
+  return tr.setMeta(key, {
+    action: 'add',
+    from,
+    to,
+    menu,
+    pattern,
+  } satisfies AutocompleteTrMeta);
+}
+
+export function AutocompleteDecoration() {
+  const state = useEditorState();
+  const pluginState = key.getState(state);
+  if (!pluginState || pluginState.kind === 'inactive') return null;
+  return <AutocompleteDecorationInner state={pluginState} />;
+}
+
+function AutocompleteDecorationInner(props: {
+  state: AutocompleteDecorationState & { kind: 'active' };
+}) {
+  const state = useEditorState();
+  const decoration = props.state.decorations.find()[0];
+  const text = state.doc.textBetween(decoration.from, decoration.to).slice(1);
+  return (
+    <props.state.component
+      query={text}
+      from={decoration.from}
+      to={decoration.to}
+    />
+  );
+}
+
+export function removeAutocompleteDecoration(tr: Transaction) {
+  return tr.setMeta(key, { action: 'remove' } satisfies AutocompleteTrMeta);
+}
+
+function getAutocompleteDecoration(state: EditorState) {
+  const pluginState = key.getState(state);
+  if (pluginState?.kind === 'active') return pluginState.decorations.find()[0];
+}
+
+export function removeAutocompleteDecorationAndContent(state: EditorState) {
+  const decoration = getAutocompleteDecoration(state);
+  if (!decoration) return;
+  return removeAutocompleteDecoration(
+    state.tr.delete(decoration.from, decoration.to)
+  );
+}
+
+const accentForeground = css({ color: tokenSchema.color.foreground.accent });
+
+export function autocompleteDecoration(): Plugin<AutocompleteDecorationState> {
+  return new Plugin<AutocompleteDecorationState>({
+    key,
+    state: {
+      init: () => ({ kind: 'inactive' }),
+      apply(tr, value, oldState, newState): AutocompleteDecorationState {
+        const meta = tr.getMeta(key) as AutocompleteTrMeta | undefined;
+        if (meta?.action === 'add') {
+          const deco = Decoration.inline(
+            meta.from,
+            meta.to,
+            { nodeName: 'decoration-autocomplete', class: accentForeground },
+            { inclusiveStart: false, inclusiveEnd: true }
+          );
+
+          const trigger = newState.doc.textBetween(meta.from, meta.to, '');
+          const decorations = DecorationSet.create(tr.doc, [deco]);
+          return {
+            kind: 'active',
+            trigger,
+            decorations,
+            component: meta.menu,
+            pattern: meta.pattern,
+          };
+        }
+        if (value.kind === 'inactive') return value;
+        const decorations = value.decorations.map(tr.mapping, tr.doc);
+        const decorationsArr = decorations.find();
+        if (
+          meta?.action === 'remove' ||
+          !hasSelectionInDecorations(tr.selection, decorations) ||
+          decorationsArr.length !== 1
+        ) {
+          return inactiveDecorationState;
+        }
+        const { from, to } = decorationsArr[0];
+        const replacementChar = '\u{fffd}';
+        const textBetween = newState.doc.textBetween(
+          from,
+          to,
+          replacementChar,
+          replacementChar
+        );
+
+        if (
+          value.trigger !== textBetween.slice(0, value.trigger.length) ||
+          textBetween.includes(replacementChar) ||
+          (value.pattern && !value.pattern.test(textBetween))
+        ) {
+          return inactiveDecorationState;
+        }
+        return { ...value, decorations };
+      },
+    },
+    props: {
+      decorations: state => {
+        const pluginState = key.getState(state);
+        if (pluginState?.kind === 'active') return pluginState.decorations;
+        return DecorationSet.empty;
+      },
+      handlePaste,
+      handleDrop: handlePaste,
+      handleKeyDown(view, event) {
+        const state = key.getState(view.state);
+        if (state?.kind === 'active' && event.key === 'Escape') {
+          removeAutocompleteDecoration(view.state.tr);
+          return true;
+        }
+        return false;
+      },
+    },
+  });
+}
+
+function handlePaste(view: EditorView) {
+  const state = key.getState(view.state);
+  if (state?.kind === 'active') {
+    view.dispatch(removeAutocompleteDecoration(view.state.tr));
+  }
+  return false;
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/autocomplete/insert-menu.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/autocomplete/insert-menu.tsx
@@ -1,0 +1,123 @@
+import { matchSorter } from 'match-sorter';
+import { NodeType } from 'prosemirror-model';
+import { Command, EditorState } from 'prosemirror-state';
+import { useMemo } from 'react';
+import { weakMemoize } from '../utils';
+import {
+  addAutocompleteDecoration,
+  removeAutocompleteDecoration,
+  removeAutocompleteDecorationAndContent,
+} from './decoration';
+import {
+  useEditorViewRef,
+  useEditorSchema,
+  useEditorState,
+  useEditorDispatchCommand,
+} from '../editor-view';
+import { Item } from '../new-primitives';
+import { InputRule } from '../inputrules/inputrules';
+import { useEditorKeydownListener } from '../keydown';
+import { EditorAutocomplete } from './autocomplete';
+
+export type InsertMenuItemSpec = {
+  label: string;
+  description?: string;
+  command: (type: NodeType) => Command;
+};
+
+export type WithInsertMenuNodeSpec = {
+  insertMenu?: InsertMenuItemSpec[] | InsertMenuItemSpec;
+};
+
+export type InsertMenuItem = {
+  id: string;
+  label: string;
+  description?: string;
+  command: Command;
+};
+
+export const insertMenuInputRule: InputRule = {
+  pattern: /(?:^|\s)\/$/,
+  handler(state, _match, _start, end) {
+    return addAutocompleteDecoration(
+      state.tr,
+      InsertMenu,
+      end - 1,
+      end,
+      undefined
+    );
+  },
+};
+
+const getStateWithoutAutocompleteDecoration = weakMemoize(
+  (state: EditorState) => {
+    const tr = removeAutocompleteDecorationAndContent(state);
+    if (!tr) {
+      return { state };
+    }
+    return { state: state.apply(tr), tr };
+  }
+);
+
+function wrapInsertMenuCommand(command: Command): Command {
+  return (stateWithInsertMenuText, dispatch, view): boolean => {
+    const { state, tr } = getStateWithoutAutocompleteDecoration(
+      stateWithInsertMenuText
+    );
+    if (!tr) return false;
+    if (dispatch) dispatch(tr);
+    return command(state, dispatch, view);
+  };
+}
+
+function childRenderer(item: InsertMenuItem) {
+  return (
+    <Item key={item.id} textValue={item.label}>
+      {item.label}
+    </Item>
+  );
+}
+
+function InsertMenu(props: { query: string; from: number; to: number }) {
+  const viewRef = useEditorViewRef();
+  const dispatchCommand = useEditorDispatchCommand();
+  const schema = useEditorSchema();
+  const editorState = useEditorState();
+
+  const options = useMemo(
+    () =>
+      matchSorter(schema.insertMenuItems, props.query, {
+        keys: ['label'],
+      }).filter(option => option.command(editorState)),
+    [editorState, schema.insertMenuItems, props.query]
+  );
+
+  useEditorKeydownListener(event => {
+    if (event.key !== ' ') return false;
+    if (options.length === 1) {
+      dispatchCommand(wrapInsertMenuCommand(options[0].command));
+      return true;
+    }
+    if (options.length === 0) {
+      viewRef.current?.dispatch(removeAutocompleteDecoration(editorState.tr));
+    }
+    return false;
+  });
+  return (
+    <EditorAutocomplete
+      from={props.from}
+      to={props.to}
+      aria-label="Insert menu"
+      items={options}
+      children={childRenderer}
+      onEscape={() => {
+        viewRef.current?.dispatch(removeAutocompleteDecoration(editorState.tr));
+      }}
+      onAction={key => {
+        const option = options.find(option => option.id === key);
+        if (!option) return;
+        dispatchCommand(wrapInsertMenuCommand(option.command));
+      }}
+    />
+  );
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/code-block-highlighting.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/code-block-highlighting.ts
@@ -1,0 +1,171 @@
+import { Fragment, Node } from 'prosemirror-model';
+import Prism from '../../document/DocumentEditor/prism';
+import { Decoration, DecorationAttrs, DecorationSet } from 'prosemirror-view';
+import { css, tokenSchema } from '@voussoir/style';
+import { weakMemoize } from './utils';
+import { Plugin } from 'prosemirror-state';
+
+type InlineDecorationSpec = {
+  attrs: DecorationAttrs;
+  from: number;
+  to: number;
+};
+
+const emptyDecorations: InlineDecorationSpec[] = [];
+
+function getDecorationsForIndividualNode(node: Node): InlineDecorationSpec[] {
+  if (!node.type.spec.code || !node.childCount) return emptyDecorations;
+  const text = node.content.child(0).text;
+  if (!text) return emptyDecorations;
+  const lang = node.attrs.language;
+  if (
+    typeof lang !== 'string' ||
+    !Object.prototype.hasOwnProperty.call(Prism.languages, node.attrs.language)
+  ) {
+    return emptyDecorations;
+  }
+  const decorations: InlineDecorationSpec[] = [];
+  const tokens = Prism.tokenize(text, Prism.languages[node.attrs.language]);
+  function consumeTokens(start: number, tokens: (string | Prism.Token)[]) {
+    for (const token of tokens) {
+      const length = getPrismTokenLength(token);
+      const end = start + length;
+
+      if (typeof token !== 'string') {
+        const className = styles.get(token.type);
+        if (className) {
+          decorations.push({
+            attrs: { class: className },
+            from: start,
+            to: end,
+          });
+        }
+        consumeTokens(
+          start,
+          Array.isArray(token.content) ? token.content : [token.content]
+        );
+      }
+
+      start = end;
+    }
+  }
+  consumeTokens(0, tokens);
+  return decorations;
+}
+
+function getDecorationsForFragment(fragment: Fragment): InlineDecorationSpec[] {
+  let start = 0;
+  const allDecorations: InlineDecorationSpec[] = [];
+  for (let i = 0; i < fragment.childCount; i++) {
+    const node = fragment.child(i);
+    const decorations = getDecorationsForNode(node);
+    if (!decorations.length) {
+      start += node.nodeSize;
+      continue;
+    }
+    const textStart = start + 1;
+    for (const decoration of decorations) {
+      allDecorations.push({
+        attrs: decoration.attrs,
+        from: decoration.from + textStart,
+        to: decoration.to + textStart,
+      });
+    }
+    start += node.nodeSize;
+  }
+  return allDecorations;
+}
+
+export const getDecorationsForNode = weakMemoize(
+  (node: Node): InlineDecorationSpec[] => {
+    if (node.isTextblock) return getDecorationsForIndividualNode(node);
+    return getDecorationsForFragment(node.content);
+  }
+);
+
+export function codeBlockSyntaxHighlighting() {
+  return new Plugin({
+    props: {
+      decorations(state) {
+        const decorations = getDecorationsForNode(state.doc).map(decoration =>
+          Decoration.inline(decoration.from, decoration.to, decoration.attrs)
+        );
+        return DecorationSet.create(state.doc, decorations);
+      },
+    },
+  });
+}
+
+function getPrismTokenLength(token: Prism.Token | string): number {
+  if (typeof token === 'string') {
+    return token.length;
+  } else if (Array.isArray(token.content)) {
+    return token.content.reduce((l, t) => l + getPrismTokenLength(t), 0);
+  } else {
+    return getPrismTokenLength(token.content);
+  }
+}
+
+const styles = new Map(
+  [
+    {
+      types: ['comment', 'prolog', 'doctype', 'cdata'],
+      style: {
+        color: tokenSchema.color.foreground.neutralTertiary,
+        fontStyle: 'italic',
+      },
+    },
+    {
+      types: ['atrule', 'attr-name', 'class-name', 'selector'],
+      style: { color: tokenSchema.color.scale.amber11 },
+    },
+    {
+      types: [
+        'boolean',
+        'constant',
+        'inserted-sign',
+        'entity',
+        'inserted',
+        'number',
+        'regex',
+        'symbol',
+        'variable',
+      ],
+      style: { color: tokenSchema.color.scale.green11 },
+    },
+    {
+      types: ['attr-value', 'builtin', 'char', 'constant', 'generics', 'url'],
+      style: { color: tokenSchema.color.scale.pink11 },
+    },
+    {
+      types: ['string'],
+      style: { color: tokenSchema.color.scale.indigo9 },
+    },
+    {
+      types: [
+        'annotation',
+        'deleted',
+        'deleted-sign',
+        'decorator',
+        'important',
+        'tag',
+      ],
+      style: { color: tokenSchema.color.scale.red11 },
+    },
+    {
+      types: ['function', 'function-variable', 'operator'],
+      style: { color: tokenSchema.color.scale.purple11 },
+    },
+    {
+      types: ['tag', 'selector', 'keyword'],
+      style: { color: tokenSchema.color.scale.indigo11 },
+    },
+    {
+      types: ['punctuation'],
+      style: { color: tokenSchema.color.foreground.neutralSecondary },
+    },
+  ].flatMap(style => {
+    const className = css(style.style);
+    return style.types.map(x => [x, className]);
+  })
+);

--- a/packages/keystatic/src/form/fields/markdoc/editor/commands/keymap.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/commands/keymap.ts
@@ -1,0 +1,156 @@
+import {
+  chainCommands,
+  joinUp,
+  joinDown,
+  selectParentNode,
+  toggleMark,
+  setBlockType,
+  createParagraphNear,
+  liftEmptyBlock,
+  splitBlock,
+  newlineInCode,
+  selectAll,
+  deleteSelection,
+  joinForward,
+  selectNodeBackward,
+  selectNodeForward,
+  selectTextblockEnd,
+  selectTextblockStart,
+  joinBackward,
+} from 'prosemirror-commands';
+import { undo, redo } from 'prosemirror-history';
+import {
+  toggleList,
+  splitListItem,
+  liftListItem,
+  sinkListItem,
+} from '../lists';
+import { EditorSchema } from '../schema';
+import { Command } from 'prosemirror-state';
+import { NodeType } from 'prosemirror-model';
+
+const mac =
+  typeof navigator != 'undefined'
+    ? /Mac|iP(hone|[oa]d)/.test(navigator.platform)
+    : false;
+
+const codeModiferEnterCommand: Command = (state, dispatch, view) => {
+  const { $head, $anchor } = state.selection;
+  if (!$head.parent.type.spec.code || !$head.sameParent($anchor)) {
+    return false;
+  }
+  return chainCommands(createParagraphNear, liftEmptyBlock, splitBlock)(
+    state,
+    dispatch,
+    view
+  );
+};
+
+export function keymapForSchema({ nodes, marks }: EditorSchema) {
+  const bindings: Record<string, Command> = {};
+  const add = (key: string, command: Command) => {
+    if (bindings[key]) {
+      bindings[key] = chainCommands(bindings[key], command);
+    } else {
+      bindings[key] = command;
+    }
+  };
+  if (nodes.list_item) {
+    add('Enter', splitListItem(nodes.list_item));
+    add('Tab', sinkListItem(nodes.list_item));
+    add('Shift-Tab', liftListItem(nodes.list_item));
+  }
+  add(
+    'Enter',
+    chainCommands(
+      newlineInCode,
+      createParagraphNear,
+      liftEmptyBlock,
+      splitBlock
+    )
+  );
+
+  let deleteBackward = chainCommands(
+    deleteSelection,
+    joinBackward,
+    selectNodeBackward
+  );
+  let deleteForward = chainCommands(
+    deleteSelection,
+    joinForward,
+    selectNodeForward
+  );
+
+  add('Backspace', deleteBackward);
+  add('Mod-Backspace', deleteBackward);
+  add('Shift-Backspace', deleteBackward);
+  add('Delete', deleteForward);
+  add('Mod-Delete', deleteForward);
+  add('Mod-a', selectAll);
+  if (mac) {
+    add('Ctrl-h', deleteBackward);
+    add('Alt-Backspace', deleteBackward);
+    add('Ctrl-d', deleteForward);
+    add('Ctrl-Alt-Backspace', deleteForward);
+    add('Alt-Delete', deleteForward);
+    add('Alt-d', deleteForward);
+    add('Ctrl-a', selectTextblockStart);
+    add('Ctrl-e', selectTextblockEnd);
+  }
+
+  add('Mod-z', undo);
+  add('Shift-Mod-z', redo);
+  if (mac) {
+    add('Mod-y', redo);
+  }
+  const modiferEnterKeys = ['Mod-Enter', 'Shift-Enter'];
+  if (mac) {
+    modiferEnterKeys.push('Ctrl-Enter');
+  }
+  for (const key of modiferEnterKeys) {
+    add(key, codeModiferEnterCommand);
+    if (nodes.hard_break) {
+      add(key, insertHardBreak(nodes.hard_break));
+    }
+  }
+  for (const mark of Object.values(marks)) {
+    if (mark.spec.shortcuts) {
+      if (Array.isArray(mark.spec.shortcuts)) {
+        for (const shortcut of mark.spec.shortcuts) {
+          if (typeof shortcut !== 'string') {
+            throw new Error(`Invalid shortcut for mark ${mark.name}`);
+          }
+          add(shortcut, toggleMark(mark));
+        }
+        continue;
+      }
+      throw new Error(`Invalid shortcuts for mark ${mark.name}`);
+    }
+  }
+  add('Alt-ArrowUp', joinUp);
+  add('Alt-ArrowDown', joinDown);
+  add('Escape', selectParentNode);
+  if (nodes.unordered_list) {
+    add('Shift-Ctrl-8', toggleList(nodes.unordered_list));
+  }
+  if (nodes.ordered_list) {
+    add('Shift-Ctrl-9', toggleList(nodes.ordered_list));
+  }
+  add('Shift-Ctrl-0', setBlockType(nodes.paragraph));
+  for (const level of [1, 2, 3, 4, 5, 6]) {
+    add(`Shift-Ctrl-${level}`, setBlockType(nodes.heading, { level }));
+  }
+
+  return bindings;
+}
+
+function insertHardBreak(hardBreakType: NodeType): Command {
+  return (state, dispatch) => {
+    if (dispatch) {
+      dispatch(
+        state.tr.replaceSelectionWith(hardBreakType.create()).scrollIntoView()
+      );
+    }
+    return true;
+  };
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/commands/misc.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/commands/misc.ts
@@ -1,0 +1,45 @@
+import { setBlockType } from 'prosemirror-commands';
+import { NodeType } from 'prosemirror-model';
+import { Command, NodeSelection } from 'prosemirror-state';
+
+export function insertNode(nodeType: NodeType): Command {
+  return (state, dispatch) => {
+    if (
+      state.selection instanceof NodeSelection &&
+      state.selection.node.type === nodeType
+    ) {
+      return false;
+    }
+    if (dispatch) {
+      dispatch(state.tr.replaceSelectionWith(nodeType.createAndFill()!));
+    }
+    return true;
+  };
+}
+
+export function toggleCodeBlock(
+  codeBlock: NodeType,
+  paragraph: NodeType
+): Command {
+  return (state, dispatch, view) => {
+    const codeBlockPositions: [start: number, end: number][] = [];
+    for (const range of state.selection.ranges) {
+      state.doc.nodesBetween(range.$from.pos, range.$to.pos, (node, pos) => {
+        if (node.type === codeBlock) {
+          codeBlockPositions.push([pos, pos + node.nodeSize]);
+        }
+      });
+    }
+    if (!codeBlockPositions.length) {
+      return setBlockType(codeBlock)(state, dispatch, view);
+    }
+    if (dispatch) {
+      const tr = state.tr;
+      for (const [start, end] of codeBlockPositions) {
+        tr.setBlockType(start, end, paragraph);
+      }
+      dispatch(tr);
+    }
+    return true;
+  };
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/debugger.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/debugger.tsx
@@ -1,0 +1,11 @@
+import { EditorState } from 'prosemirror-state';
+import toJsxString from 'react-element-to-jsx-string';
+import { editorStateToReactNode } from './tests/editor-state-to-react-element';
+
+export function Debugger(props: { state: EditorState }) {
+  return (
+    <pre>
+      <code>{toJsxString(editorStateToReactNode(props.state))}</code>
+    </pre>
+  );
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/dropcursor.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/dropcursor.ts
@@ -1,0 +1,205 @@
+// https://github.com/ProseMirror/prosemirror-dropcursor/blob/d7347ca3d07cd9207ce83e33ed066629da4c3a9d/src/dropcursor.ts
+import { Plugin, EditorState } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+import { dropPoint } from 'prosemirror-transform';
+
+interface DropCursorOptions {
+  /// The color of the cursor. Defaults to `black`. Use `false` to apply no color and rely only on class.
+  color?: string | false;
+
+  /// The precise width of the cursor in pixels. Defaults to 1.
+  width?: number;
+
+  /// A CSS class name to add to the cursor element.
+  class?: string;
+}
+
+/// Create a plugin that, when added to a ProseMirror instance,
+/// causes a decoration to show up at the drop position when something
+/// is dragged over the editor.
+///
+/// Nodes may add a `disableDropCursor` property to their spec to
+/// control the showing of a drop cursor inside them. This may be a
+/// boolean or a function, which will be called with a view and a
+/// position, and should return a boolean.
+export function dropCursor(options: DropCursorOptions = {}): Plugin {
+  return new Plugin({
+    view(editorView) {
+      return new DropCursorView(editorView, options);
+    },
+  });
+}
+
+class DropCursorView {
+  width: number;
+  color: string | undefined;
+  class: string | undefined;
+  cursorPos: number | null = null;
+  element: HTMLElement | null = null;
+  timeout?: ReturnType<typeof setTimeout>;
+  handlers: { name: string; handler: (event: Event) => void }[];
+
+  constructor(readonly editorView: EditorView, options: DropCursorOptions) {
+    this.width = options.width ?? 1;
+    this.color = options.color === false ? undefined : options.color || 'black';
+    this.class = options.class;
+
+    this.handlers = ['dragover', 'dragend', 'drop', 'dragleave'].map(name => {
+      let handler = (e: Event) => {
+        (this as any)[name](e);
+      };
+      editorView.dom.addEventListener(name, handler);
+      return { name, handler };
+    });
+  }
+
+  destroy() {
+    this.handlers.forEach(({ name, handler }) =>
+      this.editorView.dom.removeEventListener(name, handler)
+    );
+  }
+
+  update(editorView: EditorView, prevState: EditorState) {
+    if (this.cursorPos != null && prevState.doc != editorView.state.doc) {
+      if (this.cursorPos > editorView.state.doc.content.size) {
+        this.setCursor(null);
+      } else this.updateOverlay();
+    }
+  }
+
+  setCursor(pos: number | null) {
+    if (pos == this.cursorPos) return;
+    this.cursorPos = pos;
+    if (pos == null) {
+      this.element!.parentNode!.removeChild(this.element!);
+      this.element = null;
+    } else {
+      this.updateOverlay();
+    }
+  }
+
+  updateOverlay() {
+    let $pos = this.editorView.state.doc.resolve(this.cursorPos!);
+    let isBlock = !$pos.parent.inlineContent,
+      rect;
+    if (isBlock) {
+      let before = $pos.nodeBefore,
+        after = $pos.nodeAfter;
+      if (before || after) {
+        let node = this.editorView.nodeDOM(
+          this.cursorPos! - (before ? before.nodeSize : 0)
+        );
+        if (node) {
+          let nodeRect = (node as HTMLElement).getBoundingClientRect();
+          let top = before ? nodeRect.bottom : nodeRect.top;
+          if (before && after) {
+            top =
+              (top +
+                (
+                  this.editorView.nodeDOM(this.cursorPos!) as HTMLElement
+                ).getBoundingClientRect().top) /
+              2;
+          }
+          rect = {
+            left: nodeRect.left,
+            right: nodeRect.right,
+            top: top - this.width / 2,
+            bottom: top + this.width / 2,
+          };
+        }
+      }
+    }
+    if (!rect) {
+      let coords = this.editorView.coordsAtPos(this.cursorPos!);
+      rect = {
+        left: coords.left - this.width / 2,
+        right: coords.left + this.width / 2,
+        top: coords.top,
+        bottom: coords.bottom,
+      };
+    }
+
+    let parent = this.editorView.dom.offsetParent!;
+    if (!this.element) {
+      this.element = parent.appendChild(document.createElement('div'));
+      if (this.class) this.element.className = this.class;
+      this.element.style.cssText =
+        'position: absolute; z-index: 50; pointer-events: none;';
+      if (this.color) {
+        this.element.style.backgroundColor = this.color;
+      }
+    }
+    this.element.classList.toggle('prosemirror-dropcursor-block', isBlock);
+    this.element.classList.toggle('prosemirror-dropcursor-inline', !isBlock);
+    let parentLeft, parentTop;
+    if (
+      !parent ||
+      (parent == document.body && getComputedStyle(parent).position == 'static')
+    ) {
+      parentLeft = -pageXOffset;
+      parentTop = -pageYOffset;
+    } else {
+      let rect = parent.getBoundingClientRect();
+      parentLeft = rect.left - parent.scrollLeft;
+      parentTop = rect.top - parent.scrollTop;
+    }
+    this.element.style.left = rect.left - parentLeft + 'px';
+    this.element.style.top = rect.top - parentTop + 'px';
+    this.element.style.width = rect.right - rect.left + 'px';
+    this.element.style.height = rect.bottom - rect.top + 'px';
+  }
+
+  scheduleRemoval(timeout: number) {
+    if (this.timeout !== undefined) {
+      clearTimeout(this.timeout);
+    }
+    this.timeout = setTimeout(() => this.setCursor(null), timeout);
+  }
+
+  dragover(event: DragEvent) {
+    if (!this.editorView.editable) return;
+    let pos = this.editorView.posAtCoords({
+      left: event.clientX,
+      top: event.clientY,
+    });
+
+    let node =
+      pos && pos.inside >= 0 && this.editorView.state.doc.nodeAt(pos.inside);
+    let disableDropCursor = node && node.type.spec.disableDropCursor;
+    let disabled =
+      typeof disableDropCursor == 'function'
+        ? disableDropCursor(this.editorView, pos, event)
+        : disableDropCursor;
+
+    if (pos && !disabled) {
+      let target: number | null = pos.pos;
+      if (this.editorView.dragging && this.editorView.dragging.slice) {
+        let point = dropPoint(
+          this.editorView.state.doc,
+          target,
+          this.editorView.dragging.slice
+        );
+        if (point != null) target = point;
+      }
+      this.setCursor(target);
+      this.scheduleRemoval(5000);
+    }
+  }
+
+  dragend() {
+    this.scheduleRemoval(20);
+  }
+
+  drop() {
+    this.scheduleRemoval(20);
+  }
+
+  dragleave(event: DragEvent) {
+    if (
+      event.target == this.editorView.dom ||
+      !this.editorView.dom.contains((event as any).relatedTarget)
+    ) {
+      this.setCursor(null);
+    }
+  }
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/editor-state.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/editor-state.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { EditorState, Selection } from 'prosemirror-state';
+import { history } from 'prosemirror-history';
+import { keymap } from 'prosemirror-keymap';
+import { inputRules } from './inputrules/inputrules';
+import { Mark, Node } from 'prosemirror-model';
+import { getEditorSchema } from './schema';
+import { inputRulesForSchema } from './inputrules/rules';
+import { keymapForSchema } from './commands/keymap';
+import { markdocClipboard } from './markdoc/clipboard';
+import { nodeInSelectionDecorations } from './node-in-selection';
+import { autocompleteDecoration } from './autocomplete/decoration';
+import { keydownHandler } from './keydown';
+import { gapCursor } from './gapcursor';
+import { attributes } from './attributes';
+import { dropCursor } from './dropcursor';
+
+export function createEditorState(
+  doc: Node,
+  selection?: Selection,
+  storedMarks?: readonly Mark[] | null
+) {
+  const schema = getEditorSchema(doc.type.schema);
+  return EditorState.create({
+    selection,
+    storedMarks,
+    plugins: [
+      keydownHandler(),
+      history(),
+      dropCursor(),
+      inputRules({
+        rules: inputRulesForSchema(schema),
+      }),
+      attributes(),
+      gapCursor(),
+      keymap(keymapForSchema(schema)),
+      markdocClipboard(),
+      nodeInSelectionDecorations(),
+      autocompleteDecoration(),
+    ],
+    doc,
+  });
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/editor-view.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/editor-view.tsx
@@ -1,0 +1,166 @@
+import { Command, EditorState } from 'prosemirror-state';
+import { getEditorSchema, EditorSchema } from './schema';
+import React, {
+  HTMLAttributes,
+  MutableRefObject,
+  ReactNode,
+  forwardRef,
+  useContext,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react';
+import { useEventCallback } from './utils';
+import { EditorView } from 'prosemirror-view';
+
+const EditorStateContext = React.createContext<EditorState | null>(null);
+
+export function useEditorState() {
+  const state = useContext(EditorStateContext);
+  if (state === null) {
+    throw new Error('useEditorState must be used inside ProseMirrorEditorView');
+  }
+  return state;
+}
+
+export function useEditorDispatchCommand() {
+  return useStableEditorContext().dispatchCommand;
+}
+
+export function useEditorSchema() {
+  return useStableEditorContext().schema;
+}
+
+export function useEditorViewRef() {
+  return useStableEditorContext().view;
+}
+
+export function useLayoutEffectWithEditorUpdated(effect: () => void) {
+  const editorView = useEditorViewRef();
+  const state = useEditorState();
+
+  const update = useEventCallback(() => {
+    if (editorView.current && editorView.current.state !== state) {
+      editorView.current?.updateState(state);
+    }
+  });
+
+  useLayoutEffect(() => {
+    update();
+    return effect();
+  }, [update, effect]);
+}
+
+export function useEditorView(
+  state: EditorState,
+  _onEditorStateChange: (state: EditorState) => void
+) {
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const onEditorStateChange = useEventCallback(_onEditorStateChange);
+  // TODO: don't have this useRef
+  // preview props should allow updater functions
+  const stateRef = useRef(state);
+  useLayoutEffect(() => {
+    stateRef.current = state;
+  });
+  useLayoutEffect(() => {
+    if (mountRef.current === null) {
+      return;
+    }
+    const view = new EditorView(
+      { mount: mountRef.current },
+      {
+        state: stateRef.current,
+        dispatchTransaction(tr) {
+          const newEditorState = stateRef.current.apply(tr);
+          stateRef.current = newEditorState;
+          onEditorStateChange(newEditorState);
+        },
+      }
+    );
+    viewRef.current = view;
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+  }, [mountRef, onEditorStateChange]);
+  useLayoutEffect(() => {
+    viewRef.current?.updateState(state);
+  }, [state]);
+  return {
+    view: viewRef,
+    mount: mountRef,
+  };
+}
+
+/**
+ * This cannot be moved after mount
+ *
+ * This could be fixed by storing the editable ref in state but that would be more initial re-renders
+ * and moving the editable isn't a thing that we actually would want to do.
+ */
+export function ProseMirrorEditable(props: HTMLAttributes<HTMLElement>) {
+  const { mount } = useStableEditorContext();
+  return <div {...props} ref={mount} />;
+}
+
+type StableContext = {
+  view: MutableRefObject<EditorView | null>;
+  mount: MutableRefObject<HTMLDivElement | null>;
+  dispatchCommand: (command: Command) => void;
+  schema: EditorSchema;
+};
+
+const StableEditorContext = React.createContext<StableContext | null>(null);
+
+function useStableEditorContext() {
+  const context = useContext(StableEditorContext);
+  if (context === null) {
+    throw new Error('editor hooks must be used inside a ProseMirrorEditorView');
+  }
+  return context;
+}
+
+export const ProseMirrorEditor = forwardRef(function ProseMirrorEditorView(
+  props: {
+    value: EditorState;
+    onChange: (state: EditorState) => void;
+    children: ReactNode;
+  },
+  ref: React.Ref<{ view: EditorView | null }>
+) {
+  const { view, mount } = useEditorView(props.value, props.onChange);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      get view() {
+        return view.current;
+      },
+    }),
+    [view]
+  );
+
+  const stableContext = useMemo((): StableContext => {
+    return {
+      view,
+      mount,
+      dispatchCommand: command => {
+        if (!view.current) return;
+        command(view.current.state, view.current.dispatch, view.current);
+        view.current.focus();
+      },
+      schema: getEditorSchema(props.value.schema),
+    };
+  }, [mount, props.value.schema, view]);
+
+  return (
+    <StableEditorContext.Provider value={stableContext}>
+      <EditorStateContext.Provider value={props.value}>
+        {props.children}
+      </EditorStateContext.Provider>
+    </StableEditorContext.Provider>
+  );
+});

--- a/packages/keystatic/src/form/fields/markdoc/editor/gapcursor/gapcursor.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/gapcursor/gapcursor.ts
@@ -1,0 +1,166 @@
+// https://github.com/ProseMirror/prosemirror-gapcursor/blob/bbbee7d483754310f63f3b18d81f5a1da1250234/src/gapcursor.ts#L1
+import { Selection, NodeSelection } from 'prosemirror-state';
+import { Slice, ResolvedPos, Node } from 'prosemirror-model';
+import { Mappable } from 'prosemirror-transform';
+
+/// Gap cursor selections are represented using this class. Its
+/// `$anchor` and `$head` properties both point at the cursor position.
+export class GapCursor extends Selection {
+  /// Create a gap cursor.
+  constructor($pos: ResolvedPos) {
+    super($pos, $pos);
+  }
+
+  map(doc: Node, mapping: Mappable): Selection {
+    let $pos = doc.resolve(mapping.map(this.head));
+    return GapCursor.valid($pos) ? new GapCursor($pos) : Selection.near($pos);
+  }
+
+  content() {
+    return Slice.empty;
+  }
+
+  eq(other: Selection): boolean {
+    return other instanceof GapCursor && other.head == this.head;
+  }
+
+  toJSON(): any {
+    return { type: 'ksgapcursor', pos: this.head };
+  }
+
+  /// @internal
+  static fromJSON(doc: Node, json: any): GapCursor {
+    if (typeof json.pos != 'number') {
+      throw new RangeError('Invalid input for GapCursor.fromJSON');
+    }
+    return new GapCursor(doc.resolve(json.pos));
+  }
+
+  /// @internal
+  getBookmark() {
+    return new GapBookmark(this.anchor);
+  }
+
+  /// @internal
+  static valid($pos: ResolvedPos) {
+    let parent = $pos.parent;
+    if (parent.isTextblock || !closedBefore($pos) || !closedAfter($pos)) {
+      return false;
+    }
+    let override = parent.type.spec.allowGapCursor;
+    if (override != null) return override;
+    let deflt = parent.contentMatchAt($pos.index()).defaultType;
+    return deflt && deflt.isTextblock;
+  }
+
+  /// @internal
+  static findGapCursorFrom($pos: ResolvedPos, dir: number, mustMove = false) {
+    search: for (;;) {
+      if (!mustMove && GapCursor.valid($pos)) return $pos;
+      let pos = $pos.pos,
+        next = null;
+      // Scan up from this position
+      for (let d = $pos.depth; ; d--) {
+        let parent = $pos.node(d);
+        if (
+          dir > 0 ? $pos.indexAfter(d) < parent.childCount : $pos.index(d) > 0
+        ) {
+          next = parent.child(dir > 0 ? $pos.indexAfter(d) : $pos.index(d) - 1);
+          break;
+        } else if (d == 0) {
+          return null;
+        }
+        pos += dir;
+        let $cur = $pos.doc.resolve(pos);
+        if (GapCursor.valid($cur)) return $cur;
+      }
+
+      // And then down into the next node
+      for (;;) {
+        let inside: Node | null = dir > 0 ? next.firstChild : next.lastChild;
+        if (!inside) {
+          if (
+            next.isAtom &&
+            !next.isText &&
+            !NodeSelection.isSelectable(next)
+          ) {
+            $pos = $pos.doc.resolve(pos + next.nodeSize * dir);
+            mustMove = false;
+            continue search;
+          }
+          break;
+        }
+        next = inside;
+        pos += dir;
+        let $cur = $pos.doc.resolve(pos);
+        if (GapCursor.valid($cur)) return $cur;
+      }
+
+      return null;
+    }
+  }
+}
+
+GapCursor.prototype.visible = false;
+(GapCursor as any).findFrom = GapCursor.findGapCursorFrom;
+
+Selection.jsonID('ksgapcursor', GapCursor);
+
+class GapBookmark {
+  constructor(readonly pos: number) {}
+
+  map(mapping: Mappable) {
+    return new GapBookmark(mapping.map(this.pos));
+  }
+  resolve(doc: Node) {
+    let $pos = doc.resolve(this.pos);
+    return GapCursor.valid($pos) ? new GapCursor($pos) : Selection.near($pos);
+  }
+}
+
+function closedBefore($pos: ResolvedPos) {
+  for (let d = $pos.depth; d >= 0; d--) {
+    let index = $pos.index(d),
+      parent = $pos.node(d);
+    // At the start of this parent, look at next one
+    if (index == 0) {
+      if (parent.type.spec.isolating) return true;
+      continue;
+    }
+    // See if the node before (or its first ancestor) is closed
+    for (let before = parent.child(index - 1); ; before = before.lastChild!) {
+      if (
+        (before.childCount == 0 && !before.inlineContent) ||
+        before.isAtom ||
+        before.type.spec.isolating
+      ) {
+        return true;
+      }
+      if (before.inlineContent) return false;
+    }
+  }
+  // Hit start of document
+  return true;
+}
+
+function closedAfter($pos: ResolvedPos) {
+  for (let d = $pos.depth; d >= 0; d--) {
+    let index = $pos.indexAfter(d),
+      parent = $pos.node(d);
+    if (index == parent.childCount) {
+      if (parent.type.spec.isolating) return true;
+      continue;
+    }
+    for (let after = parent.child(index); ; after = after.firstChild!) {
+      if (
+        (after.childCount == 0 && !after.inlineContent) ||
+        after.isAtom ||
+        after.type.spec.isolating
+      ) {
+        return true;
+      }
+      if (after.inlineContent) return false;
+    }
+  }
+  return true;
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/gapcursor/index.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/gapcursor/index.ts
@@ -1,0 +1,119 @@
+// https://github.com/ProseMirror/prosemirror-gapcursor/blob/bbbee7d483754310f63f3b18d81f5a1da1250234/src/index.ts
+// our editor is Weird and lets you have gapcursors is weird positions so we're forking this
+import { keydownHandler } from 'prosemirror-keymap';
+import {
+  TextSelection,
+  NodeSelection,
+  Plugin,
+  Command,
+  EditorState,
+} from 'prosemirror-state';
+import { Fragment, Slice } from 'prosemirror-model';
+import { Decoration, DecorationSet, EditorView } from 'prosemirror-view';
+
+import { GapCursor } from './gapcursor';
+
+/// Create a gap cursor plugin. When enabled, this will capture clicks
+/// near and arrow-key-motion past places that don't have a normally
+/// selectable position nearby, and create a gap cursor selection for
+/// them. The cursor is drawn as an element with class
+/// `ProseMirror-gapcursor`. You can either include
+/// `style/gapcursor.css` from the package's directory or add your own
+/// styles to make it visible.
+export function gapCursor(): Plugin {
+  return new Plugin({
+    props: {
+      decorations: drawGapCursor,
+
+      createSelectionBetween(_view, $anchor, $head) {
+        return $anchor.pos == $head.pos && GapCursor.valid($head)
+          ? new GapCursor($head)
+          : null;
+      },
+      handleClick,
+      handleKeyDown,
+      handleDOMEvents: { beforeinput: beforeinput as any },
+    },
+  });
+}
+
+export { GapCursor };
+
+const handleKeyDown = keydownHandler({
+  ArrowLeft: arrow('horiz', -1),
+  ArrowRight: arrow('horiz', 1),
+  ArrowUp: arrow('vert', -1),
+  ArrowDown: arrow('vert', 1),
+});
+
+function arrow(axis: 'vert' | 'horiz', dir: number): Command {
+  const dirStr =
+    axis == 'vert' ? (dir > 0 ? 'down' : 'up') : dir > 0 ? 'right' : 'left';
+  return function (state, dispatch, view) {
+    let sel = state.selection;
+    let $start = dir > 0 ? sel.$to : sel.$from,
+      mustMove = sel.empty;
+    if (sel instanceof TextSelection) {
+      if (!view!.endOfTextblock(dirStr) || $start.depth == 0) return false;
+      mustMove = false;
+      $start = state.doc.resolve(dir > 0 ? $start.after() : $start.before());
+    }
+    let $found = GapCursor.findGapCursorFrom($start, dir, mustMove);
+    if (!$found) return false;
+    if (dispatch) dispatch(state.tr.setSelection(new GapCursor($found)));
+    return true;
+  };
+}
+
+function handleClick(view: EditorView, pos: number, event: MouseEvent) {
+  if (!view || !view.editable) return false;
+  let $pos = view.state.doc.resolve(pos);
+  if (!GapCursor.valid($pos)) return false;
+  let clickPos = view.posAtCoords({ left: event.clientX, top: event.clientY });
+  if (
+    clickPos &&
+    clickPos.inside > -1 &&
+    NodeSelection.isSelectable(view.state.doc.nodeAt(clickPos.inside)!)
+  ) {
+    return false;
+  }
+  view.dispatch(view.state.tr.setSelection(new GapCursor($pos)));
+  return true;
+}
+
+// This is a hack that, when a composition starts while a gap cursor
+// is active, quickly creates an inline context for the composition to
+// happen in, to avoid it being aborted by the DOM selection being
+// moved into a valid position.
+function beforeinput(view: EditorView, event: InputEvent) {
+  if (
+    event.inputType != 'insertCompositionText' ||
+    !(view.state.selection instanceof GapCursor)
+  ) {
+    return false;
+  }
+
+  let { $from } = view.state.selection;
+  let insert = $from.parent
+    .contentMatchAt($from.index())
+    .findWrapping(view.state.schema.nodes.text);
+  if (!insert) return false;
+
+  let frag = Fragment.empty;
+  for (let i = insert.length - 1; i >= 0; i--) {
+    frag = Fragment.from(insert[i].createAndFill(null, frag));
+  }
+  let tr = view.state.tr.replace($from.pos, $from.pos, new Slice(frag, 0, 0));
+  tr.setSelection(TextSelection.near(tr.doc.resolve($from.pos + 1)));
+  view.dispatch(tr);
+  return false;
+}
+
+function drawGapCursor(state: EditorState) {
+  if (!(state.selection instanceof GapCursor)) return null;
+  let node = document.createElement('div');
+  node.className = 'ProseMirror-gapcursor';
+  return DecorationSet.create(state.doc, [
+    Decoration.widget(state.selection.head, node, { key: 'gapcursor' }),
+  ]);
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/index.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/index.tsx
@@ -1,0 +1,71 @@
+import { EditorView } from 'prosemirror-view';
+import { EditorState } from 'prosemirror-state';
+import { Ref, forwardRef } from 'react';
+import { Box } from '@voussoir/layout';
+import { css } from '@emotion/css';
+import { tokenSchema } from '@voussoir/style';
+import { Toolbar } from './Toolbar';
+import { prosemirrorStyles } from './utils';
+import { EditorPopover } from './popovers';
+import { ProseMirrorEditable, ProseMirrorEditor } from './editor-view';
+import { AutocompleteDecoration } from './autocomplete/decoration';
+
+const orderedListStyles = ['lower-roman', 'decimal', 'lower-alpha'];
+const unorderedListStyles = ['square', 'disc', 'circle'];
+
+let styles: any = {};
+
+let listDepth = 10;
+
+while (listDepth--) {
+  let arr = Array.from({ length: listDepth });
+  if (arr.length) {
+    styles[arr.map(() => `ol`).join(' ')] = {
+      listStyle: orderedListStyles[listDepth % 3],
+    };
+    styles[arr.map(() => `ul`).join(' ')] = {
+      listStyle: unorderedListStyles[listDepth % 3],
+    };
+  }
+}
+
+const editableStyles = css({
+  ...styles,
+  outline: 0,
+  flex: 1,
+  minHeight: tokenSchema.size.scale[2000],
+  padding: tokenSchema.size.space.medium,
+  height: 'auto',
+  minWidth: 0,
+  fontFamily: tokenSchema.typography.fontFamily.base,
+  fontSize: tokenSchema.fontsize.text.regular.size,
+  lineHeight: 1.4,
+  a: {
+    color: tokenSchema.color.foreground.accent,
+  },
+});
+
+export const Editor = forwardRef(function Editor(
+  props: {
+    value: EditorState;
+    onChange: (state: EditorState) => void;
+  },
+  ref: Ref<{ view: EditorView | null }>
+) {
+  return (
+    <ProseMirrorEditor value={props.value} onChange={props.onChange} ref={ref}>
+      <Box
+        backgroundColor="canvas"
+        border="neutral"
+        borderRadius="medium"
+        minWidth={0}
+        UNSAFE_className={prosemirrorStyles}
+      >
+        <Toolbar />
+        <ProseMirrorEditable className={editableStyles} />
+      </Box>
+      <EditorPopover state={props.value} />
+      <AutocompleteDecoration />
+    </ProseMirrorEditor>
+  );
+});

--- a/packages/keystatic/src/form/fields/markdoc/editor/inputrules/handlers.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/inputrules/handlers.ts
@@ -1,0 +1,111 @@
+// based on https://github.com/ProseMirror/prosemirror-inputrules/blob/47dff8a7316e5cf86343e37fd97588a30345bc0a/src/inputrules.ts
+import { InputRuleHandler } from './inputrules';
+import { findWrapping, canJoin } from 'prosemirror-transform';
+import { NodeType, Node, Attrs } from 'prosemirror-model';
+
+/// Build an input rule handler for automatically wrapping a textblock when a
+/// given string is typed.
+///
+/// `nodeType` is the type of node to wrap in. If it needs attributes,
+/// you can either pass them directly, or pass a function that will
+/// compute them from the regular expression match.
+///
+/// By default, if there's a node with the same type above the newly
+/// wrapped node, the rule will try to [join](#transform.Transform.join) those
+/// two nodes. You can pass a join predicate, which takes a regular
+/// expression match and the node before the wrapped node, and can
+/// return a boolean to indicate whether a join should happen.
+export function wrappingInputRuleHandler(
+  nodeType: NodeType,
+  getAttrs: Attrs | null | ((matches: RegExpMatchArray) => Attrs | null) = null,
+  joinPredicate?: (match: RegExpMatchArray, node: Node) => boolean
+): InputRuleHandler {
+  return (state, match, start, end) => {
+    let attrs = getAttrs instanceof Function ? getAttrs(match) : getAttrs;
+    let tr = state.tr.delete(start, end);
+    let $start = tr.doc.resolve(start),
+      range = $start.blockRange(),
+      wrapping = range && findWrapping(range, nodeType, attrs);
+    if (!wrapping) return null;
+    tr.wrap(range!, wrapping);
+    let before = tr.doc.resolve(start - 1).nodeBefore;
+    if (
+      before &&
+      before.type == nodeType &&
+      canJoin(tr.doc, start - 1) &&
+      (!joinPredicate || joinPredicate(match, before))
+    ) {
+      tr.join(start - 1);
+    }
+    return tr;
+  };
+}
+
+/// Build an input rule that changes the type of a textblock when the
+/// matched text is typed into it. You'll usually want to start your
+/// regexp with `^` to that it is only matched at the start of a
+/// textblock. The optional `getAttrs` parameter can be used to compute
+/// the new node's attributes, and works the same as in the
+/// `wrappingInputRule` function.
+export function textblockTypeInputRuleHandler(
+  nodeType: NodeType,
+  getAttrs:
+    | Attrs
+    | null
+    | ((match: RegExpMatchArray) => Attrs | null | false) = null
+): InputRuleHandler {
+  return (state, match, start, end) => {
+    let $start = state.doc.resolve(start);
+    let attrs = getAttrs instanceof Function ? getAttrs(match) : getAttrs;
+    if (attrs === false) return null;
+    if (
+      !$start
+        .node(-1)
+        .canReplaceWith($start.index(-1), $start.indexAfter(-1), nodeType)
+    ) {
+      return null;
+    }
+    return state.tr
+      .delete(start, end)
+      .setBlockType(start, start, nodeType, attrs);
+  };
+}
+
+export function replaceTypeInputRuleHandler(
+  nodeType: NodeType,
+  getAttrs: Attrs | null | ((match: RegExpMatchArray) => Attrs | null) = null
+): InputRuleHandler {
+  return (state, match, start, end) => {
+    let $start = state.doc.resolve(start);
+    let attrs = getAttrs instanceof Function ? getAttrs(match) : getAttrs;
+    if (
+      !$start
+        .node(-1)
+        .canReplaceWith($start.index(-1), $start.indexAfter(-1), nodeType)
+    ) {
+      return null;
+    }
+
+    // might want to move the selection to after the divider
+    return state.tr
+      .delete(start, end)
+      .replaceSelectionWith(nodeType.createAndFill(attrs)!);
+  };
+}
+
+export function stringHandler(replacement: string): InputRuleHandler {
+  return (state, match, start, end) => {
+    let insert = replacement;
+    if (match[1]) {
+      let offset = match[0].lastIndexOf(match[1]);
+      insert += match[0].slice(offset + match[1].length);
+      start += offset;
+      let cutOff = start - end;
+      if (cutOff > 0) {
+        insert = match[0].slice(offset - cutOff, offset) + insert;
+        start = end;
+      }
+    }
+    return state.tr.insertText(insert, start, end);
+  };
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/inputrules/inputrules.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/inputrules/inputrules.ts
@@ -1,0 +1,84 @@
+// https://github.com/ProseMirror/prosemirror-inputrules/blob/47dff8a7316e5cf86343e37fd97588a30345bc0a/src/inputrules.ts
+// modified to add as a separate transaction with closeHistory so that undo and redo just works correctly
+import { closeHistory } from 'prosemirror-history';
+import {
+  Plugin,
+  Transaction,
+  EditorState,
+  TextSelection,
+} from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+
+export type InputRuleHandler = (
+  state: EditorState,
+  match: RegExpMatchArray,
+  start: number,
+  end: number
+) => Transaction | null;
+
+export type InputRule = {
+  pattern: RegExp;
+  handler: InputRuleHandler;
+};
+
+const MAX_MATCH = 500;
+
+/// Create an input rules plugin. When enabled, it will cause text
+/// input that matches any of the given rules to trigger the rule's
+/// action.
+export function inputRules({ rules }: { rules: readonly InputRule[] }) {
+  return new Plugin({
+    props: {
+      handleTextInput(view) {
+        setTimeout(() => {
+          run(view, rules);
+        });
+        return false;
+      },
+      handleDOMEvents: {
+        compositionend: view => {
+          setTimeout(() => {
+            run(view, rules);
+          });
+        },
+      },
+    },
+  });
+}
+
+function getMatch(
+  state: EditorState,
+  from: number,
+  to: number,
+  rules: readonly InputRule[]
+) {
+  const $from = state.doc.resolve(from);
+  if ($from.parent.type.spec.code) return;
+  const textBefore = $from.parent.textBetween(
+    Math.max(0, $from.parentOffset - MAX_MATCH),
+    $from.parentOffset,
+    null,
+    '\ufffc'
+  );
+  for (const rule of rules) {
+    const match = rule.pattern.exec(textBefore);
+    if (!match) continue;
+    const matchFrom = from - match[0].length;
+    const tr = rule.handler(state, match, matchFrom, to);
+    if (!tr) continue;
+    return tr;
+  }
+  return;
+}
+
+function run(view: EditorView, rules: readonly InputRule[]) {
+  const state = view.state;
+  if (view.composing || !(state.selection instanceof TextSelection)) {
+    return;
+  }
+  const { $cursor } = state.selection;
+  if (!$cursor) return;
+  const tr = getMatch(state, $cursor.pos, $cursor.pos, rules);
+  if (!tr) return;
+  view.dispatch(closeHistory(tr));
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/inputrules/rules.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/inputrules/rules.ts
@@ -1,0 +1,125 @@
+import escape from 'escape-string-regexp';
+import { EditorSchema } from '../schema';
+import {
+  replaceTypeInputRuleHandler,
+  stringHandler,
+  textblockTypeInputRuleHandler,
+  wrappingInputRuleHandler,
+} from './handlers';
+import { InputRule } from './inputrules';
+import { shortcuts, simpleMarkShortcuts } from './shortcuts';
+import { MarkType, Node } from 'prosemirror-model';
+import { insertMenuInputRule } from '../autocomplete/insert-menu';
+import { attributeMenuInputRule } from '../attributes/new-attribute';
+
+const textShortcutRules = Object.entries(shortcuts).map(
+  ([shortcut, replacement]): InputRule => ({
+    pattern: new RegExp(`(${escape(shortcut)})\\s$`),
+    handler: stringHandler(replacement),
+  })
+);
+
+export function inputRulesForSchema({ nodes, marks }: EditorSchema) {
+  const rules = [...textShortcutRules];
+  rules.push({
+    pattern: /^\s*>\s$/,
+    handler: wrappingInputRuleHandler(nodes.blockquote),
+  });
+
+  rules.push({
+    pattern: /^\s*\d+(?:\.|\))\s$/,
+    handler: wrappingInputRuleHandler(nodes.ordered_list),
+  });
+
+  rules.push({
+    pattern: /^\s*([-+*])\s$/,
+    handler: wrappingInputRuleHandler(nodes.unordered_list),
+  });
+
+  rules.push({
+    pattern: /^```(\w+)?\s$/,
+    handler: textblockTypeInputRuleHandler(nodes.code_block, match => ({
+      language: match[1] ?? 'plain',
+    })),
+  });
+
+  rules.push({
+    pattern: /^---$/,
+    handler: replaceTypeInputRuleHandler(nodes.divider),
+  });
+
+  rules.push({
+    pattern: /^(#{1,6})\s$/,
+    handler: replaceTypeInputRuleHandler(nodes.heading, match => ({
+      level: match[1].length,
+    })),
+  });
+
+  for (const [markName, shortcuts] of simpleMarkShortcuts) {
+    const mark = marks[markName];
+    if (!mark) continue;
+    for (const shortcut of shortcuts) {
+      rules.push({
+        pattern: new RegExp(
+          `${
+            shortcut[0] === '_'
+              ? '(?:^|\\s)'
+              : shortcut === '*'
+              ? '(?:^|[^\\*])'
+              : ''
+          }${escape(shortcut)}([^${escape(shortcut[0])}\\s]|(?:[^${escape(
+            shortcut[0]
+          )}\\s].*[^\\s]))${escape(shortcut)}$`
+        ),
+        handler: (state, [, content], __start, end) => {
+          const start = end - content.length - shortcut.length * 2;
+          if (!allowsMarkType(state.doc, start, end, mark)) return null;
+          const tr = state.tr;
+          tr.addMark(
+            start + shortcut.length,
+            end - shortcut.length,
+            mark.create()
+          );
+          tr.delete(end - shortcut.length, end);
+          tr.delete(start, start + shortcut.length);
+          tr.removeStoredMark(mark);
+          return tr;
+        },
+      });
+    }
+  }
+  if (marks.link) {
+    const linkType = marks.link;
+    rules.push({
+      pattern: /(?:^|[^!])\[(.*)\]\((.*)\)$/,
+      handler(state, [, text, href], __start, end) {
+        const start = end - href.length - text.length - 4;
+        if (!allowsMarkType(state.doc, start, end, linkType)) return null;
+        const tr = state.tr;
+        tr.addMark(start, end, linkType.create({ href }));
+        tr.delete(start + 1 + text.length, end);
+        tr.delete(start, start + 1);
+        tr.removeStoredMark(linkType);
+        return tr;
+      },
+    });
+  }
+  rules.push(insertMenuInputRule);
+  rules.push(attributeMenuInputRule);
+  return rules;
+}
+
+function allowsMarkType(
+  doc: Node,
+  start: number,
+  end: number,
+  markType: MarkType
+) {
+  let allowsMarkType = true;
+  doc.nodesBetween(start, end, node => {
+    if (!node.isText && !node.type.allowsMarkType(markType)) {
+      allowsMarkType = false;
+    }
+  });
+  return allowsMarkType;
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/inputrules/shortcuts.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/inputrules/shortcuts.ts
@@ -1,0 +1,15 @@
+export const shortcuts: Record<string, string> = {
+  '...': '…',
+  '-->': '→',
+  '->': '→',
+  '<-': '←',
+  '<--': '←',
+  '--': '–',
+};
+
+export const simpleMarkShortcuts = new Map([
+  ['bold', ['**', '__']],
+  ['italic', ['*', '_']],
+  ['strikethrough', ['~~']],
+  ['code', ['`']],
+] as const);

--- a/packages/keystatic/src/form/fields/markdoc/editor/keydown.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/keydown.ts
@@ -1,0 +1,54 @@
+import { Plugin, PluginKey } from 'prosemirror-state';
+import { useEffect } from 'react';
+import { useEventCallback } from './utils';
+import { useEditorState } from './editor-view';
+
+type Handlers = Set<{ fn: (event: KeyboardEvent) => boolean }>;
+
+const key = new PluginKey<Handlers>('keydown');
+
+/**
+ * Generally only one of these should be rendered at a time
+ *
+ * It's for autocomplete or etc. where you want to handle keydown in a react component
+ * because the selection is in a particular place
+ */
+export function useEditorKeydownListener(
+  handler: (event: KeyboardEvent) => boolean
+) {
+  const state = useEditorState();
+  const pluginState = key.getState(state);
+  const stableHandler = useEventCallback(handler);
+  useEffect(() => {
+    if (!pluginState) return;
+    const obj = { fn: stableHandler };
+    pluginState.add(obj);
+    return () => {
+      pluginState.delete(obj);
+    };
+  }, [pluginState, stableHandler]);
+}
+
+export function keydownHandler() {
+  return new Plugin<Handlers>({
+    key,
+    state: {
+      init() {
+        return new Set();
+      },
+      apply(tr, value) {
+        return value;
+      },
+    },
+    props: {
+      handleKeyDown(view, event) {
+        const pluginState = key.getState(view.state);
+        if (!pluginState) return false;
+        for (const handler of pluginState) {
+          if (handler.fn(event)) return true;
+        }
+        return false;
+      },
+    },
+  });
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/lists.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/lists.ts
@@ -1,0 +1,344 @@
+// https://github.com/ProseMirror/prosemirror-schema-list/blob/d017648e4f4472076599aa12ec839ae222e6e1b5/src/schema-list.ts
+import {
+  findWrapping,
+  liftTarget,
+  canSplit,
+  ReplaceAroundStep,
+  canJoin,
+} from 'prosemirror-transform';
+import { Slice, Fragment, NodeType, Attrs, NodeRange } from 'prosemirror-model';
+import {
+  Command,
+  EditorState,
+  Transaction,
+  NodeSelection,
+  Selection,
+} from 'prosemirror-state';
+
+export function toggleList(
+  listType: NodeType,
+  attrs: Attrs | null = null
+): Command {
+  return function (state: EditorState, dispatch?: (tr: Transaction) => void) {
+    let { $from, $to } = state.selection;
+    let range = $from.blockRange($to),
+      doJoin = false,
+      outerRange = range;
+    if (!range) return false;
+    // This is at the top of an existing list item
+    if (
+      range.depth >= 2 &&
+      $from.node(range.depth - 1).type.compatibleContent(listType) &&
+      range.startIndex == 0
+    ) {
+      // Don't do anything if this is the top of the list
+      if ($from.index(range.depth - 1) == 0) return false;
+      let $insert = state.doc.resolve(range.start - 2);
+      outerRange = new NodeRange($insert, $insert, range.depth);
+      if (range.endIndex < range.parent.childCount) {
+        range = new NodeRange(
+          $from,
+          state.doc.resolve($to.end(range.depth)),
+          range.depth
+        );
+      }
+      doJoin = true;
+    }
+    let wrap = findWrapping(outerRange!, listType, attrs, range);
+    if (!wrap) return false;
+    if (dispatch) {
+      dispatch(
+        doWrapInList(state.tr, range, wrap, doJoin, listType).scrollIntoView()
+      );
+    }
+    return true;
+  };
+}
+
+function doWrapInList(
+  tr: Transaction,
+  range: NodeRange,
+  wrappers: { type: NodeType; attrs?: Attrs | null }[],
+  joinBefore: boolean,
+  listType: NodeType
+) {
+  let content = Fragment.empty;
+  for (let i = wrappers.length - 1; i >= 0; i--) {
+    content = Fragment.from(
+      wrappers[i].type.create(wrappers[i].attrs, content)
+    );
+  }
+
+  tr.step(
+    new ReplaceAroundStep(
+      range.start - (joinBefore ? 2 : 0),
+      range.end,
+      range.start,
+      range.end,
+      new Slice(content, 0, 0),
+      wrappers.length,
+      true
+    )
+  );
+
+  let found = 0;
+  for (let i = 0; i < wrappers.length; i++) {
+    if (wrappers[i].type == listType) found = i + 1;
+  }
+  let splitDepth = wrappers.length - found;
+
+  let splitPos = range.start + wrappers.length - (joinBefore ? 2 : 0),
+    parent = range.parent;
+  for (
+    let i = range.startIndex, e = range.endIndex, first = true;
+    i < e;
+    i++, first = false
+  ) {
+    if (!first && canSplit(tr.doc, splitPos, splitDepth)) {
+      tr.split(splitPos, splitDepth);
+      splitPos += 2 * splitDepth;
+    }
+    splitPos += parent.child(i).nodeSize;
+  }
+  return tr;
+}
+
+/// Build a command that splits a non-empty textblock at the top level
+/// of a list item by also splitting that list item.
+export function splitListItem(itemType: NodeType): Command {
+  return function (state: EditorState, dispatch?: (tr: Transaction) => void) {
+    let { $from, $to, node } = state.selection as NodeSelection;
+    if ((node && node.isBlock) || $from.depth < 2 || !$from.sameParent($to)) {
+      return false;
+    }
+    let grandParent = $from.node(-1);
+    if (grandParent.type != itemType) return false;
+    if (
+      $from.parent.content.size == 0 &&
+      $from.node(-1).childCount == $from.indexAfter(-1)
+    ) {
+      // In an empty block. If this is a nested list, the wrapping
+      // list item should be split. Otherwise, bail out and let next
+      // command handle lifting.
+      if (
+        $from.depth == 3 ||
+        $from.node(-3).type != itemType ||
+        $from.index(-2) != $from.node(-2).childCount - 1
+      ) {
+        return false;
+      }
+      if (dispatch) {
+        let wrap = Fragment.empty;
+        let depthBefore = $from.index(-1) ? 1 : $from.index(-2) ? 2 : 3;
+        // Build a fragment containing empty versions of the structure
+        // from the outer list item to the parent node of the cursor
+        for (let d = $from.depth - depthBefore; d >= $from.depth - 3; d--) {
+          wrap = Fragment.from($from.node(d).copy(wrap));
+        }
+        let depthAfter =
+          $from.indexAfter(-1) < $from.node(-2).childCount
+            ? 1
+            : $from.indexAfter(-2) < $from.node(-3).childCount
+            ? 2
+            : 3;
+        // Add a second list item with an empty default start node
+        wrap = wrap.append(Fragment.from(itemType.createAndFill()));
+        let start = $from.before($from.depth - (depthBefore - 1));
+        let tr = state.tr.replace(
+          start,
+          $from.after(-depthAfter),
+          new Slice(wrap, 4 - depthBefore, 0)
+        );
+        let sel = -1;
+        tr.doc.nodesBetween(start, tr.doc.content.size, (node, pos) => {
+          if (sel > -1) return false;
+          if (node.isTextblock && node.content.size == 0) sel = pos + 1;
+        });
+        if (sel > -1) tr.setSelection(Selection.near(tr.doc.resolve(sel)));
+        dispatch(tr.scrollIntoView());
+      }
+      return true;
+    }
+    let nextType =
+      $to.pos == $from.end() ? grandParent.contentMatchAt(0).defaultType : null;
+    let tr = state.tr.delete($from.pos, $to.pos);
+    let types = nextType ? [null, { type: nextType }] : undefined;
+    if (!canSplit(tr.doc, $from.pos, 2, types)) return false;
+    if (dispatch) dispatch(tr.split($from.pos, 2, types).scrollIntoView());
+    return true;
+  };
+}
+
+/// Create a command to lift the list item around the selection up into
+/// a wrapping list.
+export function liftListItem(itemType: NodeType): Command {
+  return function (state: EditorState, dispatch?: (tr: Transaction) => void) {
+    let { $from, $to } = state.selection;
+    let range = $from.blockRange(
+      $to,
+      node => node.childCount > 0 && node.firstChild!.type == itemType
+    );
+    if (!range) return false;
+    if (!dispatch) return true;
+    if ($from.node(range.depth - 1).type == itemType) {
+      // Inside a parent list
+      return liftToOuterList(state, dispatch, itemType, range);
+    } // Outer list node
+    else {
+      return liftOutOfList(state, dispatch, range);
+    }
+  };
+}
+
+function liftToOuterList(
+  state: EditorState,
+  dispatch: (tr: Transaction) => void,
+  itemType: NodeType,
+  range: NodeRange
+) {
+  let tr = state.tr,
+    end = range.end,
+    endOfList = range.$to.end(range.depth);
+  if (end < endOfList) {
+    // There are siblings after the lifted items, which must become
+    // children of the last item
+    tr.step(
+      new ReplaceAroundStep(
+        end - 1,
+        endOfList,
+        end,
+        endOfList,
+        new Slice(
+          Fragment.from(itemType.create(null, range.parent.copy())),
+          1,
+          0
+        ),
+        1,
+        true
+      )
+    );
+    range = new NodeRange(
+      tr.doc.resolve(range.$from.pos),
+      tr.doc.resolve(endOfList),
+      range.depth
+    );
+  }
+  const target = liftTarget(range);
+  if (target == null) return false;
+  tr.lift(range, target);
+  let after = tr.mapping.map(end, -1) - 1;
+  if (canJoin(tr.doc, after)) tr.join(after);
+  dispatch(tr.scrollIntoView());
+  return true;
+}
+
+function liftOutOfList(
+  state: EditorState,
+  dispatch: (tr: Transaction) => void,
+  range: NodeRange
+) {
+  let tr = state.tr,
+    list = range.parent;
+  // Merge the list items into a single big item
+  for (
+    let pos = range.end, i = range.endIndex - 1, e = range.startIndex;
+    i > e;
+    i--
+  ) {
+    pos -= list.child(i).nodeSize;
+    tr.delete(pos - 1, pos + 1);
+  }
+  let $start = tr.doc.resolve(range.start),
+    item = $start.nodeAfter!;
+  if (tr.mapping.map(range.end) != range.start + $start.nodeAfter!.nodeSize) {
+    return false;
+  }
+  let atStart = range.startIndex == 0,
+    atEnd = range.endIndex == list.childCount;
+  let parent = $start.node(-1),
+    indexBefore = $start.index(-1);
+  if (
+    !parent.canReplace(
+      indexBefore + (atStart ? 0 : 1),
+      indexBefore + 1,
+      item.content.append(atEnd ? Fragment.empty : Fragment.from(list))
+    )
+  ) {
+    return false;
+  }
+  let start = $start.pos,
+    end = start + item.nodeSize;
+  // Strip off the surrounding list. At the sides where we're not at
+  // the end of the list, the existing list is closed. At sides where
+  // this is the end, it is overwritten to its end.
+  tr.step(
+    new ReplaceAroundStep(
+      start - (atStart ? 1 : 0),
+      end + (atEnd ? 1 : 0),
+      start + 1,
+      end - 1,
+      new Slice(
+        (atStart
+          ? Fragment.empty
+          : Fragment.from(list.copy(Fragment.empty))
+        ).append(
+          atEnd ? Fragment.empty : Fragment.from(list.copy(Fragment.empty))
+        ),
+        atStart ? 0 : 1,
+        atEnd ? 0 : 1
+      ),
+      atStart ? 0 : 1
+    )
+  );
+  dispatch(tr.scrollIntoView());
+  return true;
+}
+
+/// Create a command to sink the list item around the selection down
+/// into an inner list.
+export function sinkListItem(itemType: NodeType): Command {
+  return function (state, dispatch) {
+    let { $from, $to } = state.selection;
+    let range = $from.blockRange(
+      $to,
+      node => node.childCount > 0 && node.firstChild!.type == itemType
+    );
+    if (!range) return false;
+    let startIndex = range.startIndex;
+    if (startIndex == 0) return false;
+    let parent = range.parent,
+      nodeBefore = parent.child(startIndex - 1);
+    if (nodeBefore.type != itemType) return false;
+
+    if (dispatch) {
+      let nestedBefore =
+        nodeBefore.lastChild && nodeBefore.lastChild.type == parent.type;
+      let inner = Fragment.from(nestedBefore ? itemType.create() : null);
+      let slice = new Slice(
+        Fragment.from(
+          itemType.create(null, Fragment.from(parent.type.create(null, inner)))
+        ),
+        nestedBefore ? 3 : 1,
+        0
+      );
+      let before = range.start,
+        after = range.end;
+      dispatch(
+        state.tr
+          .step(
+            new ReplaceAroundStep(
+              before - (nestedBefore ? 3 : 1),
+              after,
+              before,
+              after,
+              slice,
+              1,
+              true
+            )
+          )
+          .scrollIntoView()
+      );
+    }
+    return true;
+  };
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/markdoc/clipboard.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/markdoc/clipboard.tsx
@@ -1,0 +1,129 @@
+import {
+  DOMParser,
+  DOMSerializer,
+  ResolvedPos,
+  Slice,
+} from 'prosemirror-model';
+import { Plugin } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+import { proseMirrorToMarkdoc } from './serialize';
+import Markdoc from '@markdoc/markdoc';
+import { markdocToProseMirror } from './parse';
+import { getEditorSchema } from '../schema';
+
+export function markdocClipboard() {
+  return new Plugin({
+    props: {
+      // TODO: for a doc like this:
+      // <doc>
+      //   <blockquote><paragraph>h<anchor/>ell</head>o</paragraph></blockquote>
+      // </doc>
+      // you shouldn't get the block quote
+      clipboardTextSerializer(content, view) {
+        try {
+          return Markdoc.format(
+            proseMirrorToMarkdoc(
+              view.state.doc.type.create({}, content.content)
+            )
+          );
+        } catch (err) {
+          console.log('failed to serialize clipboard text as markdoc', err);
+          return content.content.textBetween(0, content.content.size, '\n\n');
+        }
+      },
+      clipboardTextParser(text, $context, plain, view) {
+        try {
+          return Slice.maxOpen(
+            markdocToProseMirror(
+              Markdoc.parse(text),
+              getEditorSchema(view.state.schema)
+            ).content
+          );
+        } catch (err) {
+          console.log('failed to parse clipboard text as markdoc', err);
+          return defaultClipboardTextParser(text, $context, plain, view);
+        }
+      },
+      handlePaste(view, event) {
+        if (view.props.editable && !view.props.editable(view.state)) {
+          return false;
+        }
+        if (!event.clipboardData) {
+          return false;
+        }
+        const html = event.clipboardData.getData('text/html');
+        if (html && isProbablyHtmlFromVscode(html)) {
+          const plain = event.clipboardData.getData('text/plain');
+          view.pasteText(plain);
+          return true;
+        }
+        return false;
+      },
+    },
+  });
+}
+
+// vscode adds extra data to the DataTransfer but those only exist when pasted into a chromium browser
+// this works across browser
+function isProbablyHtmlFromVscode(html: string) {
+  const parser = new globalThis.DOMParser();
+  const parsed = parser.parseFromString(html, 'text/html');
+  const firstDiv = parsed.body.firstElementChild;
+  if (
+    parsed.body.childElementCount !== 1 ||
+    firstDiv?.tagName !== 'DIV' ||
+    !(firstDiv instanceof HTMLElement) ||
+    !firstDiv.style.fontFamily.includes('monospace')
+  ) {
+    return false;
+  }
+  for (const line of firstDiv.children) {
+    if (line.tagName === 'BR') continue;
+    if (line.tagName !== 'DIV') return false;
+    for (const span of line.children) {
+      if (span.tagName !== 'SPAN') return false;
+    }
+  }
+  return true;
+}
+
+function defaultClipboardTextParser(
+  text: string,
+  $context: ResolvedPos,
+  plain: boolean,
+  view: EditorView
+) {
+  let marks = $context.marks();
+  let { schema } = view.state,
+    serializer = DOMSerializer.fromSchema(schema);
+  let dom = document.createElement('div');
+  text.split(/(?:\r\n?|\n)+/).forEach(block => {
+    let p = dom!.appendChild(document.createElement('p'));
+    if (block) {
+      p.appendChild(serializer.serializeNode(schema.text(block, marks)));
+    }
+  });
+  let parser =
+    view.someProp('clipboardParser') ||
+    view.someProp('domParser') ||
+    DOMParser.fromSchema(view.state.schema);
+  return parser.parseSlice(dom!, {
+    preserveWhitespace: true,
+    context: $context,
+    // @ts-expect-error
+    ruleFromNode(dom: HTMLElement) {
+      if (
+        dom.nodeName == 'BR' &&
+        !dom.nextSibling &&
+        dom.parentNode &&
+        !inlineParents.test(dom.parentNode.nodeName)
+      ) {
+        return { ignore: true };
+      }
+      return null;
+    },
+  });
+}
+
+const inlineParents =
+  /^(a|abbr|acronym|b|cite|code|del|em|i|ins|kbd|label|output|q|ruby|s|samp|span|strong|sub|sup|time|u|tt|var)$/i;

--- a/packages/keystatic/src/form/fields/markdoc/editor/markdoc/parse.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/markdoc/parse.ts
@@ -1,0 +1,335 @@
+'use client';
+import { Ast, Node as MarkdocNode, ValidateError } from '@markdoc/markdoc';
+import {
+  Mark,
+  MarkType,
+  NodeType,
+  Node as ProseMirrorNode,
+} from 'prosemirror-model';
+import { EditorSchema } from '../schema';
+
+let state:
+  | { schema: EditorSchema; errors: ValidateError[]; marks: readonly Mark[] }
+  | undefined;
+function getState(): typeof state & {} {
+  if (!state) {
+    throw new Error('state not set');
+  }
+  return state;
+}
+
+function getSchema() {
+  return getState().schema;
+}
+
+function error(error: ValidateError) {
+  getState().errors.push(error);
+}
+
+function withMark<T>(mark: Mark, fn: () => T): T {
+  const state = getState();
+  const oldMarks = state.marks;
+  state.marks = mark.addToSet(state.marks);
+  try {
+    return fn();
+  } finally {
+    state.marks = oldMarks;
+  }
+}
+
+function childrenToProseMirrorNodes(nodes: MarkdocNode[]) {
+  const children: ProseMirrorNode[] = [];
+  for (const node of nodes) {
+    const pmNode = markdocNodeToProseMirrorNode(node);
+    if (pmNode) {
+      if (Array.isArray(pmNode)) {
+        children.push(...pmNode);
+      } else {
+        children.push(pmNode);
+      }
+    }
+  }
+  return children;
+}
+
+function notAllowed(node: MarkdocNode) {
+  error({
+    error: {
+      id: 'unspecified-type',
+      level: 'critical',
+      message: `${node.type} is not allowed`,
+    },
+    lines: node.lines,
+    type: node.type,
+    location: node.location,
+  });
+  return childrenToProseMirrorNodes(node.children);
+}
+
+function createAndFill(
+  markdocNode: MarkdocNode,
+  nodeType: NodeType,
+  attrs: Record<string, any>,
+  extraChildren?: ProseMirrorNode[]
+) {
+  const children = childrenToProseMirrorNodes(markdocNode.children);
+  const node = nodeType.createAndFill(
+    attrs,
+    extraChildren ? [...children, ...extraChildren] : children
+  );
+  if (!node) {
+    error({
+      error: {
+        id: 'unexpected-children',
+        level: 'critical',
+        message: `${markdocNode.type} has unexpected children`,
+      },
+      lines: markdocNode.lines,
+      type: markdocNode.type,
+      location: markdocNode.location,
+    });
+  }
+  return node;
+}
+
+function addMark(node: MarkdocNode, mark: Mark | MarkType | undefined) {
+  if (!mark) return notAllowed(node);
+  return withMark(mark instanceof MarkType ? mark.create() : mark, () =>
+    childrenToProseMirrorNodes(node.children)
+  );
+}
+
+export function markdocToProseMirror(
+  node: MarkdocNode,
+  schema: EditorSchema
+): ProseMirrorNode {
+  state = {
+    schema,
+    errors: [],
+    marks: [],
+  };
+  try {
+    let pmNode = markdocNodeToProseMirrorNode(node);
+    if (state.errors.length) {
+      throw new Error(
+        state.errors.map(e => e.lines[0] + ':' + e.error.message).join('\n')
+      );
+    }
+    if (!(pmNode instanceof ProseMirrorNode)) {
+      throw new Error('unexpected node');
+    }
+    return pmNode;
+  } finally {
+    state = undefined;
+  }
+}
+
+function parseAnnotations(node: MarkdocNode): ProseMirrorNode[] {
+  const schema = getSchema();
+  return node.annotations.map((x): ProseMirrorNode => {
+    if (x.type === 'id') {
+      return schema.nodes.attribute.createChecked({ key: 'id' }, [
+        schema.nodes.attribute_string.createChecked(null, [
+          schema.schema.text(x.name),
+        ]),
+      ]);
+    }
+    if (x.type === 'class') {
+      return schema.nodes.attribute.createChecked({ key: 'class' }, [
+        schema.nodes.attribute_string.createChecked(null, [
+          schema.schema.text(x.name),
+        ]),
+      ]);
+    }
+    let val: undefined | ProseMirrorNode;
+    if (typeof x.value === 'string') {
+      val = schema.nodes.attribute_string.createChecked(null, [
+        schema.schema.text(x.value),
+      ]);
+    }
+    if (x.value === true) {
+      val = schema.nodes.attribute_true.createChecked();
+    }
+    if (x.value === false) {
+      val = schema.nodes.attribute_false.createChecked();
+    }
+    if (val === undefined) {
+      error({
+        error: {
+          id: 'unimplemented-annotation',
+          level: 'critical',
+          message: `currently, only string and boolean annotations are implemented (got ${x.value})`,
+        },
+        lines: node.lines,
+        type: node.type,
+        location: node.location,
+      });
+      return schema.nodes.attribute.createAndFill({ key: x.name })!;
+    }
+    return schema.nodes.attribute.createChecked({ key: x.name }, [val]);
+  });
+}
+
+function markdocNodeToProseMirrorNode(
+  node: MarkdocNode
+): ProseMirrorNode | ProseMirrorNode[] | null {
+  if (node.errors.length) {
+    for (const err of node.errors) {
+      error({
+        error: err,
+        lines: node.lines,
+        type: node.type,
+        location: node.location,
+      });
+    }
+    return null;
+  }
+  if (node.type === 'error') {
+    error({
+      error: {
+        id: 'error-node',
+        level: 'critical',
+        message: 'Unexpected error node without errors',
+      },
+      lines: node.lines,
+      type: node.type,
+      location: node.location,
+    });
+    return null;
+  }
+  const schema = getSchema();
+  if (node.type === 'inline') {
+    return childrenToProseMirrorNodes(node.children);
+  }
+  if (node.type === 'em') {
+    return addMark(node, schema.marks.italic);
+  }
+  if (node.type === 'code') {
+    return addMark(node, schema.marks.code);
+  }
+  if (node.type === 's') {
+    return addMark(node, schema.marks.strikethrough);
+  }
+  if (node.type === 'strong') {
+    return addMark(node, schema.marks.bold);
+  }
+  if (node.type === 'softbreak') {
+    return schema.schema.text('\n');
+  }
+  if (node.type === 'hardbreak') {
+    if (!schema.nodes.hard_break) return notAllowed(node);
+    return schema.nodes.hard_break.create();
+  }
+  if (node.type === 'blockquote') {
+    return createAndFill(node, schema.nodes.blockquote, {});
+  }
+  if (node.type === 'heading') {
+    return createAndFill(
+      node,
+      schema.nodes.heading,
+      {
+        level: node.attributes.level,
+      },
+      parseAnnotations(node)
+    );
+  }
+  if (node.type === 'paragraph') {
+    return createAndFill(
+      node,
+      schema.nodes.paragraph,
+      {},
+      parseAnnotations(node)
+    );
+  }
+  if (node.type === 'comment') {
+    return [];
+  }
+  if (node.type === 'document') {
+    return createAndFill(node, schema.nodes.doc, {});
+  }
+  if (node.type === 'fence') {
+    return createAndFill(node, schema.nodes.code_block, {
+      language:
+        typeof node.attributes.language === 'string'
+          ? node.attributes.language
+          : 'plain',
+    });
+  }
+  if (node.type === 'hr') {
+    return createAndFill(node, schema.nodes.divider, {});
+  }
+  if (node.type === 'link') {
+    return addMark(
+      node,
+      schema.marks.link?.create({ href: node.attributes.href })
+    );
+  }
+  if (node.type === 'text') {
+    return schema.schema.text(node.attributes.content, getState().marks);
+  }
+  if (node.type === 'item') {
+    if (node.children[0]?.type === 'inline') {
+      node = new Ast.Node('item', node.attributes, [
+        new Ast.Node('paragraph', {}, node.children),
+      ]);
+    }
+    return createAndFill(node, schema.nodes.list_item, {});
+  }
+  if (node.type === 'list') {
+    return createAndFill(
+      node,
+      node.attributes.ordered
+        ? schema.nodes.ordered_list
+        : schema.nodes.unordered_list,
+      {}
+    );
+  }
+  if (node.type === 'tag' && node.tag) {
+    const children = childrenToProseMirrorNodes(node.children);
+    const tagChildren = [
+      schema.nodes.tag_attributes.createChecked(null, parseAnnotations(node)),
+      ...Object.entries(node.slots).map(
+        ([slotName, slotContent]) => (
+          console.log(slotContent),
+          schema.nodes.tag_slot.createChecked(
+            { name: slotName },
+            childrenToProseMirrorNodes([slotContent])
+          )
+        )
+      ),
+      ...(children.length
+        ? [schema.nodes.tag_slot.createChecked({ name: 'children' }, children)]
+        : []),
+    ];
+
+    const pmNode = schema.nodes.tag.createChecked(
+      { name: node.tag },
+      tagChildren
+    );
+    if (!pmNode) {
+      error({
+        error: {
+          id: 'unexpected-children',
+          level: 'critical',
+          message: `${node.type} has unexpected children`,
+        },
+        lines: node.lines,
+        type: node.type,
+        location: node.location,
+      });
+    }
+    return pmNode;
+  }
+
+  error({
+    error: {
+      id: 'unhandled-type',
+      level: 'critical',
+      message: `Unhandled type ${node.type}`,
+    },
+    lines: node.lines,
+    type: node.type,
+    location: node.location,
+  });
+  return null;
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/markdoc/serialize.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/markdoc/serialize.ts
@@ -1,0 +1,103 @@
+'use client';
+import { Ast, Node as MarkdocNode, NodeType } from '@markdoc/markdoc';
+import { Fragment, Mark, Node as ProseMirrorNode } from 'prosemirror-model';
+import { getEditorSchema } from '../schema';
+
+function blocks(fragment: Fragment): MarkdocNode[] {
+  const children: MarkdocNode[] = [];
+  fragment.forEach(child => {
+    children.push(proseMirrorToMarkdoc(child));
+  });
+  return children;
+}
+
+function inline(fragment: Fragment): MarkdocNode[] {
+  return [new Ast.Node('inline', {}, textblockChildren(fragment))];
+}
+
+// TODO: this should handle marks spanning over multiple text nodes properly
+function textblockChildren(fragment: Fragment): MarkdocNode[] {
+  const children: MarkdocNode[] = [];
+  fragment.forEach(child => {
+    if (child.text !== undefined) {
+      let node = new Ast.Node('text', { content: child.text }, []);
+      const schema = getEditorSchema(child.type.schema);
+      let linkMark: Mark | undefined;
+      for (const mark of child.marks) {
+        if (mark.type === schema.marks.link) {
+          linkMark = mark;
+          continue;
+        }
+        let type: NodeType | undefined;
+        if (mark.type === schema.marks.bold) {
+          type = 'strong';
+        }
+        if (mark.type === schema.marks.code) {
+          type = 'code';
+        }
+        if (mark.type === schema.marks.italic) {
+          type = 'em';
+        }
+        if (mark.type === schema.marks.strikethrough) {
+          type = 's';
+        }
+        if (type) {
+          node = new Ast.Node(type, { type: mark.type.name }, [node]);
+        }
+      }
+      if (linkMark) {
+        node = new Ast.Node('link', { href: linkMark.attrs.href }, [node]);
+      }
+      children.push(node);
+    }
+  });
+  return children;
+}
+
+export function proseMirrorToMarkdoc(node: ProseMirrorNode): MarkdocNode {
+  const schema = getEditorSchema(node.type.schema);
+  if (node.type === schema.nodes.doc) {
+    return new Ast.Node('document', {}, blocks(node.content));
+  }
+  if (node.type === schema.nodes.paragraph) {
+    return new Ast.Node('paragraph', {}, inline(node.content));
+  }
+  if (node.type === schema.nodes.blockquote) {
+    return new Ast.Node('blockquote', {}, blocks(node.content));
+  }
+  if (node.type === schema.nodes.divider) {
+    return new Ast.Node('hr');
+  }
+  if (node.type === schema.nodes.heading) {
+    return new Ast.Node(
+      'heading',
+      { level: node.attrs.level },
+      inline(node.content)
+    );
+  }
+  if (node.type === schema.nodes.code_block) {
+    return new Ast.Node(
+      'fence',
+      typeof node.attrs.language === 'string' && node.attrs.language !== 'plain'
+        ? {
+            language: node.attrs.language,
+            content: node.textBetween(0, node.content.size) + '\n',
+          }
+        : { content: node.textBetween(0, node.content.size) + '\n' },
+      inline(node.content)
+    );
+  }
+  if (node.type === schema.nodes.list_item) {
+    return new Ast.Node('item', {}, blocks(node.content));
+  }
+  if (node.type === schema.nodes.ordered_list) {
+    return new Ast.Node('list', { ordered: true }, blocks(node.content));
+  }
+  if (node.type === schema.nodes.unordered_list) {
+    return new Ast.Node('list', { ordered: false }, blocks(node.content));
+  }
+
+  return new Ast.Node('paragraph', {}, inline(node.content));
+
+  throw new Error('unhandled node type');
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/new-primitives/EditorListbox.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/new-primitives/EditorListbox.tsx
@@ -1,0 +1,96 @@
+import { useSelectableCollection } from '@react-aria/selection';
+import { chain } from '@react-aria/utils';
+import { useListState } from '@react-stately/list';
+import {
+  AriaLabelingProps,
+  CollectionBase,
+  MultipleSelection,
+} from '@react-types/shared';
+import { Key, RefObject, useEffect, useRef } from 'react';
+
+import { ListBoxBase, listStyles, useListBoxLayout } from '@voussoir/listbox';
+import { BaseStyleProps } from '@voussoir/style';
+
+export type EditorListboxProps<T> = {
+  listenerRef: RefObject<HTMLElement>;
+  scrollRef?: RefObject<HTMLElement>;
+  onAction?: (key: Key) => void;
+  onEscape?: () => void;
+} & CollectionBase<T> &
+  AriaLabelingProps &
+  MultipleSelection &
+  Pick<
+    BaseStyleProps,
+    | 'height'
+    | 'width'
+    | 'maxHeight'
+    | 'maxWidth'
+    | 'minHeight'
+    | 'minWidth'
+    | 'UNSAFE_className'
+    | 'UNSAFE_style'
+  >;
+
+export function useEditorListbox<T extends object>(
+  props: EditorListboxProps<T>
+) {
+  let { listenerRef, onEscape, scrollRef, ...otherProps } = props;
+  let state = useListState(props);
+  let layout = useListBoxLayout(state);
+
+  // keyboard and selection management
+  let listboxRef = useRef<HTMLDivElement>(null);
+  let { collectionProps } = useSelectableCollection({
+    keyboardDelegate: layout,
+    ref: listenerRef,
+    scrollRef: scrollRef ?? listboxRef,
+    selectionManager: state.selectionManager,
+    disallowEmptySelection: true,
+    disallowTypeAhead: true,
+    isVirtualized: true,
+    shouldFocusWrap: true,
+  });
+
+  let onKeyDown = (e: KeyboardEvent) => {
+    switch (e.key) {
+      case 'Enter':
+        state.selectionManager.select(state.selectionManager.focusedKey);
+        props.onAction?.(state.selectionManager.focusedKey);
+        e.preventDefault();
+        break;
+      case 'Escape':
+        onEscape?.();
+        break;
+    }
+  };
+
+  let keydownListener = chain(onKeyDown, collectionProps.onKeyDown);
+  return {
+    keydownListener,
+    listbox: (
+      <ListBoxBase
+        ref={listboxRef}
+        layout={layout}
+        state={state}
+        autoFocus="first"
+        // focusOnPointerEnter
+        shouldUseVirtualFocus
+        shouldFocusWrap
+        UNSAFE_className={listStyles}
+        {...otherProps}
+      />
+    ),
+  };
+}
+
+export function EditorListbox<T extends object>(props: EditorListboxProps<T>) {
+  const { keydownListener, listbox } = useEditorListbox(props);
+
+  useEffect(() => {
+    let domNode = props.listenerRef.current;
+    domNode?.addEventListener('keydown', keydownListener);
+    return () => domNode?.removeEventListener('keydown', keydownListener);
+  }, [keydownListener, props.listenerRef]);
+
+  return listbox;
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/new-primitives/EditorPopover.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/new-primitives/EditorPopover.tsx
@@ -1,0 +1,164 @@
+import {
+  HTMLProps,
+  ReactNode,
+  forwardRef,
+  useImperativeHandle,
+  useState,
+} from 'react';
+import {
+  ContextData,
+  FloatingPortal,
+  Middleware,
+  Placement,
+  ReferenceElement,
+  autoUpdate,
+  flip,
+  inline,
+  limitShift,
+  offset,
+  shift,
+  size,
+  useFloating,
+} from '@floating-ui/react';
+import {
+  BaseStyleProps,
+  classNames,
+  css,
+  tokenSchema,
+  useStyleProps,
+} from '@voussoir/style';
+
+export type EditorPopoverProps = {
+  children: ReactNode;
+  reference: ReferenceElement;
+  placement?: Placement;
+  /**
+   * How the popover should adapt when constrained by available space in the viewport.
+   * @default 'flip'
+   */
+  adaptToViewport?: 'flip' | 'stick' | 'stretch';
+} & Pick<
+  BaseStyleProps,
+  | 'height'
+  | 'width'
+  | 'maxHeight'
+  | 'maxWidth'
+  | 'minHeight'
+  | 'minWidth'
+  | 'UNSAFE_className'
+  | 'UNSAFE_style'
+>;
+
+export type EditorPopoverRef = { context: ContextData; update: () => void };
+
+export const EditorPopover = forwardRef<EditorPopoverRef, EditorPopoverProps>(
+  function EditorPopover(props, forwardedRef) {
+    const { children, reference, placement = 'bottom' } = props;
+
+    const styleProps = useStyleProps(props);
+    const [floating, setFloating] = useState<HTMLDivElement | null>(null);
+    const middleware = getMiddleware(props);
+    const { floatingStyles, context, update } = useFloating({
+      elements: { reference, floating },
+      middleware,
+      placement,
+      whileElementsMounted: autoUpdate,
+    });
+
+    useImperativeHandle(
+      forwardedRef,
+      () => {
+        return { context, update };
+      },
+      [context, update]
+    );
+
+    return (
+      <FloatingPortal>
+        <DialogElement
+          ref={setFloating}
+          {...styleProps}
+          style={{ ...floatingStyles, ...styleProps.style }}
+        >
+          {children}
+        </DialogElement>
+      </FloatingPortal>
+    );
+  }
+);
+
+// Utils
+// ------------------------------
+
+export const DEFAULT_OFFSET = 8;
+
+export function getMiddleware(
+  props: EditorPopoverProps
+): Array<Middleware | null | undefined | false> {
+  const { adaptToViewport } = props;
+
+  if (adaptToViewport === 'stick') {
+    return [
+      offset(DEFAULT_OFFSET),
+      shift({
+        crossAxis: true,
+        padding: DEFAULT_OFFSET,
+        limiter: limitShift({
+          offset: ({ rects }) => ({
+            crossAxis: rects.floating.height,
+          }),
+        }),
+      }),
+    ];
+  }
+  if (adaptToViewport === 'stretch') {
+    return [
+      flip(),
+      offset(DEFAULT_OFFSET),
+      size({
+        apply({ elements, availableHeight }) {
+          Object.assign(elements.floating.style, {
+            maxHeight: `${availableHeight}px`,
+          });
+        },
+        padding: DEFAULT_OFFSET,
+      }),
+    ];
+  }
+
+  return [
+    offset(DEFAULT_OFFSET),
+    flip({ padding: DEFAULT_OFFSET }),
+    shift({ padding: DEFAULT_OFFSET }),
+    inline(),
+  ];
+}
+
+// Styled components
+// ------------------------------
+
+export const DialogElement = forwardRef<
+  HTMLDivElement,
+  HTMLProps<HTMLDivElement>
+>(function DialogElement(props, forwardedRef) {
+  return (
+    <div
+      role="dialog"
+      ref={forwardedRef}
+      {...props}
+      className={classNames(
+        css({
+          backgroundColor: tokenSchema.color.background.surface,
+          borderRadius: tokenSchema.size.radius.medium,
+          border: `${tokenSchema.size.border.regular} solid ${tokenSchema.color.border.emphasis}`,
+          boxShadow: `${tokenSchema.size.shadow.medium} ${tokenSchema.color.shadow.regular}`,
+          boxSizing: 'content-box', // resolves measurement/scroll issues related to border
+          minHeight: tokenSchema.size.element.regular,
+          minWidth: tokenSchema.size.element.regular,
+          outline: 0,
+        }),
+        props.className
+      )}
+    />
+  );
+});

--- a/packages/keystatic/src/form/fields/markdoc/editor/new-primitives/EditorToolbar.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/new-primitives/EditorToolbar.tsx
@@ -1,0 +1,393 @@
+import { FocusScope, createFocusManager } from '@react-aria/focus';
+import { useLocale } from '@react-aria/i18n';
+import { PressProps, PressResponder } from '@react-aria/interactions';
+import { isMac, mergeProps } from '@react-aria/utils';
+import { useControlledState } from '@react-stately/utils';
+import {
+  AriaLabelingProps,
+  DOMAttributes,
+  ValueBase,
+} from '@react-types/shared';
+import { assertNever } from 'emery';
+
+import {
+  ActionButton,
+  ToggleButton,
+  ToggleButtonProps,
+} from '@voussoir/button';
+import { Divider, Flex } from '@voussoir/layout';
+import { filterDOMProps } from '@voussoir/utils';
+import {
+  Dispatch,
+  Key,
+  KeyboardEvent,
+  PropsWithChildren,
+  ReactNode,
+  RefObject,
+  SetStateAction,
+  createContext,
+  useContext,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
+
+type EditorToolbarState = {
+  /** The value of the last focused node. */
+  readonly lastFocusedId: Key | null;
+  /** Sets the last focused node. */
+  setLastFocusedId: Dispatch<SetStateAction<Key | null>>;
+};
+type EditorToolbarContextType = {
+  state: EditorToolbarState;
+};
+const EditorToolbarContext = createContext<EditorToolbarContextType | null>(
+  null
+);
+function useToolbarContext() {
+  let context = useContext(EditorToolbarContext);
+  if (context == null) {
+    throw new Error('useToolbarContext must be used within a EditorToolbar');
+  }
+  return context;
+}
+
+type EditorToolbarProps = PropsWithChildren<{}> & AriaLabelingProps;
+export function EditorToolbar(props: EditorToolbarProps) {
+  let { children } = props;
+  let ref = useRef<HTMLDivElement>(null);
+  let { state, toolbarProps } = useToolbar(props, ref);
+
+  return (
+    <EditorToolbarContext.Provider value={{ state }}>
+      <FocusScope>
+        <Flex gap="regular" ref={ref} {...toolbarProps}>
+          {children}
+        </Flex>
+      </FocusScope>
+    </EditorToolbarContext.Provider>
+  );
+}
+
+// =============================================================================
+// Group
+// =============================================================================
+
+type GroupSelectionType =
+  | {
+      selectionMode: 'single';
+      selectedValue: Key | null;
+      setSelectedValue: (value: Key | null) => void;
+    }
+  | {
+      selectionMode: 'multiple';
+      selectedValue: Key[];
+      setSelectedValue: (value: Key[]) => void;
+    };
+const GroupSelectionContext = createContext<GroupSelectionType | null>(null);
+function useGroupSelectionContext() {
+  let context = useContext(GroupSelectionContext);
+  if (context == null) {
+    throw new Error('useGroupSelectionContext must be used within a group');
+  }
+  return context;
+}
+function useSelectionItem(props: EditorToolbarItemProps): {
+  isSelected: boolean;
+  buttonProps: PressProps & DOMAttributes;
+} {
+  let { isDisabled, value } = props;
+  let context = useGroupSelectionContext();
+
+  if (context.selectionMode === 'single') {
+    let { selectedValue, setSelectedValue } = context;
+    let isSelected = selectedValue === value;
+    return {
+      isSelected,
+      buttonProps: {
+        'aria-checked': isSelected,
+        onPress: () => {
+          if (isDisabled) {
+            return;
+          }
+
+          if (isSelected) {
+            setSelectedValue(null);
+          } else {
+            setSelectedValue(value);
+          }
+        },
+        role: 'radio' as const,
+      },
+    };
+  }
+  if (context.selectionMode === 'multiple') {
+    let { selectedValue, setSelectedValue } = context;
+    let isSelected = selectedValue.includes(value);
+    return {
+      isSelected,
+      buttonProps: {
+        'aria-pressed': isSelected,
+        onPress: () => {
+          if (isDisabled) {
+            return;
+          }
+
+          if (selectedValue.includes(value)) {
+            setSelectedValue(
+              selectedValue.filter(existingValue => existingValue !== value)
+            );
+          } else {
+            setSelectedValue(selectedValue.concat(value));
+          }
+        },
+      },
+    };
+  }
+  assertNever(context);
+}
+
+export type SelectionMode = 'none' | 'single' | 'multiple';
+type EditorToolbarGroupProps = AriaLabelingProps & {
+  /** The contents of the group. */
+  children?: ReactNode;
+} & (
+    | ({ selectionMode: 'multiple' } & ValueBase<Key[]>)
+    | ({ selectionMode: 'single' } & ValueBase<Key | null>)
+    | { selectionMode?: 'none' }
+  );
+export function EditorToolbarGroup(props: EditorToolbarGroupProps) {
+  if (props.selectionMode === 'single') {
+    return <EditorSingleSelectionGroup {...props} />;
+  }
+  if (props.selectionMode === 'multiple') {
+    return <EditorMultipleSelectionGroup {...props} />;
+  }
+
+  return (
+    <Flex gap="xsmall" role="group" {...filterDOMPropsWithLabelWarning(props)}>
+      {props.children}
+    </Flex>
+  );
+}
+/** @private SINGLE selection */
+function EditorSingleSelectionGroup(
+  props: EditorToolbarGroupProps & { selectionMode: 'single' }
+) {
+  let [selectedValue, setSelectedValue] = useControlledState<Key | null>(
+    props.value!,
+    props.defaultValue!,
+    props.onChange!
+  );
+
+  let context = {
+    selectionMode: props.selectionMode,
+    selectedValue,
+    setSelectedValue,
+  };
+
+  return (
+    <GroupSelectionContext.Provider value={context}>
+      <Flex
+        gap="xsmall"
+        role="radiogroup"
+        {...filterDOMPropsWithLabelWarning(props)}
+      >
+        {props.children}
+      </Flex>
+    </GroupSelectionContext.Provider>
+  );
+}
+/** @private MULTI selection */
+function EditorMultipleSelectionGroup(
+  props: EditorToolbarGroupProps & { selectionMode: 'multiple' }
+) {
+  let [selectedValue, setSelectedValue] = useControlledState(
+    props.value!,
+    props.defaultValue || [],
+    props.onChange!
+  );
+
+  let context = {
+    selectionMode: props.selectionMode,
+    selectedValue,
+    setSelectedValue,
+  };
+
+  return (
+    <GroupSelectionContext.Provider value={context}>
+      <Flex
+        gap="xsmall"
+        role="group"
+        {...filterDOMPropsWithLabelWarning(props)}
+      >
+        {props.children}
+      </Flex>
+    </GroupSelectionContext.Provider>
+  );
+}
+
+// =============================================================================
+// Item
+// =============================================================================
+
+type EditorToolbarItemProps = {
+  /** The contents of the item. */
+  children?: ReactNode;
+  /** Whether the item is disabled. */
+  isDisabled?: boolean;
+  /** The value of the item. */
+  value: Key;
+};
+
+/** A toolbar item may be a checkbox/radio/toggle button, depending on context. */
+export function EditorToolbarItem(props: EditorToolbarItemProps) {
+  let { children, isDisabled, ...otherProps } = props;
+  let { itemProps } = useToolbarItem(props);
+  let { isSelected, buttonProps } = useSelectionItem(props);
+
+  return (
+    // Use a PressResponder to send DOM props through, allow overriding things
+    // like role and tabIndex.
+    <PressResponder {...mergeProps(buttonProps, itemProps)}>
+      <ActionButton
+        prominence="low"
+        isDisabled={isDisabled}
+        isSelected={isSelected}
+        {...otherProps}
+      >
+        {children}
+      </ActionButton>
+    </PressResponder>
+  );
+}
+
+type EditorToolbarButtonProps = Omit<ToggleButtonProps, 'prominence'>;
+export function EditorToolbarButton(props: EditorToolbarButtonProps) {
+  let { itemProps } = useToolbarItem(props);
+
+  return (
+    <PressResponder {...itemProps}>
+      <ToggleButton prominence="low" {...props} />
+    </PressResponder>
+  );
+}
+
+export function EditorToolbarSeparator() {
+  return <Divider orientation="vertical" flexShrink={0} />;
+}
+
+// =============================================================================
+// Utils
+// =============================================================================
+
+function filterDOMPropsWithLabelWarning<P extends AriaLabelingProps>(props: P) {
+  let { 'aria-labelledby': ariaLabelledby, 'aria-label': ariaLabel } = props;
+
+  if (!ariaLabelledby && !ariaLabel) {
+    console.warn(
+      'You must specify an aria-label or aria-labelledby attribute for accessibility.'
+    );
+  }
+
+  return filterDOMProps(props, { labellable: true });
+}
+
+function useToolbarItem<P extends { isDisabled?: boolean }>(props: P) {
+  let { isDisabled } = props;
+  let { state } = useToolbarContext();
+  let { lastFocusedId, setLastFocusedId } = state;
+  let id = useId();
+  let tabIndex = lastFocusedId === id || lastFocusedId == null ? 0 : -1;
+
+  // clear the last focused ID when the item is unmounted or becomes disabled,
+  // which will reset the tabIndex for each item to 0 avoiding a situation where
+  // the user cannot tab to any items
+  useEffect(() => {
+    let reset = (lastId: Key | null) => (lastId === id ? null : lastId);
+    if (isDisabled) {
+      setLastFocusedId(reset);
+    }
+    return () => {
+      setLastFocusedId(reset);
+    };
+  }, [id, isDisabled, setLastFocusedId]);
+
+  return {
+    itemProps: {
+      tabIndex,
+      onFocus: () => {
+        setLastFocusedId(id);
+      },
+    },
+  };
+}
+
+function useToolbar(props: EditorToolbarProps, ref: RefObject<HTMLElement>) {
+  let [lastFocusedId, setLastFocusedId] = useState<Key | null>(null);
+  let { direction } = useLocale();
+  let focusManager = createFocusManager(ref, { wrap: true });
+  let isRtl = direction === 'rtl';
+
+  let onKeyDown = (e: KeyboardEvent) => {
+    if (!e.currentTarget.contains(e.target as HTMLElement)) {
+      return;
+    }
+
+    // let users navigate by group with alt/ctrl + arrow keys
+    let accept = (node: Element) => {
+      let isFirstChild = node.parentElement?.firstElementChild === node;
+      let isGroupChild = /group/.test(node.parentElement?.role || '');
+
+      return !isGroupChild || isFirstChild;
+    };
+    let options = (isMac() ? e.altKey : e.ctrlKey) ? { accept } : {};
+
+    switch (e.key) {
+      case 'Home':
+        e.preventDefault();
+        e.stopPropagation();
+        focusManager.focusFirst();
+        break;
+      case 'End':
+        e.preventDefault();
+        e.stopPropagation();
+        focusManager.focusLast();
+        break;
+      case 'ArrowRight':
+      case 'ArrowDown':
+        e.preventDefault();
+        e.stopPropagation();
+        if (e.key === 'ArrowRight' && isRtl) {
+          focusManager.focusPrevious(options);
+        } else {
+          focusManager.focusNext(options);
+        }
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        e.stopPropagation();
+        if (e.key === 'ArrowLeft' && isRtl) {
+          focusManager.focusNext(options);
+        } else {
+          focusManager.focusPrevious(options);
+        }
+        break;
+    }
+  };
+
+  return {
+    toolbarProps: {
+      ...filterDOMPropsWithLabelWarning(props),
+      onKeyDown,
+      role: 'toolbar',
+      'aria-orientation': 'horizontal' as const,
+    },
+    state: {
+      lastFocusedId,
+      setLastFocusedId,
+    },
+  };
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/new-primitives/index.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/new-primitives/index.ts
@@ -1,0 +1,17 @@
+export {
+  EditorListbox,
+  useEditorListbox,
+  type EditorListboxProps,
+} from './EditorListbox';
+export type { ReferenceElement, VirtualElement } from '@floating-ui/react';
+export { Item, Section } from '@voussoir/listbox';
+export { EditorPopover } from './EditorPopover';
+export {
+  EditorToolbar,
+  EditorToolbarButton,
+  EditorToolbarGroup,
+  EditorToolbarItem,
+  EditorToolbarSeparator,
+} from './EditorToolbar';
+
+export type { EditorPopoverProps, EditorPopoverRef } from './EditorPopover';

--- a/packages/keystatic/src/form/fields/markdoc/editor/node-in-selection.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/node-in-selection.ts
@@ -1,0 +1,40 @@
+import { AllSelection, Plugin, TextSelection } from 'prosemirror-state';
+import { Decoration, DecorationSet } from 'prosemirror-view';
+import { classes } from './utils';
+
+export function nodeInSelectionDecorations() {
+  return new Plugin({
+    props: {
+      decorations(state) {
+        const decorations: Decoration[] = [];
+        let from: number | undefined, to: number | undefined;
+        if (state.selection instanceof TextSelection) {
+          ({ from, to } = state.selection);
+        }
+        if (state.selection instanceof AllSelection) {
+          from = 0;
+          to = state.doc.content.size;
+        }
+        if (from !== undefined && to !== undefined) {
+          const _from = from;
+          const _to = to;
+          state.doc.nodesBetween(from, to, (node, pos) => {
+            if (node.isText) {
+              return;
+            }
+            const nodeFrom = pos;
+            const nodeTo = pos + node.nodeSize;
+            if (nodeFrom >= _from && nodeTo <= _to) {
+              decorations.push(
+                Decoration.node(pos, pos + node.nodeSize, {
+                  class: classes.nodeInSelection,
+                })
+              );
+            }
+          });
+        }
+        return DecorationSet.create(state.doc, decorations);
+      },
+    },
+  });
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/popovers/code-block-language.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/popovers/code-block-language.tsx
@@ -1,0 +1,68 @@
+import { Item } from '@react-stately/collections';
+import { Combobox } from '@voussoir/combobox';
+import { matchSorter } from 'match-sorter';
+import { useMemo, useState } from 'react';
+import {
+  aliasesToCanonicalName,
+  canonicalNameToLabel,
+  labelToCanonicalName,
+  languagesWithAliases,
+  aliasesToLabel,
+} from '../../../document/DocumentEditor/code-block/languages';
+
+export function CodeBlockLanguageCombobox(props: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const labelForVal = props.value
+    ? aliasesToLabel.get(props.value) ?? props.value
+    : 'Plain text';
+  const [inputValue, setInputValue] = useState(labelForVal);
+  const [isFocused, setIsFocused] = useState(false);
+  if (!isFocused && labelForVal !== inputValue) {
+    setInputValue(labelForVal);
+  }
+  return (
+    <Combobox
+      aria-label="Language"
+      width="scale.2000"
+      allowsCustomValue // allow consumers to support other languages
+      inputValue={inputValue}
+      onInputChange={setInputValue}
+      onFocus={() => {
+        setIsFocused(true);
+      }}
+      onBlur={() => {
+        setIsFocused(false);
+      }}
+      onSelectionChange={selection => {
+        if (aliasesToCanonicalName.has(inputValue)) {
+          selection = aliasesToCanonicalName.get(inputValue)!;
+        }
+        if (selection === null) {
+          props.onChange(inputValue === '' ? 'plain' : inputValue);
+        } else if (typeof selection === 'string') {
+          props.onChange(selection);
+          const label = canonicalNameToLabel.get(selection);
+          if (label) {
+            setInputValue(label);
+          }
+        }
+      }}
+      selectedKey={
+        props.value ? aliasesToCanonicalName.get(props.value) ?? null : 'plain'
+      }
+      items={useMemo(
+        () =>
+          labelToCanonicalName.has(inputValue)
+            ? languagesWithAliases
+            : matchSorter(languagesWithAliases, inputValue, {
+                keys: ['label', 'value', 'aliases'],
+              }),
+        [inputValue]
+      )}
+    >
+      {item => <Item key={item.value}>{item.label}</Item>}
+    </Combobox>
+  );
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/popovers/index.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/popovers/index.tsx
@@ -1,0 +1,220 @@
+import { Node } from 'prosemirror-model';
+import { EditorState, TextSelection } from 'prosemirror-state';
+import {
+  ReactElement,
+  RefObject,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react';
+import { EditorSchema, getEditorSchema } from '../schema';
+import { BlockPopover } from '../primitives/BlockPopover';
+import { ActionButton } from '@voussoir/button';
+import { Icon } from '@voussoir/icon';
+import { trash2Icon } from '@voussoir/icon/icons/trash2Icon';
+import { Flex } from '@voussoir/layout';
+import { TooltipTrigger, Tooltip } from '@voussoir/tooltip';
+import {
+  useEditorViewRef,
+  useEditorDispatchCommand,
+  useLayoutEffectWithEditorUpdated,
+} from '../editor-view';
+import { LinkToolbar } from './link-toolbar';
+import { ToolbarSeparator } from '../primitives';
+import { CodeBlockLanguageCombobox } from './code-block-language';
+
+type PopoverRenderer = (props: {
+  node: Node;
+  state: EditorState;
+  pos: number;
+}) => ReactElement | null;
+
+const popoverComponents: Record<string, PopoverRenderer> = {
+  code_block: function CodeBlockPopover(props) {
+    const viewRef = useEditorViewRef();
+    const dispatchCommand = useEditorDispatchCommand();
+    const triggerRef = useMemo((): RefObject<HTMLElement | null> => {
+      return {
+        get current() {
+          if (!viewRef.current) return null;
+          const { node } = viewRef.current.domAtPos(props.pos + 1);
+          if (!(node instanceof HTMLElement)) return null;
+          return node.parentElement;
+        },
+      };
+    }, [props.pos, viewRef]);
+    const updatePositionRef = useRef<() => void>(() => {});
+    useLayoutEffectWithEditorUpdated(
+      useCallback(() => {
+        // just to indicate that this is a dependency of the effect
+        // because we want to update the position when the state changes
+        // eslint-disable-next-line no-unused-expressions
+        props.state;
+        updatePositionRef.current();
+      }, [props.state, updatePositionRef])
+    );
+    return (
+      <BlockPopover triggerRef={triggerRef} ref={updatePositionRef}>
+        <Flex gap="regular" padding="regular">
+          <CodeBlockLanguageCombobox
+            value={props.node.attrs.language}
+            onChange={val => {
+              dispatchCommand((state, dispatch) => {
+                if (dispatch) {
+                  dispatch(
+                    state.tr.setNodeMarkup(props.pos, undefined, {
+                      ...props.node.attrs,
+                      language: val,
+                    })
+                  );
+                }
+                return true;
+              });
+            }}
+          />
+          <ToolbarSeparator />
+          <TooltipTrigger>
+            <ActionButton
+              prominence="low"
+              onPress={() => {
+                dispatchCommand((state, dispatch) => {
+                  if (dispatch) {
+                    dispatch(
+                      state.tr.delete(
+                        props.pos,
+                        props.pos + props.node.nodeSize
+                      )
+                    );
+                  }
+                  return true;
+                });
+              }}
+            >
+              <Icon src={trash2Icon} />
+            </ActionButton>
+            <Tooltip tone="critical">Remove</Tooltip>
+          </TooltipTrigger>
+        </Flex>
+      </BlockPopover>
+    );
+  },
+} satisfies Partial<Record<keyof EditorSchema['nodes'], PopoverRenderer>>;
+
+// TODO: this is broken
+const LinkPopover: PopoverRenderer = props => {
+  const viewRef = useEditorViewRef();
+  const dispatchCommand = useEditorDispatchCommand();
+  const triggerRef = useMemo((): RefObject<HTMLElement | null> => {
+    return {
+      get current() {
+        if (!viewRef.current) return null;
+        const { node } = viewRef.current.domAtPos(props.pos + 1);
+        if (!(node instanceof HTMLElement)) return null;
+        return node;
+      },
+    };
+  }, [props.pos, viewRef]);
+  const updatePositionRef = useRef<() => void>(() => {});
+  useLayoutEffect(() => {
+    viewRef.current?.updateState(props.state);
+    updatePositionRef.current?.();
+  }, [props.pos, props.state, triggerRef, viewRef, updatePositionRef]);
+  const schema = getEditorSchema(props.state.schema);
+  if (!schema.marks.link) return null;
+  const href = schema.marks.link.isInSet(props.node.marks)?.attrs.href;
+  if (typeof href !== 'string') {
+    return null;
+  }
+  return (
+    <BlockPopover triggerRef={triggerRef} ref={updatePositionRef}>
+      <LinkToolbar
+        href={href}
+        onUnlink={() => {
+          dispatchCommand((state, dispatch) => {
+            if (dispatch) {
+              dispatch(
+                state.tr.removeMark(
+                  props.pos,
+                  props.pos + props.node.nodeSize,
+                  state.schema.marks.link
+                )
+              );
+            }
+            return true;
+          });
+        }}
+        onHrefChange={href => {
+          dispatchCommand((state, dispatch) => {
+            if (dispatch) {
+              dispatch(
+                state.tr
+                  .removeMark(
+                    props.pos,
+                    props.pos + props.node.nodeSize,
+                    state.schema.marks.link
+                  )
+                  .addMark(
+                    props.pos,
+                    props.pos + props.node.nodeSize,
+                    state.schema.marks.link.create({ href })
+                  )
+              );
+            }
+            return true;
+          });
+        }}
+      />
+    </BlockPopover>
+  );
+};
+
+function getPopoverDecoration(
+  state: EditorState
+): { node: Node; component: PopoverRenderer; pos: number } | null {
+  if (state.selection instanceof TextSelection) {
+    const schema = getEditorSchema(state.schema);
+    if (schema.marks.link) {
+      const { $from, $to } = state.selection;
+      const nodeAfterFrom = $from.nodeAfter;
+      const nodeAfterTo = $to.nodeAfter;
+      if (nodeAfterFrom && nodeAfterTo) {
+        const linkMarkInFrom = schema.marks.link.isInSet(nodeAfterFrom.marks);
+        const linkMarkInTo = schema.marks.link.isInSet(nodeAfterTo.marks);
+        if (linkMarkInFrom && linkMarkInTo === linkMarkInTo) {
+          return { node: nodeAfterTo, component: LinkPopover, pos: $from.pos };
+        }
+      }
+    }
+  }
+  const commonAncestorPos = state.selection.$from.start(
+    state.selection.$from.sharedDepth(state.selection.to)
+  );
+  const $pos = state.doc.resolve(commonAncestorPos);
+  for (let i = $pos.depth; i > 0; i++) {
+    const node = $pos.node(i);
+    if (!node) break;
+    const renderer = popoverComponents[node.type.name];
+    if (renderer !== undefined) {
+      return { node, component: renderer, pos: $pos.start(i) - 1 };
+    }
+  }
+
+  return null;
+}
+
+export function EditorPopover(props: { state: EditorState }) {
+  const popoverDecoration = useMemo(
+    () => getPopoverDecoration(props.state),
+    [props.state]
+  );
+  if (!popoverDecoration) return null;
+  return (
+    <popoverDecoration.component
+      key={popoverDecoration.node.type.name}
+      node={popoverDecoration.node}
+      pos={popoverDecoration.pos}
+      state={props.state}
+    />
+  );
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/popovers/languages.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/popovers/languages.ts
@@ -1,0 +1,82 @@
+import Prism from '../../../document/DocumentEditor/prism';
+
+const languages = [
+  { label: 'Plain text', value: 'plain' },
+  { label: 'C', value: 'c' },
+  { label: 'C++', value: 'cpp' },
+  { label: 'Arduino', value: 'arduino' },
+  { label: 'Bash', value: 'bash' },
+  { label: 'C#', value: 'csharp' },
+  { label: 'CSS', value: 'css' },
+  { label: 'Diff', value: 'diff' },
+  { label: 'Go', value: 'go' },
+  { label: 'INI', value: 'ini' },
+  { label: 'Java', value: 'java' },
+  { label: 'JavaScript', value: 'javascript' },
+  { label: 'JSX', value: 'jsx' },
+  { label: 'JSON', value: 'json' },
+  { label: 'Kotlin', value: 'kotlin' },
+  { label: 'Less', value: 'less' },
+  { label: 'Lua', value: 'lua' },
+  { label: 'Makefile', value: 'makefile' },
+  { label: 'Markdown', value: 'markdown' },
+  { label: 'Objective-C', value: 'objectivec' },
+  { label: 'Perl', value: 'perl' },
+  { label: 'PHP', value: 'php' },
+  { label: 'Python', value: 'python' },
+  { label: 'R', value: 'r' },
+  { label: 'Ruby', value: 'ruby' },
+  { label: 'Rust', value: 'rust' },
+  { label: 'Sass', value: 'sass' },
+  { label: 'SCSS', value: 'scss' },
+  { label: 'SQL', value: 'sql' },
+  { label: 'Swift', value: 'swift' },
+  { label: 'TypeScript', value: 'typescript' },
+  { label: 'TSX', value: 'tsx' },
+  { label: 'VB.NET', value: 'vbnet' },
+  { label: 'YAML', value: 'yaml' },
+];
+
+export const canonicalNameToLabel = new Map(
+  languages.map(x => [x.value, x.label])
+);
+export const labelToCanonicalName = new Map(
+  languages.map(x => [x.label, x.value])
+);
+
+const languageToCanonicalName = new Map(
+  languages.map(lang => [Prism.languages[lang.value], lang.value])
+);
+
+export const aliasesToCanonicalName = new Map(
+  Object.keys(Prism.languages).flatMap(lang => {
+    const canonicalName = languageToCanonicalName.get(Prism.languages[lang]);
+    if (canonicalName === undefined) {
+      return [];
+    }
+    return [[lang, canonicalName]];
+  })
+);
+
+const languagesToAliases = new Map(
+  languages.map(lang => [lang.value, [] as string[]])
+);
+
+languagesToAliases.set('plain', ['plain']);
+
+for (const [alias, canonicalName] of aliasesToCanonicalName) {
+  languagesToAliases.get(canonicalName)!.push(alias);
+}
+export const languagesWithAliases = [
+  ...[...languagesToAliases].map(([canonicalName, aliases]) => ({
+    label: canonicalNameToLabel.get(canonicalName)!,
+    value: canonicalName,
+    aliases,
+  })),
+];
+export const aliasesToLabel = new Map(
+  [...aliasesToCanonicalName].map(([alias, canonicalName]) => [
+    alias,
+    canonicalNameToLabel.get(canonicalName)!,
+  ])
+);

--- a/packages/keystatic/src/form/fields/markdoc/editor/popovers/link-toolbar.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/popovers/link-toolbar.tsx
@@ -1,0 +1,123 @@
+import { useLocalizedStringFormatter } from '@react-aria/i18n';
+import { ActionButton, ButtonGroup, Button } from '@voussoir/button';
+import { DialogContainer, useDialogContainer, Dialog } from '@voussoir/dialog';
+import { Icon } from '@voussoir/icon';
+import { editIcon } from '@voussoir/icon/icons/editIcon';
+import { externalLinkIcon } from '@voussoir/icon/icons/externalLinkIcon';
+import { unlinkIcon } from '@voussoir/icon/icons/unlinkIcon';
+import { Flex } from '@voussoir/layout';
+import { Content } from '@voussoir/slots';
+import { TextField } from '@voussoir/text-field';
+import { TooltipTrigger, Tooltip } from '@voussoir/tooltip';
+import { Heading, Text } from '@voussoir/typography';
+import { useState } from 'react';
+import { isValidURL } from '../../../document/DocumentEditor/isValidURL';
+import localizedMessages from '../../../../../app/l10n/index.json';
+
+export function LinkToolbar(props: {
+  href: string;
+  onHrefChange: (href: string) => void;
+  onUnlink: () => void;
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const stringFormatter = useLocalizedStringFormatter(localizedMessages);
+  return (
+    <Flex gap="small" padding="regular">
+      <TooltipTrigger>
+        <ActionButton prominence="low" onPress={() => setDialogOpen(true)}>
+          <Icon src={editIcon} />
+        </ActionButton>
+        <Tooltip>{stringFormatter.format('edit')}</Tooltip>
+      </TooltipTrigger>
+      <TooltipTrigger>
+        <ActionButton
+          prominence="low"
+          onPress={() => {
+            window.open(props.href, '_blank', 'noopener,noreferrer');
+          }}
+        >
+          <Icon src={externalLinkIcon} />
+        </ActionButton>
+        <Tooltip>
+          <Text truncate={3}>{props.href}</Text>
+        </Tooltip>
+      </TooltipTrigger>
+      <TooltipTrigger>
+        <ActionButton prominence="low" onPress={props.onUnlink}>
+          <Icon src={unlinkIcon} />
+        </ActionButton>
+        {/* TODO: needs localization */}
+        <Tooltip>Unlink</Tooltip>
+      </TooltipTrigger>
+      <DialogContainer
+        onDismiss={() => {
+          setDialogOpen(false);
+        }}
+      >
+        {dialogOpen && (
+          <LinkDialog
+            text=""
+            href={props.href}
+            onSubmit={({ href }) => {
+              props.onHrefChange(href);
+            }}
+          />
+        )}
+      </DialogContainer>
+    </Flex>
+  );
+}
+
+function LinkDialog({
+  onSubmit,
+  ...props
+}: {
+  href?: string;
+  text?: string;
+  onSubmit: (value: { href: string }) => void;
+}) {
+  let [href, setHref] = useState(props.href || '');
+  let [touched, setTouched] = useState(false);
+
+  let { dismiss } = useDialogContainer();
+  let stringFormatter = useLocalizedStringFormatter(localizedMessages);
+  const showInvalidState = touched && !isValidURL(href);
+
+  return (
+    <Dialog size="small">
+      <form
+        style={{ display: 'contents' }}
+        onSubmit={event => {
+          if (event.target !== event.currentTarget) return;
+          event.preventDefault();
+          if (!showInvalidState) {
+            dismiss();
+            onSubmit({ href });
+          }
+        }}
+      >
+        <Heading>{props.href ? 'Edit' : 'Add'} link</Heading>
+        <Content>
+          <Flex gap="large" direction="column">
+            <TextField label="Text" value={props.text} isReadOnly />
+            <TextField
+              autoFocus
+              isRequired
+              onBlur={() => setTouched(true)}
+              label="Link"
+              onChange={setHref}
+              value={href}
+              errorMessage={showInvalidState && 'Please provide a valid URL.'}
+            />
+          </Flex>
+        </Content>
+        <ButtonGroup>
+          <Button onPress={dismiss}>{stringFormatter.format('cancel')}</Button>
+          <Button prominence="high" type="submit">
+            {stringFormatter.format('save')}
+          </Button>
+        </ButtonGroup>
+      </form>
+    </Dialog>
+  );
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/primitives/BlockPopover.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/primitives/BlockPopover.tsx
@@ -1,0 +1,234 @@
+import {
+  AriaPopoverProps,
+  PopoverAria,
+  useOverlay,
+  useOverlayPosition,
+} from '@react-aria/overlays';
+import { mergeProps, useLayoutEffect } from '@react-aria/utils';
+import {
+  OverlayTriggerState,
+  useOverlayTriggerState,
+} from '@react-stately/overlays';
+import {
+  ReactNode,
+  Ref,
+  RefObject,
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+
+import { Overlay, PopoverProps } from '@voussoir/overlays';
+import { css, tokenSchema, transition } from '@voussoir/style';
+
+type BlockPopoverProps = Pick<PopoverProps, 'hideArrow' | 'placement'> & {
+  triggerRef: RefObject<HTMLElement | null>;
+  children: ReactNode;
+};
+
+export const BlockPopover = forwardRef(function BlockPopover(
+  { placement: preferredPlacement, triggerRef, ...props }: BlockPopoverProps,
+  ref: Ref<() => void>
+) {
+  let wrapperRef = useRef<HTMLDivElement>(null);
+  let popoverRef = useRef(null);
+  const state = useOverlayTriggerState({
+    isOpen: true,
+  });
+  let { placement, popoverProps, updatePosition } = useBlockPopover(
+    {
+      isNonModal: true,
+      isKeyboardDismissDisabled: false,
+      placement: preferredPlacement,
+      triggerRef: triggerRef as any,
+      popoverRef,
+    },
+    state
+  );
+
+  useImperativeHandle(ref, () => updatePosition, [updatePosition]);
+
+  return (
+    <Overlay
+      isOpen
+      // @ts-expect-error FIXME: resolve ref inconsistencies
+      nodeRef={wrapperRef}
+    >
+      <div
+        ref={popoverRef}
+        {...popoverProps}
+        data-open={state.isOpen}
+        data-placement={placement}
+        contentEditable={false}
+        className={css({
+          backgroundColor: tokenSchema.color.background.surface, // TODO: component token?
+          borderRadius: tokenSchema.size.radius.medium, // TODO: component token?
+          border: `${tokenSchema.size.border.regular} solid ${tokenSchema.color.border.emphasis}`,
+          boxSizing: 'content-box', // resolves measurement/scroll issues related to border
+          // boxShadow: `0 0 0 ${tokenSchema.size.border.regular} ${tokenSchema.color.border.emphasis}`,
+          minHeight: tokenSchema.size.element.regular,
+          minWidth: tokenSchema.size.element.regular,
+          opacity: 0,
+          outline: 0,
+          pointerEvents: 'auto',
+          position: 'absolute',
+          // use filter:drop-shadow instead of box-shadow so the arrow is included
+          filter: `drop-shadow(0 1px 4px ${tokenSchema.color.shadow.regular})`,
+          // filter bug in safari: https://stackoverflow.com/questions/56478925/safari-drop-shadow-filter-remains-visible-even-with-hidden-element
+          willChange: 'filter',
+          userSelect: 'none',
+
+          // placement
+          '&[data-placement="top"]': {
+            marginBottom: tokenSchema.size.space.regular,
+            transform: `translateY(${tokenSchema.size.space.regular})`,
+          },
+          '&[data-placement="bottom"]': {
+            marginTop: tokenSchema.size.space.regular,
+            transform: `translateY(calc(${tokenSchema.size.space.regular} * -1))`,
+          },
+
+          '&[data-open="true"]': {
+            opacity: 1,
+            transform: `translateX(0) translateY(0)`,
+
+            // enter animation
+            transition: transition(['opacity', 'transform'], {
+              easing: 'easeOut',
+            }),
+          },
+        })}
+      >
+        {props.children}
+      </div>
+    </Overlay>
+  );
+});
+
+/**
+ * Provides the behavior and accessibility implementation for a popover component.
+ * A popover is an overlay element positioned relative to a trigger.
+ */
+function useBlockPopover(
+  props: AriaPopoverProps,
+  state: OverlayTriggerState
+): PopoverAria & { updatePosition: () => void } {
+  let {
+    triggerRef,
+    popoverRef,
+    isNonModal,
+    isKeyboardDismissDisabled,
+    ...otherProps
+  } = props;
+
+  let [isSticky, setSticky] = useState(false);
+
+  let { overlayProps, underlayProps } = useOverlay(
+    {
+      isOpen: state.isOpen,
+      onClose: state.close,
+      shouldCloseOnBlur: true,
+      isDismissable: !isNonModal,
+      isKeyboardDismissDisabled: false,
+    },
+    popoverRef
+  );
+
+  // stick the popover to the bottom of the viewport instead of flipping
+  const containerPadding = 8;
+  useEffect(() => {
+    if (state.isOpen) {
+      const checkForStickiness = () => {
+        const vh = Math.max(
+          document.documentElement.clientHeight || 0,
+          window.innerHeight || 0
+        );
+        let popoverRect = popoverRef.current?.getBoundingClientRect();
+        let triggerRect = triggerRef.current?.getBoundingClientRect();
+        if (popoverRect && triggerRect) {
+          setSticky(
+            triggerRect.bottom + popoverRect.height + containerPadding * 2 >
+              vh && triggerRect.top < vh
+          );
+        }
+      };
+      checkForStickiness();
+      window.addEventListener('scroll', checkForStickiness);
+      return () => {
+        checkForStickiness();
+        window.removeEventListener('scroll', checkForStickiness);
+      };
+    }
+  }, [popoverRef, triggerRef, state.isOpen]);
+
+  let {
+    overlayProps: positionProps,
+    arrowProps,
+    placement,
+    updatePosition,
+  } = useOverlayPosition({
+    ...otherProps,
+    containerPadding,
+    shouldFlip: false,
+    targetRef: triggerRef,
+    overlayRef: popoverRef,
+    isOpen: state.isOpen,
+    onClose: undefined,
+  });
+
+  // force update position when the trigger changes
+  let previousBoundingRect = usePrevious(
+    triggerRef.current?.getBoundingClientRect()
+  );
+  useLayoutEffect(() => {
+    if (previousBoundingRect) {
+      const currentBoundingRect = triggerRef.current?.getBoundingClientRect();
+      if (currentBoundingRect) {
+        const hasChanged =
+          previousBoundingRect.height !== currentBoundingRect.height ||
+          previousBoundingRect.width !== currentBoundingRect.width ||
+          previousBoundingRect.x !== currentBoundingRect.x ||
+          previousBoundingRect.y !== currentBoundingRect.y;
+        if (hasChanged) {
+          updatePosition();
+        }
+      }
+    }
+  }, [previousBoundingRect, triggerRef, updatePosition]);
+
+  // make sure popovers are below modal dialogs and their blanket
+  if (positionProps.style) {
+    positionProps.style.zIndex = 1;
+  }
+
+  // switching to position: fixed will undoubtedly bite me later, but this hack works for now
+  if (isSticky) {
+    positionProps.style = {
+      ...positionProps.style,
+      // @ts-expect-error
+      maxHeight: null,
+      position: 'fixed',
+      // @ts-expect-error
+      top: null,
+      bottom: containerPadding,
+    };
+  }
+
+  return {
+    arrowProps,
+    placement,
+    popoverProps: mergeProps(overlayProps, positionProps),
+    underlayProps,
+    updatePosition,
+  };
+}
+
+function usePrevious<T>(value: T) {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/primitives/index.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/primitives/index.tsx
@@ -1,0 +1,4 @@
+'use client';
+export { BlockPopover } from './BlockPopover';
+
+export * from './toolbar';

--- a/packages/keystatic/src/form/fields/markdoc/editor/primitives/toolbar.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/primitives/toolbar.tsx
@@ -1,0 +1,5 @@
+import { Divider } from '@voussoir/layout';
+
+export const ToolbarSeparator = () => {
+  return <Divider orientation="vertical" flexShrink={0} />;
+};

--- a/packages/keystatic/src/form/fields/markdoc/editor/schema.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/schema.tsx
@@ -1,0 +1,497 @@
+'use client';
+import { css, tokenSchema } from '@voussoir/style';
+import {
+  DOMOutputSpec,
+  NodeSpec,
+  MarkSpec,
+  Schema,
+  NodeType,
+  MarkType,
+  Node,
+} from 'prosemirror-model';
+import { classes } from './utils';
+import {
+  InsertMenuItem,
+  WithInsertMenuNodeSpec,
+} from './autocomplete/insert-menu';
+import { setBlockType, wrapIn } from 'prosemirror-commands';
+import { insertNode } from './commands/misc';
+import { toggleList } from './lists';
+import { Config } from '@markdoc/markdoc';
+import { attributeSchema } from './attributes/schema';
+
+const blockElementSpacing = css({
+  marginBlock: '1em',
+  '&:first-child': {
+    marginBlockStart: 0,
+  },
+  '&:last-child': {
+    marginBlockEnd: 0,
+  },
+});
+
+const paragraphDOM: DOMOutputSpec = ['p', { class: blockElementSpacing }, 0];
+const blockquoteDOM: DOMOutputSpec = [
+  'blockquote',
+  {
+    class: `${classes.blockParent} ${css({
+      marginInline: 0,
+      paddingInline: tokenSchema.size.space.large,
+      borderInlineStartStyle: 'solid',
+      borderInlineStartWidth: tokenSchema.size.border.large,
+      borderColor: tokenSchema.color.border.neutral,
+      [`&.${classes.nodeInSelection}, &.${classes.nodeSelection}`]: {
+        borderColor: tokenSchema.color.alias.borderSelected,
+      },
+    })}`,
+  },
+  0,
+];
+const dividerDOM: DOMOutputSpec = [
+  'hr',
+  {
+    contenteditable: 'false',
+    class: css({
+      marginBlock: '1em',
+      backgroundColor: tokenSchema.color.border.neutral,
+      [`&.${classes.nodeInSelection}, &.${classes.nodeSelection}`]: {
+        outline: 0,
+        backgroundColor: tokenSchema.color.alias.borderSelected,
+      },
+      border: 0,
+      height: tokenSchema.size.border.large,
+      padding: 0,
+      cursor: 'pointer',
+    }),
+  },
+];
+const codeDOM: DOMOutputSpec = [
+  'pre',
+  {
+    class: css({
+      backgroundColor: tokenSchema.color.background.surface,
+      borderRadius: tokenSchema.size.radius.medium,
+      color: tokenSchema.color.foreground.neutralEmphasis,
+      fontFamily: tokenSchema.typography.fontFamily.code,
+      fontSize: '0.85em',
+      lineHeight: tokenSchema.typography.lineheight.medium,
+      maxWidth: '100%',
+      overflow: 'auto',
+      padding: tokenSchema.size.space.medium,
+
+      code: {
+        fontFamily: 'inherit',
+      },
+    }),
+  },
+  ['code', { class: css({ display: 'block', width: '100%' }) }, 0],
+];
+const hardBreakDOM: DOMOutputSpec = ['br'];
+
+const listClass = `${blockElementSpacing} ${css({
+  paddingInlineStart: tokenSchema.size.space.medium,
+})}`;
+const olDOM: DOMOutputSpec = ['ol', { class: listClass }, 0];
+const ulDOM: DOMOutputSpec = ['ul', { class: listClass }, 0];
+const liDOM: DOMOutputSpec = [
+  'li',
+  {
+    class: css({
+      'p,ul,ol': {
+        marginBlock: 0,
+      },
+    }),
+  },
+  0,
+];
+
+export type EditorNodeSpec = NodeSpec & WithInsertMenuNodeSpec;
+
+const inlineContent = `(text | (text hard_break) | attribute)*`;
+
+const levels = [1, 2, 3, 4, 5, 6];
+
+const nodeSpecs = {
+  doc: {
+    content: 'block+',
+  },
+  paragraph: {
+    content: inlineContent,
+    group: 'block',
+    parseDOM: [{ tag: 'p' }],
+    toDOM() {
+      return paragraphDOM;
+    },
+  },
+  text: {
+    group: 'inline',
+  },
+  tag_attributes: {
+    content: 'attribute*',
+    selectable: false,
+    defining: true,
+    toDOM() {
+      return [
+        'div',
+        {
+          class: css({
+            display: 'block',
+          }),
+        },
+        [
+          'span',
+          {
+            'data-tag-name': 'true',
+            class: css({
+              '::before': {
+                display: 'inline',
+                width: 'auto',
+                content: 'var(--tag-name)',
+              },
+            }),
+          },
+        ],
+        ['div', { class: css({ display: 'inline-block' }) }, 0],
+      ];
+    },
+  },
+  tag_slot: {
+    attrs: {
+      name: { default: 'children' },
+    },
+    content: 'block+',
+    defining: true,
+    toDOM(node) {
+      if (node.attrs.name === 'children') {
+        return [
+          'div',
+          { class: css({ borderTop: '2px solid green', paddingInline: -2 }) },
+          0,
+        ];
+      }
+      return [
+        'div',
+        {
+          'data-slot': node.attrs.name,
+          class: css({
+            borderTop: '2px solid green',
+            paddingInline: -2,
+            '::before': {
+              content: `attr(data-slot)`,
+              display: 'inline-block',
+            },
+          }),
+        },
+        0,
+      ];
+    },
+  },
+  tag: {
+    attrs: {
+      name: {},
+    },
+    group: 'block',
+    defining: true,
+    content: 'tag_attributes tag_slot*',
+    toDOM(node) {
+      return [
+        'div',
+        {
+          'data-tag': node.attrs.name,
+          class: css({
+            border: '2px solid hotpink',
+            marginBlock: '1em',
+            padding: 2,
+            '--tag-name': JSON.stringify(node.attrs.name),
+          }),
+        },
+        0,
+      ];
+    },
+  },
+  blockquote: {
+    content: 'block+',
+    group: 'block',
+    defining: true,
+    parseDOM: [{ tag: 'blockquote' }],
+    toDOM() {
+      return blockquoteDOM;
+    },
+    insertMenu: {
+      label: 'Blockquote',
+      command: wrapIn,
+    },
+  },
+  divider: {
+    group: 'block',
+    parseDOM: [{ tag: 'hr' }],
+    toDOM() {
+      return dividerDOM;
+    },
+    insertMenu: {
+      label: 'Divider',
+      command: insertNode,
+    },
+  },
+  code_block: {
+    content: 'text*',
+    group: 'block',
+    defining: true,
+    insertMenu: {
+      label: 'Code block',
+      command: setBlockType,
+    },
+    marks: '',
+    code: true,
+    parseDOM: [{ tag: 'pre', preserveWhitespace: 'full' }],
+    toDOM() {
+      return codeDOM;
+    },
+  },
+  list_item: {
+    content: 'block+',
+    parseDOM: [{ tag: 'li' }],
+    toDOM() {
+      return liDOM;
+    },
+    defining: true,
+  },
+  unordered_list: {
+    content: 'list_item+',
+    group: 'block',
+    parseDOM: [{ tag: 'ul' }],
+    toDOM() {
+      return ulDOM;
+    },
+    insertMenu: {
+      label: 'Bullet list',
+      command: toggleList,
+    },
+  },
+  ordered_list: {
+    content: 'list_item+',
+    group: 'block',
+    parseDOM: [{ tag: 'ol' }],
+    toDOM() {
+      return olDOM;
+    },
+    insertMenu: {
+      label: 'Ordered list',
+      command: toggleList,
+    },
+  },
+  hard_break: {
+    inline: true,
+    group: 'inline',
+    selectable: false,
+    parseDOM: [{ tag: 'br' }],
+    toDOM() {
+      return hardBreakDOM;
+    },
+  },
+  heading: {
+    attrs: {
+      level: { default: levels[0] },
+    },
+    content: inlineContent,
+    group: 'block',
+    parseDOM: levels.map(level => ({
+      tag: 'h' + level,
+      attrs: { level },
+    })),
+    defining: true,
+    toDOM(node) {
+      return ['h' + node.attrs.level, 0];
+    },
+    insertMenu: levels.map(level => ({
+      label: 'Heading ' + level,
+      command: type => setBlockType(type, { level }),
+    })),
+  },
+  ...attributeSchema,
+} satisfies Record<string, EditorNodeSpec>;
+
+const italicDOM: DOMOutputSpec = ['em', 0];
+const boldDOM: DOMOutputSpec = ['strong', 0];
+const inlineCodeDOM: DOMOutputSpec = ['code', 0];
+const strikethroughDOM: DOMOutputSpec = ['s', 0];
+
+const markSpecs = {
+  link: {
+    attrs: {
+      href: {},
+      title: { default: '' },
+    },
+    inclusive: false,
+    parseDOM: [
+      {
+        tag: 'a[href]',
+        getAttrs(node) {
+          if (typeof node === 'string') return false;
+          const href = node.getAttribute('href');
+          if (!href) return false;
+          return {
+            href,
+            title: node.getAttribute('title') ?? '',
+          };
+        },
+      },
+    ],
+    toDOM(node) {
+      return [
+        'a',
+        {
+          href: node.attrs.href,
+          title: node.attrs.title === '' ? undefined : node.attrs.title,
+        },
+        0,
+      ];
+    },
+  },
+  italic: {
+    shortcuts: ['Mod-i', 'Mod-I'],
+    parseDOM: [
+      { tag: 'i' },
+      { tag: 'em' },
+      { style: 'font-style=italic' },
+      { style: 'font-style=normal', clearMark: m => m.type.name == 'italic' },
+    ],
+    toDOM() {
+      return italicDOM;
+    },
+  },
+  bold: {
+    shortcuts: ['Mod-b', 'Mod-B'],
+    parseDOM: [
+      { tag: 'strong' },
+      {
+        tag: 'b',
+        getAttrs: node =>
+          typeof node === 'string'
+            ? false
+            : node.style.fontWeight != 'normal' && null,
+      },
+      { style: 'font-weight=400', clearMark: m => m.type.name == 'strong' },
+      {
+        style: 'font-weight',
+        getAttrs: value =>
+          typeof value === 'string'
+            ? /^(bold(er)?|[5-9]\d{2,})$/.test(value) && null
+            : false,
+      },
+    ],
+    toDOM() {
+      return boldDOM;
+    },
+  },
+  strikethrough: {
+    shortcuts: ['Mod-Shift-s', 'Mod-Shift-S'],
+    parseDOM: [{ tag: 's' }],
+    toDOM() {
+      return strikethroughDOM;
+    },
+  },
+  code: {
+    shortcuts: ['Mod-`', 'Mod-Shift-M', 'Mod-E', 'Mod-e'],
+    parseDOM: [{ tag: 'code' }],
+    toDOM() {
+      return inlineCodeDOM;
+    },
+  },
+} satisfies Record<string, MarkSpec>;
+
+export type EditorSchema = {
+  schema: Schema;
+  nodes: {
+    [_ in keyof typeof nodeSpecs]: NodeType;
+  };
+  marks: {
+    [_ in keyof typeof markSpecs]: MarkType;
+  };
+  markdocConfig: Config | undefined;
+  insertMenuItems: InsertMenuItem[];
+};
+
+export function createEditorSchema(markdocConfig: Config) {
+  const schema = new Schema({
+    nodes: nodeSpecs,
+    marks: markSpecs,
+  });
+
+  const insertMenuItems: Omit<InsertMenuItem, 'id'>[] = [];
+  for (const node of Object.values(schema.nodes)) {
+    const insertMenuSpec = (node.spec as EditorNodeSpec).insertMenu;
+    if (insertMenuSpec) {
+      if (Array.isArray(insertMenuSpec)) {
+        for (const item of insertMenuSpec) {
+          insertMenuItems.push({
+            label: item.label,
+            command: item.command(node),
+          });
+        }
+      } else {
+        insertMenuItems.push({
+          label: insertMenuSpec.label,
+          command: insertMenuSpec.command(node),
+        });
+      }
+    }
+  }
+  for (const [tagName, tagConfig] of Object.entries(markdocConfig.tags ?? {})) {
+    insertMenuItems.push({
+      label: tagName,
+      command: (state, dispatch) => {
+        if (!dispatch) return false;
+        const n = editorSchema.nodes;
+        const attributes: Node[] = [];
+        for (const [attrName, attrConfig] of Object.entries(
+          tagConfig.attributes ?? {}
+        )) {
+          if (attrConfig.required && attrConfig.default === undefined) {
+            attributes.push(n.attribute.createAndFill({ key: attrName })!);
+          }
+        }
+        const tagChildren = [n.tag_attributes.createChecked(null, attributes)];
+        for (const [slotName, slotConfig] of Object.entries(
+          tagConfig.slots ?? {}
+        )) {
+          if (slotConfig.required) {
+            tagChildren.push(n.tag_slot.createAndFill({ name: slotName })!);
+          }
+        }
+        if (
+          !tagConfig.selfClosing &&
+          (tagConfig.children === undefined || tagConfig.children.length)
+        ) {
+          tagChildren.push(n.tag_slot.createAndFill({ name: 'children' })!);
+        }
+        state.tr.replaceSelectionWith(
+          n.tag.createChecked({ tag: tagName }, tagChildren)
+        );
+        return true;
+      },
+    });
+  }
+  const editorSchema: EditorSchema = {
+    schema,
+    nodes: schema.nodes as EditorSchema['nodes'],
+    marks: schema.marks as EditorSchema['marks'],
+    markdocConfig,
+    insertMenuItems: insertMenuItems
+      .sort((a, b) => a.label.localeCompare(b.label))
+      .map((item, i) => ({ ...item, id: i.toString() })),
+  };
+  schemaToEditorSchema.set(schema, editorSchema);
+
+  return editorSchema;
+}
+
+const schemaToEditorSchema = new WeakMap<Schema, EditorSchema>();
+
+export function getEditorSchema(schema: Schema): EditorSchema {
+  const editorSchema = schemaToEditorSchema.get(schema);
+  if (!editorSchema) {
+    throw new Error('No editor schema for schema');
+  }
+  return editorSchema;
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/blockquote.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/blockquote.test.tsx
@@ -1,0 +1,168 @@
+/** @jest-environment jsdom */
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { jsx, renderEditor } from './utils';
+
+test('inserting a blockquote with a shortcut works', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <paragraph>
+        <text>
+          {'>'}
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  );
+  await user.keyboard(' ');
+  await user.keyboard('some content');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <blockquote>
+        <paragraph>
+          <text>
+            some content
+            <cursor />
+          </text>
+        </paragraph>
+      </blockquote>
+    </doc>
+  `);
+});
+
+test('backspace at start of blockquote', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <blockquote>
+        <paragraph>
+          <text>
+            <cursor />
+            some content
+          </text>
+        </paragraph>
+      </blockquote>
+    </doc>
+  );
+  await user.keyboard('{Backspace}');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text>
+          <cursor />
+          some content
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('enter on empty line at end of blockquote exits blockquote', async () => {
+  const { user, state } = renderEditor(
+    <doc>
+      <blockquote>
+        <paragraph>
+          <text>some content</text>
+        </paragraph>
+        <paragraph>
+          <cursor />
+        </paragraph>
+      </blockquote>
+    </doc>
+  );
+
+  await user.keyboard('{Enter}');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <blockquote>
+        <paragraph>
+          <text>
+            some content
+          </text>
+        </paragraph>
+      </blockquote>
+      <paragraph>
+        <cursor />
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('enter on empty line in middle splits the blockquote', async () => {
+  const { user, state } = renderEditor(
+    <doc>
+      <blockquote>
+        <paragraph>
+          <text>some content</text>
+        </paragraph>
+        <paragraph>
+          <cursor />
+        </paragraph>
+        <paragraph>
+          <text>some content</text>
+        </paragraph>
+      </blockquote>
+    </doc>
+  );
+
+  await user.keyboard('{Enter}');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <blockquote>
+        <paragraph>
+          <text>
+            some content
+          </text>
+        </paragraph>
+      </blockquote>
+      <blockquote>
+        <paragraph>
+          <cursor />
+        </paragraph>
+        <paragraph>
+          <text>
+            some content
+          </text>
+        </paragraph>
+      </blockquote>
+    </doc>
+  `);
+});
+
+test('enter on empty line at start with other non-empty paragraphs moves the start out of the blockquote', async () => {
+  const { user, state } = renderEditor(
+    <doc>
+      <blockquote>
+        <paragraph>
+          <cursor />
+        </paragraph>
+        <paragraph>
+          <text>a</text>
+        </paragraph>
+        <paragraph>
+          <text>b</text>
+        </paragraph>
+      </blockquote>
+    </doc>
+  );
+
+  await user.keyboard('{Enter}');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <cursor />
+      </paragraph>
+      <blockquote>
+        <paragraph>
+          <text>
+            a
+          </text>
+        </paragraph>
+        <paragraph>
+          <text>
+            b
+          </text>
+        </paragraph>
+      </blockquote>
+    </doc>
+  `);
+});

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/code-block.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/code-block.test.tsx
@@ -1,0 +1,372 @@
+/** @jest-environment jsdom */
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { jsx, renderEditor } from './utils';
+
+const basicDoc = (
+  <doc>
+    <paragraph>
+      <cursor />
+    </paragraph>
+  </doc>
+);
+
+for (const type of [
+  ' ',
+  // TODO: make enter work
+  // '{Enter}'
+] as const) {
+  test(`inserting a code block with a shortcut ending with a ${type}`, async () => {
+    const { state, user } = renderEditor(basicDoc);
+    await user.keyboard(`\`\`\`${type}some content`);
+    expect(state()).toEqual(
+      <doc>
+        <code_block language="plain">
+          <text>
+            some content
+            <cursor />
+          </text>
+        </code_block>
+      </doc>
+    );
+  });
+  test(`inserting a code block with a shortcut with a known language with a ${type}`, async () => {
+    const { state, user } = renderEditor(basicDoc);
+    await user.keyboard(`\`\`\`js${type}some content`);
+    expect(state()).toEqual(
+      <doc>
+        <code_block language="js">
+          <text>
+            some content
+            <cursor />
+          </text>
+        </code_block>
+      </doc>
+    );
+  });
+  test(`inserting a code block with an unknown language a shortcut ending with a ${type}`, async () => {
+    const { state, user } = renderEditor(basicDoc);
+    await user.keyboard(`\`\`\`asdasdasdasdasdfasdfasdf${type}some content`);
+
+    expect(state()).toEqual(
+      <doc>
+        <code_block language="asdasdasdasdasdfasdfasdf">
+          <text>
+            some content
+            <cursor />
+          </text>
+        </code_block>
+      </doc>
+    );
+  });
+}
+
+test('enter inserts a new line', async () => {
+  const { user, state } = renderEditor(
+    <doc>
+      <code_block language="plain">
+        <text>
+          {'asdkjnajsndakjndkjnaksdjnasdasdasd'}
+          <cursor />
+        </text>
+      </code_block>
+    </doc>
+  );
+
+  await user.keyboard('{Enter}some text');
+
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <code_block>
+        <text>
+          asdkjnajsndakjndkjnaksdjnasdasdasd
+    some text
+          <cursor />
+        </text>
+      </code_block>
+    </doc>
+  `);
+});
+
+test('insertBreak when at end with \n as last character just adds a new line', async () => {
+  const { user, state } = renderEditor(
+    <doc>
+      <code_block language="plain">
+        <text>
+          {'asdkjnajsndakjndkjnaksdjn\nasdasdasd\n'}
+          <cursor />
+        </text>
+      </code_block>
+    </doc>
+  );
+
+  await user.keyboard('{Enter}');
+
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <code_block>
+        <text>
+          asdkjnajsndakjndkjnaksdjn
+    asdasdasd
+
+
+          <cursor />
+        </text>
+      </code_block>
+    </doc>
+  `);
+});
+
+test('shift+enter in the middle of a code block splits it', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <code_block language="plain">
+        <text>
+          some text
+          <cursor />
+          {'more text\n'}
+        </text>
+      </code_block>
+    </doc>
+  );
+
+  await user.keyboard('{Shift>}{Enter}{/Shift}');
+
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <code_block>
+        <text>
+          some text
+        </text>
+      </code_block>
+      <code_block>
+        <text>
+          <cursor />
+          more text
+
+        </text>
+      </code_block>
+    </doc>
+  `);
+});
+
+test('shift+enter at the end of a code block inserts a paragraph after', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <code_block language="plain">
+        <text>
+          some text
+          {'more text\n'}
+          <cursor />
+        </text>
+      </code_block>
+    </doc>
+  );
+
+  await user.keyboard('{Shift>}{Enter}{/Shift}');
+
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <code_block>
+        <text>
+          some textmore text
+
+        </text>
+      </code_block>
+      <paragraph>
+        <cursor />
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('shift+enter at the start of a code block inserts a paragraph before', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <code_block language="plain">
+        <text>
+          <cursor />
+          some text
+          {'more text\n'}
+        </text>
+      </code_block>
+    </doc>
+  );
+
+  await user.keyboard('{Shift>}{Enter}{/Shift}');
+
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph />
+      <code_block>
+        <text>
+          <cursor />
+          some textmore text
+
+        </text>
+      </code_block>
+    </doc>
+  `);
+});
+
+test('code block button is disabled when selection is around a divider', () => {
+  const { rendered } = renderEditor(
+    <doc>
+      <node_selection>
+        <divider />
+      </node_selection>
+    </doc>
+  );
+
+  const button = rendered.getByLabelText('Code block');
+
+  expect(button).toBeDisabled();
+});
+
+test('code block button is enabled and not pressed when in paragraph', () => {
+  const { rendered } = renderEditor(
+    <doc>
+      <paragraph>
+        <cursor />
+      </paragraph>
+      <code_block language="plain" />
+    </doc>
+  );
+
+  const button = rendered.getByLabelText('Code block');
+  expect(button).toBeEnabled();
+  expect(button).toHaveAttribute('aria-pressed', 'false');
+});
+
+test('clicking on the code block button converts the current nodes to code blocks', async () => {
+  const { rendered, user, state } = renderEditor(
+    <doc>
+      <paragraph>
+        <text>
+          blah
+          <anchor />
+        </text>
+      </paragraph>
+      <paragraph>
+        <text>more</text>
+      </paragraph>
+      <heading level={1}>
+        <text>
+          more
+          <head />
+        </text>
+      </heading>
+    </doc>
+  );
+
+  const button = rendered.getByLabelText('Code block');
+  expect(button).toBeEnabled();
+  expect(button).toHaveAttribute('aria-pressed', 'false');
+  await user.click(button);
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <code_block>
+        <text>
+          blah
+          <anchor />
+        </text>
+      </code_block>
+      <code_block>
+        <text>
+          more
+        </text>
+      </code_block>
+      <code_block>
+        <text>
+          more
+          <head />
+        </text>
+      </code_block>
+    </doc>
+  `);
+});
+
+test('clicking the code block button while the selection is contains code blocks converts only the code blocks to paragraphs', async () => {
+  const content = (Type: 'code_block' | 'paragraph') => {
+    const stuff =
+      Type === 'code_block' ? (
+        <Type language="plain">
+          <text>something</text>
+        </Type>
+      ) : (
+        <Type>
+          <text>something</text>
+        </Type>
+      );
+    return (
+      <doc>
+        <paragraph>
+          <text>
+            blah <anchor />
+          </text>
+        </paragraph>
+        {stuff}
+        <paragraph>
+          <text>more</text>
+        </paragraph>
+        {stuff}
+        <heading level={1}>
+          <text>more</text>
+        </heading>
+        <paragraph>
+          <text>more</text>
+        </paragraph>
+        <paragraph>
+          <text>
+            more
+            <head />
+          </text>
+        </paragraph>
+      </doc>
+    );
+  };
+  const { rendered, user, state } = renderEditor(content('code_block'));
+
+  const button = rendered.getByLabelText('Code block');
+  expect(button).toBeEnabled();
+  expect(button).toHaveAttribute('aria-pressed', 'true');
+  await user.click(button);
+  expect(state()).toEqual(content('paragraph'));
+});
+
+test('clicking the code block while the selection is within a code block converts it to a paragraph', async () => {
+  const content = (Type: 'code_block' | 'paragraph') => (
+    <doc>
+      {Type === 'code_block' ? (
+        <Type language="plain">
+          <text>
+            some
+            <cursor />
+            thing
+          </text>
+        </Type>
+      ) : (
+        <Type>
+          <text>
+            some
+            <cursor />
+            thing
+          </text>
+        </Type>
+      )}
+      <heading level={1}>
+        <text>more</text>
+      </heading>
+      <paragraph>
+        <text>more</text>
+      </paragraph>
+    </doc>
+  );
+  const { rendered, user, state } = renderEditor(content('code_block'));
+
+  const button = rendered.getByLabelText('Code block');
+  expect(button).toBeEnabled();
+  expect(button).toHaveAttribute('aria-pressed', 'true');
+  await user.click(button);
+  expect(state()).toEqual(content('paragraph'));
+});

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/divider.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/divider.test.tsx
@@ -1,0 +1,26 @@
+/** @jest-environment jsdom */
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { jsx, renderEditor } from './utils';
+
+test('inserting a divider with a shortcut works', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <paragraph>
+        <text>
+          --
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  );
+
+  await user.keyboard('-');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <node_selection>
+        <divider />
+      </node_selection>
+    </doc>
+  `);
+});

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/editor-state-to-react-element.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/editor-state-to-react-element.ts
@@ -1,0 +1,167 @@
+import { GapCursor } from '../gapcursor/gapcursor';
+import { Mark, Node } from 'prosemirror-model';
+import {
+  TextSelection,
+  NodeSelection,
+  EditorState,
+  Selection,
+  AllSelection,
+} from 'prosemirror-state';
+import { ReactNode, createElement, ReactElement } from 'react';
+
+function cursorInText(
+  text: string,
+  anchorOffset: number | undefined,
+  headOffset: number | undefined,
+  storedMarks: readonly Mark[] | null
+): ReactNode {
+  if (anchorOffset === undefined && headOffset === undefined) {
+    return text;
+  }
+  const headProps: Record<string, unknown> =
+    storedMarks === null ? {} : { marks: serializeMarks(storedMarks) };
+  if (anchorOffset !== undefined && headOffset !== undefined) {
+    if (anchorOffset === headOffset) {
+      return [
+        text.slice(0, anchorOffset) || undefined,
+        createElement('cursor', headProps),
+        text.slice(anchorOffset) || undefined,
+      ];
+    }
+    const startOffset = Math.min(anchorOffset, headOffset);
+    const endOffset = Math.max(anchorOffset, headOffset);
+    const headElement = createElement('head', headProps);
+    const anchorElement = createElement('anchor');
+
+    return [
+      text.slice(0, startOffset) || undefined,
+      startOffset === anchorOffset ? anchorElement : headElement,
+      text.slice(startOffset, endOffset) || undefined,
+      endOffset === anchorOffset ? anchorElement : headElement,
+      text.slice(endOffset) || undefined,
+    ];
+  }
+  if (anchorOffset !== undefined) {
+    return [
+      text.slice(0, anchorOffset) || undefined,
+      createElement('anchor'),
+      text.slice(anchorOffset) || undefined,
+    ];
+  }
+  if (headOffset !== undefined) {
+    return [
+      text.slice(0, headOffset) || undefined,
+      createElement('head', headProps),
+      text.slice(headOffset) || undefined,
+    ];
+  }
+}
+
+function serializeMarks(marks: readonly Mark[]) {
+  const serialized: Record<string, unknown> = {};
+  for (const mark of marks) {
+    if (mark.type.name in serialized) {
+      throw new Error(
+        `text node has multiple marks of the same type: ${mark.type.name}`
+      );
+    }
+    serialized[mark.type.name] =
+      Object.keys(mark.attrs).length > 0 ? mark.attrs : true;
+  }
+  return serialized;
+}
+
+// we're converting the doc to react elements because Jest
+// knows how to pretty-print react elements in snapshots
+function nodeToReactElement(
+  node: Node,
+  selection: Selection,
+  storedMarks: readonly Mark[] | null
+): ReactElement | ReactElement[] {
+  if (node.isText) {
+    const { $anchor, $head } = selection;
+    const isAnchorInNode =
+      $anchor.doc.nodeAt($anchor.pos - $anchor.textOffset) === node;
+    const isHeadInNode =
+      $head.doc.nodeAt($head.pos - $head.textOffset) === node;
+    const text = node.text!;
+    const props: Record<string, unknown> = {
+      children: cursorInText(
+        node.text!,
+        $anchor.nodeBefore === node
+          ? text.length
+          : isAnchorInNode
+          ? $anchor.textOffset
+          : undefined,
+        $head.nodeBefore === node
+          ? text.length
+          : isHeadInNode
+          ? $head.textOffset
+          : undefined,
+        storedMarks
+      ),
+      ...serializeMarks(node.marks),
+    };
+
+    return createElement('text', props);
+  }
+
+  if (node.marks.length) {
+    throw new Error(
+      `non-text node has marks: ${node.marks.map(mark => mark.type.name)}`
+    );
+  }
+
+  const children: ReactNode[] = [];
+  node.content.forEach(node => {
+    children.push(nodeToReactElement(node, selection, storedMarks));
+  });
+
+  if (!children.length && selection instanceof TextSelection) {
+    if (selection.$cursor && selection.$cursor.parent === node) {
+      children.push(createElement('cursor'));
+    } else if (selection.$anchor.parent === node) {
+      children.push(createElement('anchor'));
+    } else if (selection.$head.parent === node) {
+      children.push(createElement('head'));
+    }
+  }
+
+  const element = createElement(node.type.name, {
+    ...node.attrs,
+    children,
+  });
+  if (selection instanceof NodeSelection && selection.node === node) {
+    return createElement('node_selection', { children: element });
+  }
+  if (selection instanceof GapCursor) {
+    const $pos = selection.$anchor;
+    if ($pos.nodeBefore === node && $pos.nodeAfter === null) {
+      return [element, createElement('gap_cursor')];
+    }
+    if ($pos.nodeAfter === node) {
+      return [createElement('gap_cursor'), element];
+    }
+  }
+  return element;
+}
+
+export function editorStateToReactNode(state: EditorState): ReactNode {
+  if (
+    !(state.selection instanceof TextSelection) &&
+    !(state.selection instanceof NodeSelection) &&
+    !(state.selection instanceof GapCursor) &&
+    !(state.selection instanceof AllSelection)
+  ) {
+    console.log(state.selection);
+    throw new Error(`no serialization for selection type: ${state.selection}`);
+  }
+  if (state.storedMarks && !(state.selection instanceof TextSelection)) {
+    throw new Error('unexpected stored marks without text selection');
+  }
+  return nodeToReactElement(
+    state.doc,
+    state.selection,
+    state.storedMarks
+  ) as ReactElement;
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/heading.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/heading.test.tsx
@@ -1,0 +1,147 @@
+/** @jest-environment jsdom */
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { jsx, renderEditor, undo } from './utils';
+
+for (const level of [1, 2, 3, 4, 5, 6]) {
+  const shortcut = '#'.repeat(level);
+  const editorStateWithLevel = (
+    <doc>
+      <heading level={level}>
+        <cursor />
+      </heading>
+    </doc>
+  );
+  const docWithShortcut = (
+    <doc>
+      <paragraph>
+        <text>
+          {shortcut}
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  );
+  test(`inserting a heading with ${shortcut} works`, async () => {
+    const { state, user } = renderEditor(docWithShortcut);
+    await user.keyboard(' ');
+    expect(state()).toEqual(editorStateWithLevel);
+  });
+  const undoneEditorState = (
+    <doc>
+      <paragraph>
+        <text>
+          {shortcut} <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  );
+  test(`inserting a heading with ${shortcut} works then undoing it returns back to with the shortcut`, async () => {
+    const { state, user } = renderEditor(docWithShortcut);
+    await user.keyboard(' ');
+    expect(state()).toEqual(editorStateWithLevel);
+    await undo(user);
+    expect(state()).toEqual(undoneEditorState);
+  });
+
+  test(`inserting a heading with ${shortcut} works then undoing it and redoing it works`, async () => {
+    const { state, user } = renderEditor(docWithShortcut);
+    await user.keyboard(' ');
+    expect(state()).toEqual(editorStateWithLevel);
+    await user.keyboard('{Control>}z{/Control}');
+    expect(state()).toEqual(undoneEditorState);
+    await user.keyboard('{Control>}{Shift>}z{/Control}{/Shift}');
+    expect(state()).toEqual(editorStateWithLevel);
+  });
+}
+
+test('inserting a break at the end of the heading exits the heading', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <heading level={1}>
+        <text>
+          Some heading
+          <cursor />
+        </text>
+      </heading>
+    </doc>
+  );
+
+  await user.keyboard('{Enter}');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <heading
+        level={1}
+      >
+        <text>
+          Some heading
+        </text>
+      </heading>
+      <paragraph>
+        <cursor />
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('inserting a break in the middle of the heading splits the text and does not exit the heading', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <heading level={1}>
+        <text>
+          Some <cursor />
+          heading
+        </text>
+      </heading>
+    </doc>
+  );
+
+  await user.keyboard('{Enter}');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <heading
+        level={1}
+      >
+        <text>
+          Some 
+        </text>
+      </heading>
+      <heading
+        level={1}
+      >
+        <text>
+          <cursor />
+          heading
+        </text>
+      </heading>
+    </doc>
+  `);
+});
+
+test('inserting a break at the start of the heading inserts a paragraph above the heading', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <heading level={1}>
+        <text>
+          <cursor />
+          Some heading
+        </text>
+      </heading>
+    </doc>
+  );
+
+  await user.keyboard('{Enter}');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph />
+      <heading
+        level={1}
+      >
+        <text>
+          <cursor />
+          Some heading
+        </text>
+      </heading>
+    </doc>
+  `);
+});

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/markdown-link-shortcut.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/markdown-link-shortcut.test.tsx
@@ -1,0 +1,299 @@
+/** @jest-environment jsdom */
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { jsx, renderEditor, undo } from './utils';
+
+test('basic link shortcut', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <paragraph>
+        <text>
+          [content](https://keystonejs.com
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  );
+  await user.keyboard(')');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text
+          link={
+            {
+              "href": "https://keystonejs.com",
+              "title": "",
+            }
+          }
+        >
+          content
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('link shortcut with content before it and whitespace directly before it works', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <paragraph>
+        <text>
+          asdasd asd [content](https://keystonejs.com
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  );
+  await user.keyboard(')');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text>
+          asdasd asd 
+        </text>
+        <text
+          link={
+            {
+              "href": "https://keystonejs.com",
+              "title": "",
+            }
+          }
+        >
+          content
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('link shortcut with content before it and no whitespace directly before it works', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <paragraph>
+        <text>
+          asdasd asd[content](https://keystonejs.com
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  );
+  await user.keyboard(')');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text>
+          asdasd asd
+        </text>
+        <text
+          link={
+            {
+              "href": "https://keystonejs.com",
+              "title": "",
+            }
+          }
+        >
+          content
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('shortcut with whitespace in the middle of the content works', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <paragraph>
+        <text>
+          [content more stuff](https://keystonejs.com
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  );
+  await user.keyboard(')');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text
+          link={
+            {
+              "href": "https://keystonejs.com",
+              "title": "",
+            }
+          }
+        >
+          content more stuff
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('link shortcut then typing inserts text outside of the link', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <paragraph>
+        <text>
+          [content](https://keystonejs.com
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  );
+  await user.keyboard(')content');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text
+          link={
+            {
+              "href": "https://keystonejs.com",
+              "title": "",
+            }
+          }
+        >
+          content
+        </text>
+        <text>
+          content
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('link shortcut with bold in some of the content works', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <paragraph>
+        <text>[co</text>
+        <text bold>nt</text>
+        <text>
+          ent](https://keystonejs.com
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  );
+  await user.keyboard(')');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text
+          link={
+            {
+              "href": "https://keystonejs.com",
+              "title": "",
+            }
+          }
+        >
+          co
+        </text>
+        <text
+          bold={true}
+          link={
+            {
+              "href": "https://keystonejs.com",
+              "title": "",
+            }
+          }
+        >
+          nt
+        </text>
+        <text
+          link={
+            {
+              "href": "https://keystonejs.com",
+              "title": "",
+            }
+          }
+        >
+          ent
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('an undo only reverts to the whole shortcut text', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <paragraph>
+        <text>
+          [content](https://keystonejs.com
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  );
+  await user.keyboard(')');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text
+          link={
+            {
+              "href": "https://keystonejs.com",
+              "title": "",
+            }
+          }
+        >
+          content
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  `);
+  await undo(user);
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text>
+          [content](https://keystonejs.com)
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test("text after the markdown shortcut isn't included in the link text", async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <paragraph>
+        <text>
+          [content](https://keystonejs.com
+          <cursor /> blah blah
+        </text>
+      </paragraph>
+    </doc>
+  );
+  await user.keyboard(')');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text
+          link={
+            {
+              "href": "https://keystonejs.com",
+              "title": "",
+            }
+          }
+        >
+          content
+          <cursor />
+        </text>
+        <text>
+          <cursor />
+           blah blah
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/marks.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/marks.test.tsx
@@ -1,0 +1,653 @@
+/** @jest-environment jsdom */
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { simpleMarkShortcuts } from '../inputrules/shortcuts';
+import { jsx, redo, renderEditor, undo } from './utils';
+
+for (const [markName, shortcuts] of simpleMarkShortcuts) {
+  for (const shortcut of shortcuts) {
+    describe(`${markName} with shortcut ${shortcut}`, () => {
+      test('basic shortcut usage', async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text>
+                {shortcut}thing{shortcut.slice(0, -1)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+        await user.keyboard(`${shortcut.slice(-1)}s`);
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text {...{ [markName]: true }}>thing</text>
+              <text>
+                s<cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+      test('single character inside shortcut', async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text>
+                {shortcut}a{shortcut.slice(0, -1)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+        await user.keyboard(`${shortcut.slice(-1)}s`);
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text {...{ [markName]: true }}>a</text>
+              <text>
+                s<cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+
+      test('two characters inside shortcut', async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text>
+                {shortcut}ab{shortcut.slice(0, -1)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+        await user.keyboard(`${shortcut.slice(-1)}s`);
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text {...{ [markName]: true }}>ab</text>
+              <text>
+                s<cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+      test('basic shortcut usage from empty', async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <cursor />
+            </paragraph>
+          </doc>
+        );
+        await user.keyboard(`${shortcut}thing${shortcut}s`);
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text {...{ [markName]: true }}>thing</text>
+              <text>
+                s<cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+
+      test('works when selection is not collapsed', async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text>
+                {shortcut}thing{shortcut.slice(0, -1)}
+                <anchor />
+                some wonderful content
+                <head />
+              </text>
+            </paragraph>
+          </doc>
+        );
+        await user.keyboard(shortcut.slice(-1));
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text {...{ [markName]: true }}>
+                thing
+                <cursor marks={{}} />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+      const otherMark = markName === 'italic' ? 'bold' : 'italic';
+      test('works when the start and ends are in different text nodes', async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text>{shortcut}t</text>
+              <text {...{ [otherMark]: true }}>hin</text>
+              <text>
+                g{shortcut.slice(0, -1)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+        await user.keyboard(shortcut.slice(-1));
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text {...{ [markName]: true }}>t</text>
+              <text {...{ [otherMark]: true, [markName]: true }}>hin</text>
+              <text {...{ [markName]: true }}>
+                g
+                <cursor marks={{}} />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+      test('does match when start of shortcut is in a different text node', async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text {...{ [otherMark]: true }}>{shortcut}</text>
+              <text>
+                thing{shortcut.slice(0, -1)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+
+        await user.keyboard(shortcut.slice(-1));
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text {...{ [markName]: true }}>
+                thing
+                <cursor marks={{}} />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+      if (shortcut.length === 2) {
+        test('matches when the end shortcut is in a different text node', async () => {
+          const { state, user } = renderEditor(
+            <doc>
+              <paragraph>
+                <text>{shortcut}thing</text>
+                <text {...{ [otherMark]: true }}>
+                  {shortcut.slice(0, -1)}
+                  <cursor />
+                </text>
+              </paragraph>
+            </doc>
+          );
+
+          await user.keyboard(shortcut.slice(-1));
+          expect(state()).toEqual(
+            <doc>
+              <paragraph>
+                <text {...{ [markName]: true }}>
+                  thing
+                  <cursor marks={{}} />
+                </text>
+              </paragraph>
+            </doc>
+          );
+        });
+        test('does match when first and second characters in the start shortcut are in different text nodes', async () => {
+          const { state, user } = renderEditor(
+            <doc>
+              <paragraph>
+                <text {...{ [otherMark]: true }}>{shortcut[0]}</text>
+                <text>
+                  {shortcut[1]}thing{shortcut.slice(0, -1)}
+                  <cursor />
+                </text>
+              </paragraph>
+            </doc>
+          );
+
+          await user.keyboard(shortcut.slice(-1));
+          expect(state()).toEqual(
+            <doc>
+              <paragraph>
+                <text {...{ [markName]: true }}>
+                  thing
+                  <cursor marks={{}} />
+                </text>
+              </paragraph>
+            </doc>
+          );
+        });
+      }
+      test('matches when the shortcut appears in an invalid position after the valid position in the same text node', async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text>
+                some text {shortcut}t{shortcut}hing{shortcut.slice(0, -1)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+
+        await user.keyboard(shortcut.slice(-1));
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text>some text </text>
+              <text {...{ [markName]: true }}>
+                t{shortcut}hing
+                <cursor marks={{}} />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+
+      test('does not match when there is nothing between the start and end of the shortcut', async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text>
+                {shortcut + shortcut.slice(0, -1)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+        await user.keyboard(shortcut.slice(-1));
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text>
+                {shortcut.repeat(2)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+      test('does not match when there is whitespace immediately after the end of the start of the shortcut', async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text>
+                {shortcut} thing{shortcut.slice(0, -1)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+
+        await user.keyboard(shortcut.slice(-1));
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text>
+                {shortcut} thing{shortcut}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+
+      test('does not match when there is whitespace immediately before the start of the end shortcut', async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text>
+                {shortcut}thing {shortcut.slice(0, -1)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+
+        await user.keyboard(shortcut.slice(-1));
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text>
+                {shortcut}thing {shortcut}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+      if (shortcut[0] === '_') {
+        test('does not match if there is a non-whitespace character before the start of the shortcut', async () => {
+          const { state, user } = renderEditor(
+            <doc>
+              <paragraph>
+                <text>
+                  w{shortcut}thing{shortcut.slice(0, -1)}
+                  <cursor />
+                </text>
+              </paragraph>
+            </doc>
+          );
+
+          await user.keyboard(shortcut.slice(-1));
+          expect(state()).toEqual(
+            <doc>
+              <paragraph>
+                <text>
+                  w{shortcut}thing{shortcut}
+                  <cursor />
+                </text>
+              </paragraph>
+            </doc>
+          );
+        });
+        test("does not match when there is a different text node before the start of the shortcut that doesn't end in whitespace", async () => {
+          const { state, user } = renderEditor(
+            <doc>
+              <paragraph>
+                <text {...{ [otherMark]: true }}>some text</text>
+                <text>
+                  {shortcut}thing{shortcut.slice(0, -1)}
+                  <cursor />
+                </text>
+              </paragraph>
+            </doc>
+          );
+
+          await user.keyboard(shortcut.slice(-1));
+          expect(state()).toEqual(
+            <doc>
+              <paragraph>
+                <text {...{ [otherMark]: true }}>some text</text>
+                <text>
+                  {shortcut}thing{shortcut}
+                  <cursor />
+                </text>
+              </paragraph>
+            </doc>
+          );
+        });
+        test('matches when the shortcut appears in an invalid position before the valid position in the same text node', async () => {
+          const { state, user } = renderEditor(
+            <doc>
+              <paragraph>
+                <text>
+                  some{shortcut}text {shortcut}thing{shortcut.slice(0, -1)}
+                  <cursor />
+                </text>
+              </paragraph>
+            </doc>
+          );
+
+          await user.keyboard(shortcut.slice(-1));
+          expect(state()).toEqual(
+            <doc>
+              <paragraph>
+                <text>some{shortcut}text </text>
+                <text {...{ [markName]: true }}>
+                  thing
+                  <cursor marks={{}} />
+                </text>
+              </paragraph>
+            </doc>
+          );
+        });
+      }
+      test('does match if there is content before the text but still whitespace before the shortcut', async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text>
+                w {shortcut}thing{shortcut.slice(0, -1)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+
+        await user.keyboard(shortcut.slice(-1));
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text>w </text>
+              <text {...{ [markName]: true }}>
+                thing
+                <cursor marks={{}} />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+      test("does match if there's text in the same block with marks and still whitespace before the new place", async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text bold>some text</text>
+              <text>
+                more {shortcut}something{shortcut.slice(0, -1)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+
+        await user.keyboard(shortcut.slice(-1));
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text bold>some text</text>
+              <text>more </text>
+              <text {...{ [markName]: true }}>
+                something
+                <cursor marks={{}} />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+      test("does match if there's lots of text in the same block with marks and still whitespace before the new place", async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text {...{ [otherMark]: true }}>some text</text>
+              <text bold>some text</text>
+              <text {...{ [otherMark]: true }}>some text</text>
+              <text bold>some text</text>
+              <text {...{ [otherMark]: true }}>some text</text>
+              <text bold>some text</text>
+              <text {...{ [otherMark]: true }}>some text</text>
+              <text bold>some text</text>
+              <text {...{ [otherMark]: true }}>some text</text>
+              <text bold>some text</text>
+              <text {...{ [otherMark]: true }}>some text</text>
+              <text bold>some text</text>
+              <text {...{ [otherMark]: true }}>some text</text>
+              <text bold>some text</text>
+              <text>
+                more {shortcut}something{shortcut.slice(0, -1)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+
+        await user.keyboard(shortcut.slice(-1));
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text {...{ [otherMark]: true }}>some text</text>
+              <text bold>some text</text>
+              <text {...{ [otherMark]: true }}>some text</text>
+              <text bold>some text</text>
+              <text {...{ [otherMark]: true }}>some text</text>
+              <text bold>some text</text>
+              <text {...{ [otherMark]: true }}>some text</text>
+              <text bold>some text</text>
+              <text {...{ [otherMark]: true }}>some text</text>
+              <text bold>some text</text>
+              <text {...{ [otherMark]: true }}>some text</text>
+              <text bold>some text</text>
+              <text {...{ [otherMark]: true }}>some text</text>
+              <text bold>some text</text>
+              <text>more </text>
+              <text {...{ [markName]: true }}>
+                something
+                <cursor marks={{}} />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+
+      test('undo only undos adding the mark and removing the shortcut, keeps the inserted text', async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text>
+                {shortcut}something{shortcut.slice(0, -1)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+
+        await user.keyboard(shortcut.slice(-1));
+        await undo(user);
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text>
+                {shortcut}something{shortcut}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+      test('redo works', async () => {
+        const { state, user } = renderEditor(
+          <doc>
+            <paragraph>
+              <text>
+                {shortcut}something{shortcut.slice(0, -1)}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+
+        await user.keyboard(shortcut.slice(-1));
+
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text {...{ [markName]: true }}>
+                something
+                <cursor marks={{}} />
+              </text>
+            </paragraph>
+          </doc>
+        );
+        await undo(user);
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text>
+                {shortcut}something{shortcut}
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+        await redo(user);
+        // note the lack of marks={{}} on the cursor after redoing it
+        // this isn't ideal but whatever
+        expect(state()).toEqual(
+          <doc>
+            <paragraph>
+              <text {...{ [markName]: true }}>
+                something
+                <cursor />
+              </text>
+            </paragraph>
+          </doc>
+        );
+      });
+    });
+  }
+}
+
+test('inserting a break at the end of a block with a mark removes the mark', async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <paragraph>
+        <text bold>
+          some content
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  );
+
+  await user.keyboard('{Enter}a');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text
+          bold={true}
+        >
+          some content
+        </text>
+      </paragraph>
+      <paragraph>
+        <text>
+          a
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test("inserting a break in the middle of text doesn't remove the mark", async () => {
+  const { state, user } = renderEditor(
+    <doc>
+      <paragraph>
+        <text bold>
+          some <cursor /> content
+        </text>
+      </paragraph>
+    </doc>
+  );
+  await user.keyboard('{Enter}a');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text
+          bold={true}
+        >
+          some 
+        </text>
+      </paragraph>
+      <paragraph>
+        <text
+          bold={true}
+        >
+          a
+          <cursor />
+           content
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/shortcuts.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/shortcuts.test.tsx
@@ -1,0 +1,62 @@
+/** @jest-environment jsdom */
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { shortcuts } from '../inputrules/shortcuts';
+import { jsx, redo, renderEditor, undo } from './utils';
+
+describe.each(Object.entries(shortcuts))(
+  'shortcut "%s" for "%s"',
+  (shortcut, result) => {
+    const inputDoc = (
+      <doc>
+        <paragraph>
+          <text>
+            {shortcut}
+            <cursor />
+          </text>
+        </paragraph>
+      </doc>
+    );
+    const resultingState = (
+      <doc>
+        <paragraph>
+          <text>
+            {result + ' '}
+            <cursor />
+          </text>
+        </paragraph>
+      </doc>
+    );
+    test('can be inserted', async () => {
+      const { state, user } = renderEditor(inputDoc);
+      await user.keyboard(' ');
+      expect(state()).toEqual(resultingState);
+    });
+    const undoneEditorState = (
+      <doc>
+        <paragraph>
+          <text>
+            {shortcut + ' '}
+            <cursor />
+          </text>
+        </paragraph>
+      </doc>
+    );
+    test('the replacement can be undone', async () => {
+      const { state, user } = renderEditor(inputDoc);
+      await user.keyboard(' ');
+      expect(state()).toEqual(resultingState);
+      await undo(user);
+      expect(state()).toEqual(undoneEditorState);
+    });
+    test('the replacement can be redone', async () => {
+      const { state, user } = renderEditor(inputDoc);
+      await user.keyboard(' ');
+      expect(state()).toEqual(resultingState);
+      await undo(user);
+      expect(state()).toEqual(undoneEditorState);
+      await redo(user);
+      expect(state()).toEqual(resultingState);
+    });
+  }
+);

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/test-utils.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/test-utils.test.tsx
@@ -1,0 +1,607 @@
+/** @jest-environment jsdom */
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { jsx, renderEditor } from './utils';
+
+test('basic cursor snapshot', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <cursor />
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <cursor />
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('anchor in empty paragraph', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <anchor />
+      </paragraph>
+      <paragraph>
+        <text>
+          a<head />b
+        </text>
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <anchor />
+      </paragraph>
+      <paragraph>
+        <text>
+          a
+          <head />
+          b
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('head in empty paragraph', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <head />
+      </paragraph>
+      <paragraph>
+        <text>
+          a<anchor />b
+        </text>
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <head />
+      </paragraph>
+      <paragraph>
+        <text>
+          a
+          <anchor />
+          b
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('cursor between dividers', () => {
+  expect(
+    <doc>
+      <divider />
+      <gap_cursor />
+      <divider />
+    </doc>
+  ).toMatchInlineSnapshot(`
+    <doc>
+      <divider />
+      <gap_cursor />
+      <divider />
+    </doc>
+  `);
+});
+
+test('cursor before dividers', () => {
+  expect(
+    <doc>
+      <gap_cursor />
+      <divider />
+      <divider />
+    </doc>
+  ).toMatchInlineSnapshot(`
+    <doc>
+      <gap_cursor />
+      <divider />
+      <divider />
+    </doc>
+  `);
+});
+
+test('cursor after dividers', () => {
+  expect(
+    <doc>
+      <divider />
+      <divider />
+      <gap_cursor />
+    </doc>
+  ).toMatchInlineSnapshot(`
+    <doc>
+      <divider />
+      <divider />
+      <gap_cursor />
+    </doc>
+  `);
+});
+
+test('selection around divider with divider after', () => {
+  expect(
+    <doc>
+      <node_selection>
+        <divider />
+      </node_selection>
+      <divider />
+    </doc>
+  ).toMatchInlineSnapshot(`
+    <doc>
+      <node_selection>
+        <divider />
+      </node_selection>
+      <divider />
+    </doc>
+  `);
+});
+
+test('selection around divider with nothing else', () => {
+  expect(
+    <doc>
+      <node_selection>
+        <divider />
+      </node_selection>
+    </doc>
+  ).toMatchInlineSnapshot(`
+    <doc>
+      <node_selection>
+        <divider />
+      </node_selection>
+    </doc>
+  `);
+});
+
+test('basic cursor snapshot with content', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <text>
+          some
+          <cursor />
+          thing
+        </text>
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text>
+          some
+          <cursor />
+          thing
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('basic snapshot with non-empty selection with anchor first', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <text>
+          so
+          <anchor />
+          me
+          <head />
+          thing
+        </text>
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text>
+          so
+          <anchor />
+          me
+          <head />
+          thing
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('basic snapshot with non-empty selection with head first', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <text>
+          so
+          <head />
+          me
+          <anchor />
+          thing
+        </text>
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text>
+          so
+          <head />
+          me
+          <anchor />
+          thing
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('basic snapshot with non-empty selection with head and anchor in different nodes', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <text>
+          some
+          <head />
+          thing
+        </text>
+      </paragraph>
+      <paragraph>
+        <text>
+          another
+          <anchor />
+          thing
+        </text>
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text>
+          some
+          <head />
+          thing
+        </text>
+      </paragraph>
+      <paragraph>
+        <text>
+          another
+          <anchor />
+          thing
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('editor equality match', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <cursor />
+      </paragraph>
+    </doc>
+  ).toEqual(
+    <doc>
+      <paragraph>
+        <cursor />
+      </paragraph>
+    </doc>
+  );
+});
+
+test('editor equality mismatch', () => {
+  expect(() =>
+    expect(
+      <doc>
+        <paragraph>
+          <text>
+            some text
+            <cursor />
+          </text>
+        </paragraph>
+      </doc>
+    ).toEqual(
+      <doc>
+        <paragraph>
+          <cursor />
+        </paragraph>
+      </doc>
+    )
+  ).toThrowError();
+});
+
+test('editor equality mismatch with only a different selection', () => {
+  expect(() =>
+    expect(
+      <doc>
+        <paragraph>
+          <text>
+            some
+            <cursor />
+            text
+          </text>
+        </paragraph>
+      </doc>
+    ).toEqual(
+      <doc>
+        <paragraph>
+          <text>
+            som
+            <cursor />
+            etext
+          </text>
+        </paragraph>
+      </doc>
+    )
+  ).toThrowError();
+});
+
+test('cursor in the middle of text', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <text>
+          some
+          <cursor />
+          text
+        </text>
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+      <doc>
+        <paragraph>
+          <text>
+            some
+            <cursor />
+            text
+          </text>
+        </paragraph>
+      </doc>
+    `);
+});
+
+test('cursor at start of text', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <text>
+          <cursor />
+          some text
+        </text>
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text>
+          <cursor />
+          some text
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('cursor at end of text', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <text>
+          some text
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text>
+          some text
+          <cursor />
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});
+
+test('anchor in middle, head at end', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <text>
+          some
+          <anchor />
+          text
+          <head />
+        </text>
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+      <doc>
+        <paragraph>
+          <text>
+            some
+            <anchor />
+            text
+            <head />
+          </text>
+        </paragraph>
+      </doc>
+  `);
+});
+
+test('cursor split in the same text to end with anchor first', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <text>
+          some
+          <anchor />
+          text
+          <head />
+        </text>
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+      <doc>
+        <paragraph>
+          <text>
+            some
+            <anchor />
+            text
+            <head />
+          </text>
+        </paragraph>
+      </doc>
+    `);
+});
+
+test('cursor split in the same text to end with head first', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <text>
+          some
+          <head />
+          text
+          <anchor />
+        </text>
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+      <doc>
+        <paragraph>
+          <text>
+            some
+            <head />
+            text
+            <anchor />
+          </text>
+        </paragraph>
+      </doc>
+    `);
+});
+
+test('cursor split in different text with anchor first', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <text>
+          some
+          <anchor />
+          text
+        </text>
+      </paragraph>
+      <paragraph>
+        <text>
+          somete
+          <head />
+          xt
+        </text>
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+      <doc>
+        <paragraph>
+          <text>
+            some
+            <anchor />
+            text
+          </text>
+        </paragraph>
+        <paragraph>
+          <text>
+            somete
+            <head />
+            xt
+          </text>
+        </paragraph>
+      </doc>
+    `);
+});
+
+test('cursor split in different text with head first', () => {
+  expect(
+    <doc>
+      <paragraph>
+        <text>
+          some
+          <head />
+          text
+        </text>
+      </paragraph>
+      <paragraph>
+        <text>
+          somete
+          <anchor />
+          xt
+        </text>
+      </paragraph>
+    </doc>
+  ).toMatchInlineSnapshot(`
+      <doc>
+        <paragraph>
+          <text>
+            some
+            <head />
+            text
+          </text>
+        </paragraph>
+        <paragraph>
+          <text>
+            somete
+            <anchor />
+            xt
+          </text>
+        </paragraph>
+      </doc>
+    `);
+});
+
+test("throws on input that doesn't conform to the schema", () => {
+  expect(() =>
+    renderEditor(
+      <doc>
+        <paragraph>
+          <paragraph>
+            <text>
+              some
+              <cursor />
+              text
+            </text>
+          </paragraph>
+        </paragraph>
+      </doc>
+    )
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Invalid content for node paragraph: <paragraph("sometext")>"`
+  );
+});
+
+test('delete backward', async () => {
+  let { state, user } = renderEditor(
+    <doc>
+      <paragraph>
+        <text>
+          some
+          <cursor />
+          text
+        </text>
+      </paragraph>
+    </doc>
+  );
+  await user.keyboard('{Backspace}');
+  expect(state()).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text>
+          som
+          <cursor />
+          text
+        </text>
+      </paragraph>
+    </doc>
+  `);
+});

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/utils.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/utils.tsx
@@ -1,0 +1,577 @@
+import { createEditorState } from '../editor-state';
+import { createEditorSchema, EditorSchema } from '../schema';
+import { Attrs, Mark, Node, NodeType, Schema } from 'prosemirror-model';
+import { EditorState, NodeSelection, TextSelection } from 'prosemirror-state';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Editor } from '../index';
+import { GapCursor } from '../gapcursor/gapcursor';
+import { VoussoirProvider } from '@voussoir/core';
+import { createRef } from 'react';
+import { plugins, format, NewPlugin } from 'pretty-format';
+import { EditorView } from 'prosemirror-view';
+import { editorStateToReactNode } from './editor-state-to-react-element';
+
+type SelectionConfig =
+  | {
+      kind: 'text';
+      anchor?: number;
+      head?: { pos: number; storedMarks: readonly Mark[] | null };
+    }
+  | {
+      kind: 'node';
+      pos: number;
+      storedMarks: readonly Mark[] | null;
+    }
+  | {
+      kind: 'gap';
+      pos: number;
+      storedMarks: readonly Mark[] | null;
+    };
+
+const nodesToSelectionConfig = new WeakMap<Node, SelectionConfig>();
+
+function getSelectionConfig(node: Node) {
+  return nodesToSelectionConfig.get(node);
+}
+
+function setSelectionConfig(node: Node, config: SelectionConfig) {
+  nodesToSelectionConfig.set(node, config);
+}
+
+type SelectionInfo =
+  | { kind: 'anchor' }
+  | {
+      kind: 'head' | 'cursor' | 'gap_cursor';
+      storedMarks: Record<string, unknown> | undefined;
+    };
+
+const {
+  nodes: { selection_info: selectionInfoNode },
+} = new Schema({
+  nodes: {
+    selection_info: {
+      attrs: {
+        info: {},
+      },
+    },
+    text: {},
+  },
+  topNode: 'selection_info',
+});
+
+function marksFromProps(props: Record<string, unknown>, schema: Schema) {
+  const marks: Mark[] = [];
+  for (const [key, value] of Object.entries(props)) {
+    const markType = schema.marks[key];
+    if (!markType) {
+      throw new Error(`Unknown mark ${key}`);
+    }
+    marks.push(markType.create(value === true ? undefined : (value as Attrs)));
+  }
+  return marks;
+}
+
+function createSelectionInfoNode(info: SelectionInfo) {
+  return selectionInfoNode.create({ info });
+}
+
+function storedMarksFromMarksPropOnSelectionNode(
+  marks: unknown,
+  schema: Schema
+) {
+  if (marks == null) {
+    return null;
+  }
+  return marksFromProps(marks as any, schema);
+}
+
+function getSelectionInfoFromNode(node: Node) {
+  if (node.type !== selectionInfoNode) return null;
+  return node.attrs.info as SelectionInfo;
+}
+
+const defaultEditorSchema = createEditorSchema({});
+
+const defaultSchema = defaultEditorSchema.schema;
+
+const markNamesSet = new Set(Object.keys(defaultEditorSchema.marks));
+
+for (const node of Object.values(defaultEditorSchema.nodes)) {
+  const keys = Object.keys(node.spec.attrs ?? {});
+  for (const key of keys) {
+    if (markNamesSet.has(key)) {
+      throw new Error(
+        `Node ${node.name} has an attribute named ${key} that but there is also a mark with that name`
+      );
+    }
+  }
+}
+
+export function jsx(
+  _type:
+    | keyof EditorSchema['nodes']
+    | 'anchor'
+    | 'head'
+    | 'cursor'
+    | 'gap_cursor'
+    | 'node_selection'
+    | NodeType,
+  _props: Record<string, any> | null | undefined,
+  ..._children: (
+    | string
+    | EditorStateDescription
+    | (string | EditorStateDescription)[]
+  )[]
+): EditorStateDescription {
+  const node = _jsx(
+    _type,
+    _props,
+    ..._children.flat(1).map(x => {
+      if (typeof x === 'string') {
+        return x;
+      }
+      if (x instanceof FakeEditorStateDescription) {
+        return x.node;
+      }
+      throw new Error(`invalid child ${x}`);
+    })
+  );
+  if (node.type.name === 'doc') {
+    return toEditorState(node);
+  }
+  return new FakeEditorStateDescription(node);
+}
+
+class FakeEditorStateDescription {
+  #node: Node;
+  constructor(node: Node) {
+    this.#node = node;
+  }
+  get node() {
+    return this.#node;
+  }
+  get(): never {
+    throw new Error('cannot get editor state from a non-doc node');
+  }
+}
+
+function _jsx(
+  _type:
+    | keyof EditorSchema['nodes']
+    | 'anchor'
+    | 'head'
+    | 'cursor'
+    | 'gap_cursor'
+    | 'node_selection'
+    | NodeType,
+  _props: Record<string, any> | null | undefined,
+  ..._children: (string | Node)[]
+): Node {
+  const flatChildren = _children.flat(1);
+  if (_type === 'anchor') {
+    return createSelectionInfoNode({ kind: 'anchor' });
+  }
+  const props = _props ?? {};
+  if (_type === 'gap_cursor' || _type === 'cursor' || _type === 'head') {
+    return createSelectionInfoNode({
+      kind: _type,
+      storedMarks: props.marks,
+    });
+  }
+  if (_type === 'node_selection') {
+    if (flatChildren.length !== 1) {
+      throw new Error('node_selection must have exactly one child');
+    }
+    const child = flatChildren[0];
+    if (!(child instanceof Node)) {
+      throw new Error('node_selection child must be a node');
+    }
+    const innerSelectionConfig = getSelectionConfig(child);
+    if (innerSelectionConfig) {
+      throw new Error('Node selection cannot have a selection config');
+    }
+    setSelectionConfig(child, {
+      kind: 'node',
+      pos: 0,
+      storedMarks: storedMarksFromMarksPropOnSelectionNode(
+        props.marks,
+        child.type.schema
+      ),
+    });
+    return child;
+  }
+  let type;
+  type = _type;
+  let schema = defaultSchema;
+  if (type instanceof NodeType) {
+    schema = type.schema;
+    type = type.name;
+  }
+  if (type === 'text') {
+    let out = '';
+    let selectionConfig: (SelectionConfig & { kind: 'text' }) | undefined;
+    for (const child of flatChildren) {
+      if (typeof child === 'string') {
+        out += child;
+        continue;
+      }
+      const info = getSelectionInfoFromNode(child);
+      if (info) {
+        if (!selectionConfig) {
+          selectionConfig = { kind: 'text' };
+        }
+        if (info.kind === 'anchor' || info.kind === 'cursor') {
+          if (selectionConfig.anchor !== undefined) {
+            throw new Error('Cannot have multiple anchors');
+          }
+          selectionConfig.anchor = out.length;
+        }
+        if (info.kind === 'head' || info.kind === 'cursor') {
+          if (selectionConfig.head !== undefined) {
+            throw new Error('Cannot have multiple heads');
+          }
+          selectionConfig.head = {
+            pos: out.length,
+            storedMarks: storedMarksFromMarksPropOnSelectionNode(
+              info.storedMarks,
+              schema
+            ),
+          };
+        }
+        continue;
+      }
+      throw new Error('Text nodes can only contain strings or selection nodes');
+    }
+
+    const node = schema.text(out, marksFromProps(props, schema));
+    if (selectionConfig) {
+      setSelectionConfig(node, selectionConfig);
+    }
+    return node;
+  }
+  let pos = 0;
+  const content: Node[] = [];
+  let selectionConfig: SelectionConfig | undefined;
+  for (const node of flatChildren) {
+    if (!(node instanceof Node)) {
+      throw new Error('Children of non-text nodes must only be other nodes');
+    }
+    const info = getSelectionInfoFromNode(node);
+    if (info) {
+      if (info.kind === 'gap_cursor') {
+        if (selectionConfig !== undefined) {
+          throw new Error('multiple selections');
+        }
+        selectionConfig = {
+          kind: 'gap',
+          pos,
+          storedMarks: storedMarksFromMarksPropOnSelectionNode(
+            info.storedMarks,
+            schema
+          ),
+        };
+      }
+      if (info.kind === 'anchor' || info.kind === 'cursor') {
+        if (selectionConfig === undefined) {
+          selectionConfig = { kind: 'text' };
+        }
+        if (selectionConfig.kind !== 'text') {
+          throw new Error(
+            `${selectionConfig.kind} selection cannot be combined with text selection`
+          );
+        }
+        if (selectionConfig.anchor !== undefined) {
+          throw new Error('multiple anchors');
+        }
+        selectionConfig.anchor = pos;
+      }
+      if (info.kind === 'head' || info.kind === 'cursor') {
+        if (selectionConfig === undefined) {
+          selectionConfig = { kind: 'text' };
+        }
+        if (selectionConfig.kind !== 'text') {
+          throw new Error(
+            `${selectionConfig.kind} selection cannot be combined with text selection`
+          );
+        }
+        if (selectionConfig.head !== undefined) {
+          throw new Error('multiple heads');
+        }
+        selectionConfig.head = {
+          pos,
+          storedMarks: storedMarksFromMarksPropOnSelectionNode(
+            info.storedMarks,
+            schema
+          ),
+        };
+      }
+      continue;
+    }
+    if (node.type.schema !== schema) {
+      throw new Error(
+        `Node ${node.type.name} is from a different schema to the parent ${type} node`
+      );
+    }
+    const childSelectionConfig = getSelectionConfig(node);
+    if (childSelectionConfig) {
+      if (
+        childSelectionConfig.kind === 'gap' ||
+        childSelectionConfig.kind === 'node'
+      ) {
+        if (selectionConfig !== undefined) {
+          throw new Error('multiple selections');
+        }
+        selectionConfig = {
+          kind: childSelectionConfig.kind,
+          pos: pos + childSelectionConfig.pos,
+          storedMarks: childSelectionConfig.storedMarks,
+        };
+      } else {
+        const start = (node.isText ? 0 : 1) + pos;
+
+        if (selectionConfig === undefined) {
+          selectionConfig = { kind: 'text' };
+        }
+        if (selectionConfig.kind !== 'text') {
+          throw new Error(
+            `${selectionConfig.kind} selection cannot be combined with text selection`
+          );
+        }
+        if (childSelectionConfig.anchor !== undefined) {
+          if (selectionConfig.anchor !== undefined) {
+            throw new Error('multiple anchors');
+          }
+          selectionConfig.anchor = start + childSelectionConfig.anchor;
+        }
+        if (childSelectionConfig.head !== undefined) {
+          if (selectionConfig.head !== undefined) {
+            throw new Error('multiple heads');
+          }
+          selectionConfig.head = {
+            pos: start + childSelectionConfig.head.pos,
+            storedMarks: childSelectionConfig.head.storedMarks,
+          };
+        }
+      }
+    }
+    pos += node.nodeSize;
+    content.push(node);
+  }
+
+  const node = schema.node(type, props, content);
+  if (selectionConfig) {
+    setSelectionConfig(node, selectionConfig);
+  }
+  return node;
+}
+
+type NodeChildren = EditorStateDescription[] | EditorStateDescription;
+
+type Marks = {
+  link?: { href: string; title: string };
+} & {
+  [Key in Exclude<keyof EditorSchema['marks'], 'link'>]?: true;
+};
+export declare namespace jsx {
+  namespace JSX {
+    type IntrinsicElements = {
+      text: {
+        children: (string | EditorStateDescription)[] | string;
+      } & Marks;
+      doc: { children?: NodeChildren };
+      code_block: { children?: NodeChildren; language: string };
+      heading: { level: number; children?: NodeChildren };
+      divider: { children?: NodeChildren };
+      blockquote: { children?: NodeChildren };
+      paragraph: { children?: NodeChildren };
+      unordered_list: { children?: NodeChildren };
+      ordered_list: { children?: NodeChildren };
+      list_item: { children?: NodeChildren };
+      anchor: { children?: undefined };
+      head: { children?: undefined };
+      cursor: { children?: undefined; marks?: Marks };
+      gap_cursor: { children?: undefined; marks?: Marks };
+      node_selection: { children: EditorStateDescription; marks?: Marks };
+    };
+    type Element = EditorStateDescription;
+    interface ElementAttributesProperty {
+      props: {};
+    }
+    interface ElementChildrenAttribute {
+      children: {};
+    }
+  }
+}
+
+function toEditorState(doc: Node): EditorStateDescription {
+  if (!(doc instanceof Node)) {
+    throw new Error('toEditorState only accepts a single node');
+  }
+  if (doc.type === selectionInfoNode) {
+    throw new Error('toEditorState does not accept a selection info node');
+  }
+  const selectionConfig = getSelectionConfig(doc);
+  let selection;
+  let storedMarks: readonly Mark[] | null = null;
+  if (selectionConfig?.kind === 'text') {
+    if (selectionConfig.anchor === undefined) {
+      throw new Error('missing anchor');
+    }
+    if (selectionConfig.head === undefined) {
+      throw new Error('missing head');
+    }
+    const $head = doc.resolve(selectionConfig.head.pos);
+    const $anchor = doc.resolve(selectionConfig.anchor);
+    if (!$anchor.parent.inlineContent) {
+      throw new Error(
+        'anchor must be in inline content when using text selections'
+      );
+    }
+    if (!$head.parent.inlineContent) {
+      throw new Error(
+        'head must be in inline content when using text selections'
+      );
+    }
+    selection = new TextSelection($anchor, $head);
+    storedMarks = selectionConfig.head.storedMarks;
+  }
+  if (selectionConfig?.kind === 'gap') {
+    const $pos = doc.resolve(selectionConfig.pos);
+    if (!(GapCursor as any).valid($pos)) {
+      throw new Error('invalid gap cursor position');
+    }
+    selection = new GapCursor($pos);
+    storedMarks = selectionConfig.storedMarks;
+  }
+  if (selectionConfig?.kind === 'node') {
+    const node = doc.nodeAt(selectionConfig.pos);
+    if (!node) {
+      throw new Error(`node in node_selection not found`);
+    }
+    if (!NodeSelection.isSelectable(node)) {
+      throw new Error(`node in node_selection is not selectable`);
+    }
+    selection = NodeSelection.create(doc, selectionConfig.pos);
+    storedMarks = selectionConfig.storedMarks;
+  }
+  return new RealEditorStateDescription(
+    createEditorState(doc, selection, storedMarks)
+  );
+}
+
+Range.prototype.getClientRects = function getClientRects() {
+  return [] as unknown as DOMRectList;
+};
+
+const emptyRect: Omit<DOMRect, 'toJSON'> = {
+  bottom: 0,
+  height: 0,
+  left: 0,
+  right: 0,
+  top: 0,
+  width: 0,
+  x: 0,
+  y: 0,
+};
+
+Range.prototype.getBoundingClientRect = function getBoundingClientRect() {
+  return {
+    ...emptyRect,
+    toJSON() {
+      return emptyRect;
+    },
+  };
+};
+
+export type User = ReturnType<(typeof userEvent)['setup']>;
+
+export async function undo(user: ReturnType<(typeof userEvent)['setup']>) {
+  await user.keyboard('{Control>}z{/Control}');
+}
+
+export async function redo(user: ReturnType<(typeof userEvent)['setup']>) {
+  await user.keyboard('{Control>}{Shift>}z{/Control}{/Shift}');
+}
+
+export function renderEditor(editorState: EditorStateDescription): {
+  rendered: ReturnType<typeof render>;
+  user: ReturnType<(typeof userEvent)['setup']>;
+  state: () => EditorStateDescription;
+} {
+  const viewRef = createRef<{ view: EditorView | null }>();
+  const user = userEvent.setup();
+  const getElement = () => (
+    <VoussoirProvider>
+      <Editor
+        value={editorState.get()}
+        ref={viewRef}
+        onChange={state => {
+          editorState = new RealEditorStateDescription(state);
+          rendered.rerender(getElement());
+        }}
+      />
+    </VoussoirProvider>
+  );
+  const rendered = render(getElement());
+
+  viewRef.current!.view!.focus();
+
+  return {
+    state: () => editorState,
+    user,
+    rendered,
+  };
+}
+
+const editorStateSerializer: NewPlugin = {
+  test(val) {
+    return val instanceof EditorState;
+  },
+  serialize(val: EditorState, config, indentation, depth, refs, printer) {
+    return printer(
+      editorStateToReactNode(val),
+      config,
+      indentation,
+      depth,
+      refs
+    );
+  },
+};
+
+type EditorStateDescription = {
+  get(): EditorState;
+};
+
+class RealEditorStateDescription implements EditorStateDescription {
+  #state: EditorState;
+  constructor(state: EditorState) {
+    this.#state = state;
+  }
+  get = () => {
+    return this.#state;
+  };
+  $$typeof = Symbol.for('jest.asymmetricMatcher');
+  toString() {
+    return 'EditorStateMatcher';
+  }
+  getExpectedType(): string {
+    return 'editor state';
+  }
+  toAsymmetricMatcher = () => {
+    return format(this.#state, {
+      plugins: [editorStateSerializer, plugins.ReactElement],
+      printBasicPrototype: false,
+    });
+  };
+}
+
+(expect as any).addEqualityTesters([
+  function (this: any, a: any, b: any) {
+    return (
+      a instanceof RealEditorStateDescription &&
+      b instanceof RealEditorStateDescription &&
+      this.equals(a.get().toJSON(), b.get().toJSON())
+    );
+  },
+]);

--- a/packages/keystatic/src/form/fields/markdoc/editor/utils.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/utils.ts
@@ -1,0 +1,123 @@
+import { css } from '@voussoir/style';
+import { useRef, useCallback, useEffect } from 'react';
+
+export const classes = {
+  nodeInSelection: 'ProseMirror-nodeInSelection',
+  nodeSelection: 'ProseMirror-selectednode',
+  blockParent: 'ProseMirror-blockParent',
+  focused: 'ProseMirror-focused',
+};
+
+export function weakMemoize<Arg extends object, Return>(
+  func: (arg: Arg) => Return
+): (arg: Arg) => Return {
+  const cache = new WeakMap<Arg, Return>();
+  return (arg: Arg) => {
+    if (cache.has(arg)) {
+      return cache.get(arg)!;
+    }
+    const result = func(arg);
+    cache.set(arg, result);
+    return result;
+  };
+}
+
+export const prosemirrorStyles = css`
+  .ProseMirror {
+    position: relative;
+  }
+
+  .ProseMirror {
+    word-wrap: break-word;
+    white-space: pre-wrap;
+    white-space: break-spaces;
+    -webkit-font-variant-ligatures: none;
+    font-variant-ligatures: none;
+    font-feature-settings: 'liga' 0; /* the above doesn't seem to work in Edge */
+  }
+
+  .ProseMirror pre {
+    white-space: pre-wrap;
+  }
+
+  .ProseMirror li {
+    position: relative;
+  }
+
+  .ProseMirror-hideselection *::selection {
+    background: transparent;
+  }
+  .ProseMirror-hideselection *::-moz-selection {
+    background: transparent;
+  }
+  .ProseMirror-hideselection {
+    caret-color: transparent;
+  }
+
+  .ProseMirror-selectednode {
+    outline: 2px solid #8cf;
+  }
+
+  /* Make sure li selections wrap around markers */
+
+  li.ProseMirror-selectednode {
+    outline: none;
+  }
+
+  li.ProseMirror-selectednode:after {
+    content: '';
+    position: absolute;
+    left: -32px;
+    right: -2px;
+    top: -2px;
+    bottom: -2px;
+    border: 2px solid #8cf;
+    pointer-events: none;
+  }
+
+  /* Protect against generic img rules */
+
+  img.ProseMirror-separator {
+    display: inline !important;
+    border: none !important;
+    margin: 0 !important;
+  }
+  .ProseMirror-gapcursor {
+    display: none;
+    pointer-events: none;
+    position: absolute;
+  }
+
+  .ProseMirror-gapcursor:after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: -2px;
+    width: 20px;
+    border-top: 1px solid black;
+    animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
+  }
+
+  @keyframes ProseMirror-cursor-blink {
+    to {
+      visibility: hidden;
+    }
+  }
+
+  .ProseMirror-focused .ProseMirror-gapcursor {
+    display: block;
+  }
+`;
+
+export function useEventCallback<Func extends (...args: any) => any>(
+  callback: Func
+): Func {
+  const callbackRef = useRef(callback);
+  const cb = useCallback((...args: any[]) => {
+    return callbackRef.current(...args);
+  }, []);
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+  return cb as any;
+}

--- a/packages/keystatic/src/form/fields/markdoc/index.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/index.tsx
@@ -1,0 +1,82 @@
+import Markdoc, {
+  Config as MarkdocConfig,
+  Node as MarkdocNode,
+} from '@markdoc/markdoc';
+
+import { ContentFormField } from '../../api';
+import { DocumentFieldInput } from './ui';
+import { EditorState } from 'prosemirror-state';
+import { createEditorState } from './editor/editor-state';
+import { EditorSchema, createEditorSchema } from './editor/schema';
+import { proseMirrorToMarkdoc } from './editor/markdoc/serialize';
+import { markdocToProseMirror } from './editor/markdoc/parse';
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+/**
+ * @deprecated This is experimental and buggy, use at your own risk.
+ */
+export function __experimental_markdoc_field({
+  label,
+  description,
+  config,
+}: {
+  label: string;
+  description?: string;
+  config: MarkdocConfig;
+}): __experimental_markdoc_field.Field {
+  let schema: undefined | EditorSchema;
+  let getSchema = () => {
+    if (!schema) {
+      schema = createEditorSchema(config);
+    }
+    return schema;
+  };
+  return {
+    kind: 'form',
+    formKind: 'content',
+    defaultValue() {
+      return createEditorState(getSchema().nodes.doc.createAndFill()!);
+    },
+    Input(props) {
+      return (
+        <DocumentFieldInput
+          description={description}
+          label={label}
+          {...props}
+        />
+      );
+    },
+
+    parse: (_, { content }) => {
+      const markdoc = textDecoder.decode(content);
+      const doc = markdocToProseMirror(Markdoc.parse(markdoc), getSchema());
+      return createEditorState(doc);
+    },
+    contentExtension: '.mdoc',
+    validate(value) {
+      return value;
+    },
+    serialize(value) {
+      const markdocNode = proseMirrorToMarkdoc(value.doc);
+      const markdoc = Markdoc.format(markdocNode);
+      return {
+        content: textEncoder.encode(Markdoc.format(Markdoc.parse(markdoc))),
+        external: new Map(),
+        other: new Map(),
+        value: undefined,
+      };
+    },
+    reader: {
+      parse: (_, { content }) => {
+        const text = textDecoder.decode(content);
+        return { ast: Markdoc.parse(text) };
+      },
+    },
+  };
+}
+
+export declare namespace __experimental_markdoc_field {
+  type Field = ContentFormField<EditorState, EditorState, { ast: MarkdocNode }>;
+}

--- a/packages/keystatic/src/form/fields/markdoc/ui.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/ui.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { FieldPrimitive } from '@voussoir/field';
+import { FormFieldInputProps } from '../../api';
+import { EditorState } from 'prosemirror-state';
+import { Editor } from './editor';
+
+export function DocumentFieldInput(
+  props: FormFieldInputProps<EditorState> & {
+    label: string;
+    description: string | undefined;
+  }
+) {
+  return (
+    <FieldPrimitive label={props.label} description={props.description}>
+      <Editor value={props.value} onChange={props.onChange} />
+    </FieldPrimitive>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2304,18 +2304,23 @@ importers:
       '@braintree/sanitize-url': ^6.0.2
       '@emotion/css': ^11.9.0
       '@emotion/weak-memoize': ^0.3.0
+      '@floating-ui/react': ^0.24.0
       '@hapi/iron': ^7.0.0
       '@markdoc/markdoc': ^0.3.0
       '@react-aria/focus': ^3.12.1
       '@react-aria/i18n': ^3.7.1
       '@react-aria/interactions': ^3.15.1
       '@react-aria/overlays': ^3.12.0
+      '@react-aria/selection': ^3.12.0
       '@react-aria/utils': ^3.17.0
       '@react-aria/visually-hidden': ^3.6.1
       '@react-stately/collections': ^3.5.0
       '@react-stately/list': ^3.6.0
       '@react-stately/overlays': ^3.4.3
+      '@react-stately/utils': ^3.5.1
+      '@react-types/shared': ^3.18.0
       '@sindresorhus/slugify': ^1.1.2
+      '@testing-library/user-event': ^14.4.3
       '@ts-gql/compiler': ^0.16.1
       '@ts-gql/eslint-plugin': ^0.8.5
       '@ts-gql/next': ^17.0.0
@@ -2326,6 +2331,7 @@ importers:
       '@types/node': 16.11.13
       '@types/prismjs': ^1.26.0
       '@types/react': ^18.2.8
+      '@types/react-dom': ^18.0.11
       '@types/signal-exit': ^3.0.1
       '@urql/core': ^4.0.4
       '@urql/exchange-auth': ^2.1.0
@@ -2371,6 +2377,7 @@ importers:
       apply-ref: ^1.0.0
       cookie: ^0.5.0
       emery: ^1.4.1
+      escape-string-regexp: ^4.0.0
       eslint: ^8.18.0
       fast-deep-equal: ^3.1.3
       fast-glob: ^3.2.12
@@ -2392,8 +2399,16 @@ importers:
       outdent: ^0.8.0
       pretty-format: ^29.0.1
       prismjs: ^1.29.0
+      prosemirror-commands: ^1.5.1
+      prosemirror-history: ^1.3.0
+      prosemirror-keymap: ^1.2.1
+      prosemirror-model: ^1.19.0
+      prosemirror-state: ^1.4.2
+      prosemirror-transform: ^1.7.1
+      prosemirror-view: ^1.30.2
       react: ^18.2.0
       react-dom: ^18.2.0
+      react-element-to-jsx-string: ^15.0.0
       scroll-into-view-if-needed: ^3.0.3
       signal-exit: ^3.0.7
       slate: ^0.91.4
@@ -2409,21 +2424,26 @@ importers:
       '@braintree/sanitize-url': 6.0.2
       '@emotion/css': 11.10.6
       '@emotion/weak-memoize': 0.3.0
+      '@floating-ui/react': 0.24.2_biqbaboplfbrettd7655fr4n2y
       '@hapi/iron': 7.0.1
       '@markdoc/markdoc': 0.3.0_i2bxsyfskhzbpjanbovidbfj7u
       '@react-aria/focus': 3.12.1_react@18.2.0
       '@react-aria/i18n': 3.7.1_react@18.2.0
       '@react-aria/interactions': 3.15.1_react@18.2.0
       '@react-aria/overlays': 3.12.1_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/selection': 3.12.1_react@18.2.0
       '@react-aria/utils': 3.17.0_react@18.2.0
       '@react-aria/visually-hidden': 3.6.1_react@18.2.0
       '@react-stately/collections': 3.5.1_react@18.2.0
       '@react-stately/list': 3.6.1_react@18.2.0
       '@react-stately/overlays': 3.4.4_react@18.2.0
+      '@react-stately/utils': 3.6.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       '@sindresorhus/slugify': 1.1.2
       '@ts-gql/tag': 0.7.0_graphql@16.6.0
       '@types/node': 16.11.13
       '@types/react': 18.2.8
+      '@types/react-dom': 18.0.11
       '@urql/core': 4.0.4_graphql@16.6.0
       '@urql/exchange-auth': 2.1.0_graphql@16.6.0
       '@urql/exchange-graphcache': 6.0.1_graphql@16.6.0
@@ -2467,6 +2487,7 @@ importers:
       apply-ref: 1.0.0
       cookie: 0.5.0
       emery: 1.4.1
+      escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
       graphql: 16.6.0
       ignore: 5.2.4
@@ -2484,6 +2505,13 @@ importers:
       minimatch: 7.1.0
       pretty-format: 29.4.3
       prismjs: 1.29.0
+      prosemirror-commands: 1.5.2
+      prosemirror-history: 1.3.2
+      prosemirror-keymap: 1.2.2
+      prosemirror-model: 1.19.2
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.7.3
+      prosemirror-view: 1.31.4
       scroll-into-view-if-needed: 3.0.6
       slate: 0.91.4
       slate-history: 0.86.0_slate@0.91.4
@@ -2492,6 +2520,7 @@ importers:
       urql: 4.0.0_onqnqwb3ubg5opvemcqf7c2qhy
       zod: 3.20.6
     devDependencies:
+      '@testing-library/user-event': 14.4.3
       '@ts-gql/compiler': 0.16.3_graphql@16.6.0
       '@ts-gql/eslint-plugin': 0.8.5_zxeajgyublgrbqnioyf65anicm
       '@ts-gql/next': 17.0.0_geby35jtnxiaox3zmodjvon224
@@ -2507,6 +2536,7 @@ importers:
       outdent: 0.8.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+      react-element-to-jsx-string: 15.0.0_biqbaboplfbrettd7655fr4n2y
       signal-exit: 3.0.7
       tsx: 3.12.3
       typescript: 5.1.3
@@ -6355,7 +6385,7 @@ packages:
     dependencies:
       '@react-aria/interactions': 3.15.1_react@18.2.0
       '@react-aria/utils': 3.17.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       '@swc/helpers': 0.4.14
       clsx: 1.2.1
       react: 18.2.0
@@ -6427,7 +6457,7 @@ packages:
       '@internationalized/string': 3.1.0
       '@react-aria/ssr': 3.5.0_react@18.2.0
       '@react-aria/utils': 3.17.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -6454,7 +6484,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-aria/utils': 3.17.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -6956,7 +6986,7 @@ packages:
     dependencies:
       '@react-aria/ssr': 3.5.0_react@18.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       '@swc/helpers': 0.4.14
       clsx: 1.2.1
       react: 18.2.0
@@ -7024,7 +7054,7 @@ packages:
     dependencies:
       '@react-aria/interactions': 3.15.1_react@18.2.0
       '@react-aria/utils': 3.17.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       '@swc/helpers': 0.4.14
       clsx: 1.2.1
       react: 18.2.0
@@ -9250,6 +9280,13 @@ packages:
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+
+  /@testing-library/user-event/14.4.3:
+    resolution: {integrity: sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+    dev: true
 
   /@testing-library/user-event/14.4.3_yxlyej73nftwmh2fiao7paxmlm:
     resolution: {integrity: sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==}
@@ -20531,6 +20568,10 @@ packages:
       strip-ansi: 7.0.1
       wcwidth: 1.0.1
 
+  /orderedmap/2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+    dev: false
+
   /os-browserify/0.3.0:
     resolution: {integrity: sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==}
     dev: true
@@ -21675,6 +21716,58 @@ packages:
   /property-information/6.2.0:
     resolution: {integrity: sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==}
 
+  /prosemirror-commands/1.5.2:
+    resolution: {integrity: sha512-hgLcPaakxH8tu6YvVAaILV2tXYsW3rAdDR8WNkeKGcgeMVQg3/TMhPdVoh7iAmfgVjZGtcOSjKiQaoeKjzd2mQ==}
+    dependencies:
+      prosemirror-model: 1.19.2
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.7.3
+    dev: false
+
+  /prosemirror-history/1.3.2:
+    resolution: {integrity: sha512-/zm0XoU/N/+u7i5zepjmZAEnpvjDtzoPWW6VmKptcAnPadN/SStsBjMImdCEbb3seiNTpveziPTIrXQbHLtU1g==}
+    dependencies:
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.7.3
+      prosemirror-view: 1.31.4
+      rope-sequence: 1.3.4
+    dev: false
+
+  /prosemirror-keymap/1.2.2:
+    resolution: {integrity: sha512-EAlXoksqC6Vbocqc0GtzCruZEzYgrn+iiGnNjsJsH4mrnIGex4qbLdWWNza3AW5W36ZRrlBID0eM6bdKH4OStQ==}
+    dependencies:
+      prosemirror-state: 1.4.3
+      w3c-keyname: 2.2.8
+    dev: false
+
+  /prosemirror-model/1.19.2:
+    resolution: {integrity: sha512-RXl0Waiss4YtJAUY3NzKH0xkJmsZupCIccqcIFoLTIKFlKNbIvFDRl27/kQy1FP8iUAxrjRRfIVvOebnnXJgqQ==}
+    dependencies:
+      orderedmap: 2.1.1
+    dev: false
+
+  /prosemirror-state/1.4.3:
+    resolution: {integrity: sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==}
+    dependencies:
+      prosemirror-model: 1.19.2
+      prosemirror-transform: 1.7.3
+      prosemirror-view: 1.31.4
+    dev: false
+
+  /prosemirror-transform/1.7.3:
+    resolution: {integrity: sha512-qDapyx5lqYfxVeUWEw0xTGgeP2S8346QtE7DxkalsXlX89lpzkY6GZfulgfHyk1n4tf74sZ7CcXgcaCcGjsUtA==}
+    dependencies:
+      prosemirror-model: 1.19.2
+    dev: false
+
+  /prosemirror-view/1.31.4:
+    resolution: {integrity: sha512-nJzH2LpYbonSTYFqQ1BUdEhbd1WPN/rp/K9T9qxBEYpgg3jK3BvEUCR45Ymc9IHpO0m3nBJwPm19RBxZdoBVuw==}
+    dependencies:
+      prosemirror-model: 1.19.2
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.7.3
+    dev: false
+
   /proxy-addr/2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -21927,6 +22020,19 @@ packages:
       react-is: 17.0.2
     dev: true
 
+  /react-element-to-jsx-string/15.0.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-UDg4lXB6BzlobN60P8fHWVPX3Kyw8ORrTeBtClmIlGdkOOE+GYQSFvmEU5iLLpwp/6v42DINwNcwOhOLfQ//FQ==}
+    peerDependencies:
+      react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
+      react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
+    dependencies:
+      '@base2/pretty-print-object': 1.0.1
+      is-plain-object: 5.0.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-is: 18.1.0
+    dev: true
+
   /react-focus-lock/2.9.4_i2bxsyfskhzbpjanbovidbfj7u:
     resolution: {integrity: sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==}
     peerDependencies:
@@ -21962,6 +22068,10 @@ packages:
 
   /react-is/17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  /react-is/18.1.0:
+    resolution: {integrity: sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==}
+    dev: true
 
   /react-is/18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
@@ -22683,6 +22793,10 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+
+  /rope-sequence/1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
+    dev: false
 
   /rtl-css-js/1.16.1:
     resolution: {integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==}
@@ -25065,6 +25179,10 @@ packages:
 
   /vscode-uri/3.0.7:
     resolution: {integrity: sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==}
+
+  /w3c-keyname/2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+    dev: false
 
   /w3c-xmlserializer/4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}


### PR DESCRIPTION
This introduces an experimental new field which will eventually be accessible at `fields.markdoc` from `@keystatic/core` and will replace `fields.document` but is currently exposed as `__experimental_markdoc_field` from `@keystatic/core/form/fields/markdoc`. This PR does not delete or change `fields.document` in any way, that field still works totally fine, and if you're using Keystatic right now, **you shouldn't use this new field yet**. The new editor is still a work-in-progress and is mainly going to be merged in quickly to allow us to test out the editor in projects so that we can prioritise what to solve first.

Some background on why a new field/editor:

The current `fields.document` is essentially a fork of [Keystone's document editor](https://keystonejs.com/docs/guides/document-fields) which had a few problems for what we're doing here:

- It was built on [Slate](https://www.slatejs.org) which was easy to get started with but was difficult to create the high quality editing experience that we're looking for and e.g. it made implementing certain behaviour that we need impractical such as having a cursor between two dividers. This new editor is implemented using [ProseMirror](https://prosemirror.net/) which solves a lot of the problems we were hitting (e.g. gap cursors, a built-in system for handing parsing from HTML for pasting) while still giving us flexibility to have quite custom behaviour
- The extensibility model was "component blocks" which is very different from Markdoc's extensibility model of tags and attributes. This new editor is fundamentally based around providing a good editing experience based on a Markdoc config instead
  - Another part of this that we found was that component blocks were often quite frustrating to use because defining a "preview" was _required_ when often what people wanted was just some data in the editor. The concept of previews currently doesn't exist in the new editor (it may or may not exist in the future)