### PR TITLE
Remove superscript and references to the framework that the editor is using from docs

### DIFF
--- a/docs/src/content/pages/fields/document.mdoc
+++ b/docs/src/content/pages/fields/document.mdoc
@@ -1,16 +1,9 @@
 ---
 title: Document field
 ---
-The `document` field is a highly customizable, currently&nbsp;[Slate](https://docs.slatejs.org/)-based
-{% sup %}1{% /sup %}
-, rich text editor.
+The `document` field is a highly customizable rich text editor.
 
-It lets content creators quickly and easily edit content in your system.&nbsp;
-
----
-
-{% sup %}1{% /sup %}
-soon-to-be powered by ProseMirror
+It lets content creators quickly and easily edit content in your system.
 
 ## Usage example
 


### PR DESCRIPTION
This information isn't really useful or relevant to users and I want the superscript gone so I can test the new editor on the docs content and currently it's not possible to implement stuff like that in the new editor
