### PR TITLE
Always ignore `.next` in returning local trees just like node_modules

### DIFF
--- a/packages/keystatic/src/api/read-local.ts
+++ b/packages/keystatic/src/api/read-local.ts
@@ -55,7 +55,8 @@ async function collectEntriesInDir(
           if (
             (!entry.isDirectory() && !entry.isFile()) ||
             entry.name === '.git' ||
-            entry.name === 'node_modules'
+            entry.name === 'node_modules' ||
+            entry.name === '.next'
           ) {
             return false;
           }


### PR DESCRIPTION
Always ignore `.next` in returning local trees just like node_modules
