### PR TITLE
Text input paper cuts

### DIFF
--- a/.changeset/poor-poets-rhyme.md
+++ b/.changeset/poor-poets-rhyme.md
@@ -1,0 +1,8 @@
+---
+'@voussoir/text-field': patch
+'@keystatic/core': patch
+---
+
+text input paper cuts:
+- more vertical padding on `TextArea` component.
+- antialiased editor text, to match the rest of the app.

--- a/design-system/packages/text-field/src/TextFieldPrimitive.tsx
+++ b/design-system/packages/text-field/src/TextFieldPrimitive.tsx
@@ -199,6 +199,7 @@ function useTextFieldStyles() {
       height: 'auto',
       minHeight: tokenSchema.size.scale['700'],
       overflow: 'auto',
+      paddingBlock: tokenSchema.size.space.regular,
       resize: 'none',
     },
   });

--- a/packages/keystatic/src/form/fields/document/DocumentEditor/index.tsx
+++ b/packages/keystatic/src/form/fields/document/DocumentEditor/index.tsx
@@ -559,7 +559,7 @@ let styles: any = {
   minHeight: tokenSchema.size.scale[2000],
   minWidth: 0,
   padding: tokenSchema.size.space.medium,
-  // antialiase editor text, to match the rest of the app
+  // antialiased editor text, to match the rest of the app
   MozOsxFontSmoothing: 'grayscale',
   WebkitFontSmoothing: 'antialiased',
 };

--- a/packages/keystatic/src/form/fields/document/DocumentEditor/index.tsx
+++ b/packages/keystatic/src/form/fields/document/DocumentEditor/index.tsx
@@ -345,11 +345,6 @@ export function DocumentEditor({
 
         <DocumentEditorEditable
           id="document-editor-boundary"
-          className={css({
-            padding: tokenSchema.size.space.medium,
-            height: 'auto',
-            minWidth: 0,
-          })}
           {...props}
           readOnly={onChange === undefined}
         />
@@ -559,8 +554,14 @@ let styles: any = {
   flex: 1,
   fontFamily: tokenSchema.typography.fontFamily.base,
   fontSize: tokenSchema.fontsize.text.regular.size,
+  height: 'auto',
   lineHeight: 1.4,
   minHeight: tokenSchema.size.scale[2000],
+  minWidth: 0,
+  padding: tokenSchema.size.space.medium,
+  // antialiase editor text, to match the rest of the app
+  MozOsxFontSmoothing: 'grayscale',
+  WebkitFontSmoothing: 'antialiased',
 };
 
 let listDepth = 10;


### PR DESCRIPTION
Minor fixes:
- more vertical padding on `TextArea` component
- antialiased editor text, to match the rest of the app