### PR TITLE
Add label and description to number field

### DIFF
--- a/.changeset/tiny-carrots-hug.md
+++ b/.changeset/tiny-carrots-hug.md
@@ -1,0 +1,5 @@
+---
+"@keystar/ui": patch
+---
+
+Fix label and description support in `NumberField`

--- a/design-system/pkg/src/number-field/NumberField.tsx
+++ b/design-system/pkg/src/number-field/NumberField.tsx
@@ -28,7 +28,7 @@ export const NumberField: ForwardRefExoticComponent<
   forwardedRef: ForwardedRef<HTMLInputElement>
 ) {
   props = useProviderProps(props);
-  let { isReadOnly, isDisabled, hideStepper } = props;
+  let { isReadOnly, isDisabled, hideStepper, label, description } = props;
 
   let { locale } = useLocale();
   let state = useNumberFieldState({ ...props, locale });
@@ -48,6 +48,8 @@ export const NumberField: ForwardRefExoticComponent<
     <TextFieldPrimitive
       width="alias.singleLineWidth"
       {...filterDOMProps(props)}
+      label={label}
+      description={description}
       descriptionProps={descriptionProps}
       errorMessageProps={errorMessageProps}
       labelProps={labelProps}


### PR DESCRIPTION
I'm not sure why these weren't passed before

In the `TextField` component, `...props` is spread, but in `NumberField` props is spread as `{...filterDOMProps(props)}`

This means the `description` and `label` props weren't being passed, despite being in the types and supported by the `TextFieldPrimitive` component.

@jossmac might be worth you taking a look at for consistency, but in the meantime this fixes #426