### PR TITLE
Minor updates to /docs/introduction

### DIFF
--- a/docs/src/components/document-renderer.tsx
+++ b/docs/src/components/document-renderer.tsx
@@ -53,7 +53,10 @@ const getRenderers = (
     ),
     link: ({ href, children }) => {
       return (
-        <a className="cursor-pointer underline hover:no-underline" href={href}>
+        <a
+          className="cursor-pointer underline font-medium hover:no-underline"
+          href={href}
+        >
           {children}
         </a>
       );

--- a/docs/src/content/pages/introduction.mdoc
+++ b/docs/src/content/pages/introduction.mdoc
@@ -3,9 +3,11 @@ title: Introduction
 ---
 Keystatic is designed to work when you're creating a new site, or to introduce content management into your existing codebase.
 
-It can save data locally, direct to Github, or both.
+It can save data locally, directly to Github, or both.
 
-Below are some of the common use-cases to help you get started.
+Below are some of the common use-cases to get you started.
+
+---
 
 ## Quick start
 
@@ -15,22 +17,22 @@ Perfect for trying out Keystatic and seeing what it can do.
 
 {% layout layout=[1, 1] %}
 {% layout-area %}
-**What you get:**
-
-- A local version of Keystatic running in Next.js
-- Changes saved to your local file system
-{% /layout-area %}
-
-{% layout-area %}
 **Good for:**
 
 - Checking out Keystatic for the first time.
 - Doing a demo.
 - Starting a new project.
 {% /layout-area %}
+
+{% layout-area %}
+**What you get:**
+
+- A local version of Keystatic running in Next.js
+- Changes saved to your local file system
+{% /layout-area %}
 {% /layout %}
 
-[Follow the Quick start guide](/docs/quick-start) to get started!
+[Follow the Quick start guide](/docs/quick-start)
 
 ---
 
@@ -42,22 +44,22 @@ See the power of Keystatic when integrated with Github, and deployed in Vercel.
 
 {% layout layout=[1, 1] %}
 {% layout-area %}
-**What you get:**
-
-- A new project setup on Github.
-- A free, deployed Keystatic Admin UI in Vercel to start editing content.
-{% /layout-area %}
-
-{% layout-area %}
 **Good for:**
 
 - Seeing the power of Keystatic and how it integrates with Github for saving your content.
 - Demonstrating how Keystatic's branch workflow works in the Admin UI.
 - Starting a new project.
 {% /layout-area %}
+
+{% layout-area %}
+**What you get:**
+
+- A new project setup on Github.
+- A free, deployed Keystatic Admin UI in Vercel to start editing content.
+{% /layout-area %}
 {% /layout %}
 
-[Follow the Automated setup guide](/docs/automated-setup-with-template) to start editing content from Keystatic in a few steps!
+[Follow the GitHub with Vercel guide](/docs/connect-to-github-with-vercel)
 
 ---
 
@@ -67,20 +69,20 @@ See the power of Keystatic when integrated with Github, and deployed in Vercel.
 
 {% layout layout=[1, 1] %}
 {% layout-area %}
-**What you get:**
-
-- Setup Keystatic to work in your existing project.
-{% /layout-area %}
-
-{% layout-area %}
 **Good for:**
 
 - Make your existing project editable!
 - Add Keystatic to your project with minimal effort.
 {% /layout-area %}
+
+{% layout-area %}
+**What you get:**
+
+- Setup Keystatic to work in your existing project.
+{% /layout-area %}
 {% /layout %}
 
-- Check out the [Astro integration guide](/docs/installation-astro)
-- Check out the [Next.js integration guide](/docs/installation-next-js)
+- [Astro integration guide](/docs/installation-astro)
+- [Next.js integration guide](/docs/installation-next-js)
 
 More framework guides coming soon!


### PR DESCRIPTION
- Shifted some things around ("Good for" before "What you get")
- Removed some (imo) unnecessary copy to make it cleaner and easier to scan
- Fixed a broken link
- Increased font-weight of links in the readme's for increased visibility