### PR TITLE
Configure locale

### DIFF
--- a/.changeset/heavy-moose-bow.md
+++ b/.changeset/heavy-moose-bow.md
@@ -1,0 +1,7 @@
+---
+"@keystatic/test-next-app": patch
+"@keystatic/core": patch
+"localization": patch
+---
+
+Add `locale` config option, now defaults to `en-US` instead of auto-detecting the Browser's locale.

--- a/apps/localization/src/config.ts
+++ b/apps/localization/src/config.ts
@@ -1,41 +1,5 @@
 import { collection, config, fields } from '@keystatic/core';
-
-const locales = {
-  'ar-AE': 'Arabic (UAE) 🇦🇪',
-  'bg-BG': 'Bulgarian (Bulgaria) 🇧🇬',
-  'cs-CZ': 'Czech (Czech Republic) 🇨🇿',
-  'da-DK': 'Danish (Denmark) 🇩🇰',
-  'de-DE': 'German (Germany) 🇩🇪',
-  'el-GR': 'Greek (Greece) 🇬🇷',
-  'en-US': 'English (United States) 🇺🇸',
-  'es-ES': 'Spanish (Spain) 🇪🇸',
-  'et-EE': 'Estonian (Estonia) 🇪🇪',
-  'fi-FI': 'Finnish (Finland) 🇫🇮',
-  'fr-FR': 'French (France) 🇫🇷',
-  'he-IL': 'Hebrew (Israel) 🇮🇱',
-  'hr-HR': 'Croatian (Croatia) 🇭🇷',
-  'hu-HU': 'Hungarian (Hungary) 🇭🇺',
-  'it-IT': 'Italian (Italy) 🇮🇹',
-  'ja-JP': 'Japanese (Japan) 🇯🇵',
-  'ko-KR': 'Korean (Korea) 🇰🇷',
-  'lt-LT': 'Lithuanian (Lithuania) 🇱🇹',
-  'lv-LV': 'Latvian (Latvia) 🇱🇻',
-  'nb-NO': 'Norwegian (Norway) 🇳🇴',
-  'nl-NL': 'Dutch (Netherlands) 🇳🇱',
-  'pl-PL': 'Polish (Poland) 🇵🇱',
-  'pt-BR': 'Portuguese (Brazil) 🇧🇷',
-  'pt-PT': 'Portuguese (Portugal) 🇵🇹',
-  'ro-RO': 'Romanian (Romania) 🇷🇴',
-  'ru-RU': 'Russian (Russia) 🇷🇺',
-  'sk-SK': 'Slovak (Slovakia) 🇸🇰',
-  'sl-SI': 'Slovenian (Slovenia) 🇸🇮',
-  'sr-SP': 'Serbian (Serbia) 🇷🇸',
-  'sv-SE': 'Swedish (Sweden) 🇸🇪',
-  'tr-TR': 'Turkish (Turkey) 🇹🇷',
-  'uk-UA': 'Ukrainian (Ukraine) 🇺🇦',
-  'zh-CN': 'Chinese (Simplified) 🇨🇳',
-  'zh-TW': 'Chinese (Traditional) 🇨🇳',
-};
+import { locales } from '../../../packages/keystatic/src/app/l10n/locales';
 
 const localeCollections = Object.fromEntries(
   Object.entries(locales).map(([key, label]) => [
@@ -76,10 +40,11 @@ const localeCollections = Object.fromEntries(
 );
 
 export default config({
-  storage: {
-    kind: 'github',
-    repo: { name: 'keystatic', owner: 'thinkmill' },
-  },
+  // storage: {
+  //   kind: 'github',
+  //   repo: { name: 'keystatic', owner: 'thinkmill' },
+  // },
+  storage: { kind: 'local' },
   collections: {
     ...localeCollections,
   },

--- a/packages/keystatic/src/app/l10n/locales.ts
+++ b/packages/keystatic/src/app/l10n/locales.ts
@@ -1,0 +1,45 @@
+// Note: the keys from this object are used by the config type, but the locale
+// names aren't used directly in Keystatic, they're just here to document the
+// ones we support.
+
+// The locales object is also used by `/apps/localization` to generate config
+// for managing locale translations in Keystatic itself (!!)
+
+export const locales = {
+  'ar-AE': 'Arabic (UAE) 🇦🇪',
+  'bg-BG': 'Bulgarian (Bulgaria) 🇧🇬',
+  'cs-CZ': 'Czech (Czech Republic) 🇨🇿',
+  'da-DK': 'Danish (Denmark) 🇩🇰',
+  'de-DE': 'German (Germany) 🇩🇪',
+  'el-GR': 'Greek (Greece) 🇬🇷',
+  'en-US': 'English (United States) 🇺🇸',
+  'es-ES': 'Spanish (Spain) 🇪🇸',
+  'et-EE': 'Estonian (Estonia) 🇪🇪',
+  'fi-FI': 'Finnish (Finland) 🇫🇮',
+  'fr-FR': 'French (France) 🇫🇷',
+  'he-IL': 'Hebrew (Israel) 🇮🇱',
+  'hr-HR': 'Croatian (Croatia) 🇭🇷',
+  'hu-HU': 'Hungarian (Hungary) 🇭🇺',
+  'it-IT': 'Italian (Italy) 🇮🇹',
+  'ja-JP': 'Japanese (Japan) 🇯🇵',
+  'ko-KR': 'Korean (Korea) 🇰🇷',
+  'lt-LT': 'Lithuanian (Lithuania) 🇱🇹',
+  'lv-LV': 'Latvian (Latvia) 🇱🇻',
+  'nb-NO': 'Norwegian (Norway) 🇳🇴',
+  'nl-NL': 'Dutch (Netherlands) 🇳🇱',
+  'pl-PL': 'Polish (Poland) 🇵🇱',
+  'pt-BR': 'Portuguese (Brazil) 🇧🇷',
+  'pt-PT': 'Portuguese (Portugal) 🇵🇹',
+  'ro-RO': 'Romanian (Romania) 🇷🇴',
+  'ru-RU': 'Russian (Russia) 🇷🇺',
+  'sk-SK': 'Slovak (Slovakia) 🇸🇰',
+  'sl-SI': 'Slovenian (Slovenia) 🇸🇮',
+  'sr-SP': 'Serbian (Serbia) 🇷🇸',
+  'sv-SE': 'Swedish (Sweden) 🇸🇪',
+  'tr-TR': 'Turkish (Turkey) 🇹🇷',
+  'uk-UA': 'Ukrainian (Ukraine) 🇺🇦',
+  'zh-CN': 'Chinese (Simplified) 🇨🇳',
+  'zh-TW': 'Chinese (Traditional) 🇨🇳',
+};
+
+export type Locale = keyof typeof locales;

--- a/packages/keystatic/src/app/provider.tsx
+++ b/packages/keystatic/src/app/provider.tsx
@@ -29,6 +29,7 @@ import {
   redirectToCloudAuth,
 } from './utils';
 import { Config } from '../config';
+import { I18nProvider, useLocale } from '@react-aria/i18n';
 
 export function createUrqlClient(config: Config): Client {
   const repo = {
@@ -182,6 +183,15 @@ export function createUrqlClient(config: Config): Client {
   });
 }
 
+function Locale({ children }: { children: JSX.Element }) {
+  let { locale, direction } = useLocale();
+  return (
+    <div lang={locale} dir={direction}>
+      {children}
+    </div>
+  );
+}
+
 export default function Provider({
   children,
   Link,
@@ -234,7 +244,9 @@ export default function Provider({
         rel="stylesheet"
       />
       <UrqlProvider value={useMemo(() => createUrqlClient(config), [config])}>
-        {children}
+        <I18nProvider locale={config.locale || 'en-US'}>
+          <Locale>{children}</Locale>
+        </I18nProvider>
       </UrqlProvider>
       <Toaster />
     </VoussoirProvider>

--- a/packages/keystatic/src/config.tsx
+++ b/packages/keystatic/src/config.tsx
@@ -1,4 +1,5 @@
 import { ComponentSchema, SlugFormField } from './form/api';
+import type { Locale } from './app/l10n/locales';
 
 export type DataFormat = 'json' | 'yaml';
 export type Format = DataFormat | { data?: DataFormat; contentField?: string };
@@ -24,6 +25,10 @@ export type Singleton<Schema extends Record<string, ComponentSchema>> = {
   schema: Schema;
 };
 
+type CommonConfig = {
+  locale?: Locale;
+};
+
 export type GitHubConfig<
   Collections extends {
     [key: string]: Collection<Record<string, ComponentSchema>, string>;
@@ -42,7 +47,7 @@ export type GitHubConfig<
   };
   collections?: Collections;
   singletons?: Singletons;
-};
+} & CommonConfig;
 
 export type LocalConfig<
   Collections extends {
@@ -61,7 +66,7 @@ export type LocalConfig<
   };
   collections?: Collections;
   singletons?: Singletons;
-};
+} & CommonConfig;
 
 export type CloudConfig<
   Collections extends {
@@ -78,7 +83,7 @@ export type CloudConfig<
   storage: { kind: 'cloud'; project: string };
   collections?: Collections;
   singletons?: Singletons;
-};
+} & CommonConfig;
 
 export type Config<
   Collections extends {
@@ -102,7 +107,8 @@ export type Config<
   collections?: Collections;
   singletons?: Singletons;
 } & ({} extends Collections ? {} : { collections: Collections }) &
-  ({} extends Singletons ? {} : { singletons: Singletons });
+  ({} extends Singletons ? {} : { singletons: Singletons }) &
+  CommonConfig;
 
 export function config<
   Collections extends {


### PR DESCRIPTION
Closes #402 

Adds support for a new config key `locale` which must be one of the supported locales.

Defaults to `en-US` for now (see #401 for reason)

Also adds a containing `div` with locale `lang` and `direction` per https://react-spectrum.adobe.com/react-aria/internationalization.html#example