### PR TITLE
Enforce pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "license": "MIT",
-  "packageManager": "pnpm@7.27.0",
+  "packageManager": "pnpm@7.33.3",
+  "engines": {
+    "pnpm": "7.33.3"
+  },
   "scripts": {
     "build:docs": "pnpm --filter=keystatic-docs build",
     "build:designsystem": "pnpm --filter=@voussoir/docs build",


### PR DESCRIPTION
If you get an error because of this, make sure you're using https://nodejs.org/api/corepack.html

It should be as simple as unstinstalling however you installed pnpm previously and then `corepack enable pnpm`