### PR TITLE
Add markdoc field to the docs site for testing

### DIFF
--- a/docs/keystatic.config.tsx
+++ b/docs/keystatic.config.tsx
@@ -7,7 +7,9 @@ import {
   component,
   NotEditable,
 } from '@keystatic/core';
+import { __experimental_markdoc_field } from '@keystatic/core/form/fields/markdoc';
 import { CloudImagePreview } from './src/components/previews/CloudImagePreview';
+import { Config } from '@markdoc/markdoc';
 
 export const componentBlocks = {
   aside: component({
@@ -144,6 +146,55 @@ export const componentBlocks = {
   }),
 };
 
+const markdocConfig: Config = {
+  tags: {
+    aside: {
+      render: 'Aside',
+      attributes: {
+        icon: {
+          type: String,
+          required: true,
+        },
+      },
+    },
+    'cloud-image': {
+      render: 'CloudImage',
+      attributes: {
+        href: {
+          type: String,
+          required: true,
+        },
+        alt: {
+          type: String,
+        },
+      },
+    },
+    tags: {
+      render: 'Tags',
+      attributes: {
+        tags: {
+          type: Array,
+          validate(value) {
+            if (
+              !Array.isArray(value) ||
+              value.some(v => typeof v !== 'string')
+            ) {
+              return [
+                {
+                  message: 'tags must be text',
+                  id: 'tags-text',
+                  level: 'critical',
+                },
+              ];
+            }
+            return [];
+          },
+        },
+      },
+    },
+  },
+};
+
 export default config({
   storage: {
     kind: 'local',
@@ -171,6 +222,19 @@ export default config({
           links: true,
           images: { directory: 'public/images/content' },
           componentBlocks,
+        }),
+      },
+    }),
+    pagesWithMarkdocField: collection({
+      label: 'Pages with new editor',
+      slugField: 'title',
+      format: { contentField: 'content' },
+      path: 'src/content/pages/**',
+      schema: {
+        title: fields.slug({ name: { label: 'Title' } }),
+        content: __experimental_markdoc_field({
+          label: 'Content',
+          config: markdocConfig,
         }),
       },
     }),

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
     "@heroicons/react": "^2.0.16",
     "@keystatic/core": "^0.0.107",
     "@keystatic/next": "^0.0.11",
+    "@markdoc/markdoc": "^0.3.0",
     "@sindresorhus/slugify": "^1.1.2",
     "@tailwindcss/forms": "^0.5.3",
     "@types/cookie": "^0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2171,6 +2171,7 @@ importers:
       '@heroicons/react': ^2.0.16
       '@keystatic/core': ^0.0.107
       '@keystatic/next': ^0.0.11
+      '@markdoc/markdoc': ^0.3.0
       '@sindresorhus/slugify': ^1.1.2
       '@tailwindcss/forms': ^0.5.3
       '@tailwindcss/typography': ^0.5.9
@@ -2197,6 +2198,7 @@ importers:
       '@heroicons/react': 2.0.18_react@18.2.0
       '@keystatic/core': link:../packages/keystatic
       '@keystatic/next': link:../packages/next
+      '@markdoc/markdoc': 0.3.0_i2bxsyfskhzbpjanbovidbfj7u
       '@sindresorhus/slugify': 1.1.2
       '@tailwindcss/forms': 0.5.3_tailwindcss@3.3.2
       '@types/cookie': 0.5.1


### PR DESCRIPTION
This adds a new collection to the keystatic config for the docs site using the new (very experimental) markdoc field but keeps the existing collection so everything will still work as it currently does.

For people working on the docs site rn: this will still be broken in various ways and isn't ready for you all to test just yet, I'm just getting this in because it makes it easier for me to test stuff.