### PR TITLE
Desktop spacing

### DIFF
--- a/.changeset/honest-ghosts-chew.md
+++ b/.changeset/honest-ghosts-chew.md
@@ -1,0 +1,6 @@
+---
+'@keystatic/core': patch
+'@keystar/ui': patch
+---
+
+Support "renderEmptyState" prop on `TableView` component.

--- a/design-system/pkg/src/table/TableView.tsx
+++ b/design-system/pkg/src/table/TableView.tsx
@@ -42,6 +42,7 @@ export function TableView<T extends object>(props: TableProps<T>) {
   let { collection } = state;
   let { gridProps } = useTable(props, state, ref);
   let styleProps = useTableStyleProps(props);
+  let rows = [...collection.body.childNodes];
 
   return (
     <div {...gridProps} {...styleProps} ref={ref}>
@@ -68,27 +69,35 @@ export function TableView<T extends object>(props: TableProps<T>) {
       </TableHead>
 
       <TableBody>
-        {[...collection.body.childNodes].map(row => (
-          <TableRow
-            key={row.key}
-            item={row}
-            state={state}
-            hasAction={!!props.onRowAction}
-          >
-            {[...row.childNodes].map(cell =>
-              cell.props.isSelectionCell ? (
-                <TableCheckboxCell key={cell.key} cell={cell} state={state} />
-              ) : (
-                <TableCell
-                  key={cell.key}
-                  cell={cell}
-                  state={state}
-                  overflowMode={props.overflowMode}
-                />
-              )
-            )}
-          </TableRow>
-        ))}
+        {!rows.length && props.renderEmptyState ? (
+          <div role="row" aria-rowindex={2}>
+            <div role="rowheader" aria-colspan={collection.columnCount}>
+              {props.renderEmptyState()}
+            </div>
+          </div>
+        ) : (
+          rows.map(row => (
+            <TableRow
+              key={row.key}
+              item={row}
+              state={state}
+              hasAction={!!props.onRowAction}
+            >
+              {[...row.childNodes].map(cell =>
+                cell.props.isSelectionCell ? (
+                  <TableCheckboxCell key={cell.key} cell={cell} state={state} />
+                ) : (
+                  <TableCell
+                    key={cell.key}
+                    cell={cell}
+                    state={state}
+                    overflowMode={props.overflowMode}
+                  />
+                )
+              )}
+            </TableRow>
+          ))
+        )}
       </TableBody>
     </div>
   );

--- a/design-system/pkg/src/table/types.ts
+++ b/design-system/pkg/src/table/types.ts
@@ -36,6 +36,8 @@ export type TableProps<T> = {
    * @default 'default'
    */
   prominence?: 'default' | 'low';
+  /** What should render when there is no content to display. */
+  renderEmptyState?: () => JSX.Element;
 } & BaseStyleProps &
   DOMProps &
   MultipleSelection &

--- a/packages/keystatic/src/app/CollectionPage.tsx
+++ b/packages/keystatic/src/app/CollectionPage.tsx
@@ -6,10 +6,12 @@ import { Breadcrumbs, Item } from '@keystar/ui/breadcrumbs';
 import { Button } from '@keystar/ui/button';
 import { alertCircleIcon } from '@keystar/ui/icon/icons/alertCircleIcon';
 import { folderTreeIcon } from '@keystar/ui/icon/icons/folderTreeIcon';
-import { listStartIcon } from '@keystar/ui/icon/icons/listStartIcon';
+import { listXIcon } from '@keystar/ui/icon/icons/listXIcon';
+import { searchXIcon } from '@keystar/ui/icon/icons/searchXIcon';
 import { TextLink } from '@keystar/ui/link';
 import { ProgressCircle } from '@keystar/ui/progress';
 import { SearchField } from '@keystar/ui/search-field';
+import { breakpointQueries, css, tokenSchema } from '@keystar/ui/style';
 import {
   TableView,
   TableBody,
@@ -186,7 +188,7 @@ function CollectionPageContent(props: CollectionPageContentProps) {
   if (!tree) {
     return (
       <EmptyState
-        icon={listStartIcon}
+        icon={listXIcon}
         title="Empty collection"
         message={
           <>
@@ -275,16 +277,33 @@ function CollectionTable(
   return (
     <TableView
       aria-labelledby="page-title"
-      flex
       selectionMode="none"
       onSortChange={setSortDescriptor}
       sortDescriptor={sortDescriptor}
       overflowMode="truncate"
-      // prominence="low"
-      margin={{ mobile: 'regular', tablet: 'medium' }}
       onRowAction={key => {
         router.push(getItemPath(props.basePath, props.collection, key));
       }}
+      renderEmptyState={() => (
+        <EmptyState
+          icon={searchXIcon}
+          title="No results"
+          message={`No items matching "${searchTerm}" were found.`}
+        />
+      )}
+      // prominence="low"
+      flex
+      marginTop={{ tablet: 'large' }}
+      marginBottom={{ mobile: 'regular', tablet: 'xlarge' }}
+      UNSAFE_className={css({
+        marginInline: tokenSchema.size.space.regular,
+        [breakpointQueries.above.mobile]: {
+          marginInline: `calc(${tokenSchema.size.space.xlarge} - ${tokenSchema.size.space.medium})`,
+        },
+        [breakpointQueries.above.tablet]: {
+          marginInline: `calc(${tokenSchema.size.space.xxlarge} - ${tokenSchema.size.space.medium})`,
+        },
+      })}
     >
       <TableHeader
         columns={[

--- a/packages/keystatic/src/app/ItemPage.tsx
+++ b/packages/keystatic/src/app/ItemPage.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from 'react';
 
+import { ActionGroup } from '@keystar/ui/action-group';
 import { Badge } from '@keystar/ui/badge';
 import { Breadcrumbs, Item } from '@keystar/ui/breadcrumbs';
 import { Button, ButtonGroup } from '@keystar/ui/button';
@@ -22,25 +23,21 @@ import { Box, Flex } from '@keystar/ui/layout';
 import { Notice } from '@keystar/ui/notice';
 import { ProgressCircle } from '@keystar/ui/progress';
 import { Content } from '@keystar/ui/slots';
+import { breakpointQueries, useMediaQuery } from '@keystar/ui/style';
 import { TextField } from '@keystar/ui/text-field';
 import { Heading, Text } from '@keystar/ui/typography';
 
 import { Config } from '../config';
 import { createGetPreviewProps } from '../form/preview-props';
 import { fields } from '../form/api';
+import { SlugFieldInfo } from '../form/fields/text/ui';
 import { clientSideValidateProp } from '../form/errors';
 import { useEventCallback } from '../form/fields/document/DocumentEditor/ui-utils';
-import {
-  getCollectionFormat,
-  getCollectionItemPath,
-  getRepoUrl,
-  getSlugFromState,
-  isGitHubConfig,
-} from './utils';
 
 import { useCreateBranchMutation } from './branch-selection';
-import l10nMessages from './l10n/index.json';
+import { FormForEntry, containerWidthForEntryLayout } from './entry-form';
 import { ForkRepoDialog } from './fork-repo';
+import l10nMessages from './l10n/index.json';
 import { getDataFileExtension, getSlugGlobForCollection } from './path-utils';
 import { useRouter } from './router';
 import { AppShellBody, AppShellRoot } from './shell';
@@ -52,15 +49,18 @@ import {
 } from './shell/data';
 import { AppShellHeader } from './shell/header';
 import { TreeNode } from './trees';
+import { useDeleteItem, useUpsertItem } from './updating';
 import { useItemData } from './useItemData';
 import { useHasChanged } from './useHasChanged';
 import { mergeDataStates } from './useData';
 import { useSlugsInCollection } from './useSlugsInCollection';
-import { SlugFieldInfo } from '../form/fields/text/ui';
-import { useDeleteItem, useUpsertItem } from './updating';
-import { FormForEntry, containerWidthForEntryLayout } from './entry-form';
-import { ActionGroup } from '@keystar/ui/action-group';
-import { breakpointQueries, useMediaQuery } from '@keystar/ui/style';
+import {
+  getCollectionFormat,
+  getCollectionItemPath,
+  getRepoUrl,
+  getSlugFromState,
+  isGitHubConfig,
+} from './utils';
 
 type ItemPageProps = {
   collection: string;
@@ -377,8 +377,8 @@ function HeaderActions(props: {
       return isBelowTablet ? (
         <Box
           backgroundColor="pendingEmphasis"
-          height="icon.small"
-          width="icon.small"
+          height="scale.100"
+          width="scale.100"
           borderRadius="full"
         />
       ) : (

--- a/packages/keystatic/src/app/entry-form.tsx
+++ b/packages/keystatic/src/app/entry-form.tsx
@@ -78,7 +78,11 @@ export function FormForEntry({
             <ContentPanelLayout>
               <ScrollView>
                 <Box
-                  padding={{ mobile: 'regular', tablet: 'xlarge' }}
+                  padding={{
+                    mobile: 'medium',
+                    tablet: 'xlarge',
+                    desktop: 'xxlarge',
+                  }}
                   minHeight={0}
                   minWidth={0}
                   maxWidth="container.medium"
@@ -95,7 +99,11 @@ export function FormForEntry({
               <ScrollView>
                 <Grid
                   gap="xlarge"
-                  padding={{ mobile: 'regular', tablet: 'xlarge' }}
+                  padding={{
+                    mobile: 'medium',
+                    tablet: 'xlarge',
+                    desktop: 'xxlarge',
+                  }}
                 >
                   {Object.entries(props.fields).map(([key, propVal]) =>
                     key === contentField.key ? null : (
@@ -119,7 +127,9 @@ export function FormForEntry({
   return (
     <Box height="100%" ref={ref}>
       <ScrollView>
-        <AppShellContainer padding={{ mobile: 'regular', tablet: 'xlarge' }}>
+        <AppShellContainer
+          paddingY={{ mobile: 'medium', tablet: 'xlarge', desktop: 'xxlarge' }}
+        >
           <FormValueContentFromPreviewProps
             // autoFocus
             forceValidation={forceValidation}

--- a/packages/keystatic/src/app/entry-form.tsx
+++ b/packages/keystatic/src/app/entry-form.tsx
@@ -1,7 +1,4 @@
 import { Box, Grid } from '@keystar/ui/layout';
-import { breakpoints } from '@keystar/ui/style';
-import { useResizeObserver } from '@react-aria/utils';
-import { useRef, useState } from 'react';
 
 import { FormatInfo } from './path-utils';
 import { ReadonlyPropPath } from '../form/fields/document/DocumentEditor/component-blocks/utils';
@@ -23,7 +20,7 @@ import {
   Collection,
   Singleton,
 } from '..';
-import { ContentPanelLayout } from './shell/panels';
+import { ContentPanelLayout, useContentPanelQuery } from './shell/panels';
 import { ScrollView } from './shell/primitives';
 import { AppShellContainer } from './shell';
 
@@ -51,93 +48,77 @@ export function FormForEntry({
   forceValidation: boolean | undefined;
   slugField: SlugFieldInfo | undefined;
 }) {
-  const [isAboveTablet, setIsAboveTablet] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const isAboveMobile = useContentPanelQuery({ above: 'mobile' });
   const props = _previewProps as GenericPreviewProps<
     ObjectField<Record<string, NonChildFieldComponentSchema>>,
     unknown
   >;
 
-  useResizeObserver({
-    ref,
-    onResize: () => {
-      let element = ref.current;
-      if (element) {
-        const width = element.getBoundingClientRect().width;
-        setIsAboveTablet(width >= breakpoints.tablet);
-      }
-    },
-  });
-
-  if (entryLayout === 'content' && formatInfo.contentField && isAboveTablet) {
+  if (entryLayout === 'content' && formatInfo.contentField && isAboveMobile) {
     const { contentField } = formatInfo;
     return (
-      <Box height="100%" ref={ref}>
-        <PathContextProvider value={emptyArray}>
-          <SlugFieldProvider value={slugField}>
-            <ContentPanelLayout>
-              <ScrollView>
-                <Box
-                  padding={{
-                    mobile: 'medium',
-                    tablet: 'xlarge',
-                    desktop: 'xxlarge',
-                  }}
-                  minHeight={0}
-                  minWidth={0}
-                  maxWidth="container.medium"
-                  marginX="auto"
-                >
-                  <AddToPathProvider part={contentField.key}>
-                    <InnerFormValueContentFromPreviewProps
-                      forceValidation={forceValidation}
-                      {...props.fields[contentField.key]}
-                    />
-                  </AddToPathProvider>
-                </Box>
-              </ScrollView>
-              <ScrollView>
-                <Grid
-                  gap="xlarge"
-                  padding={{
-                    mobile: 'medium',
-                    tablet: 'xlarge',
-                    desktop: 'xxlarge',
-                  }}
-                >
-                  {Object.entries(props.fields).map(([key, propVal]) =>
-                    key === contentField.key ? null : (
-                      <AddToPathProvider key={key} part={key}>
-                        <InnerFormValueContentFromPreviewProps
-                          forceValidation={forceValidation}
-                          {...propVal}
-                        />
-                      </AddToPathProvider>
-                    )
-                  )}
-                </Grid>
-              </ScrollView>
-            </ContentPanelLayout>
-          </SlugFieldProvider>
-        </PathContextProvider>
-      </Box>
+      <PathContextProvider value={emptyArray}>
+        <SlugFieldProvider value={slugField}>
+          <ContentPanelLayout>
+            <ScrollView>
+              <Box
+                padding={{
+                  mobile: 'medium',
+                  tablet: 'xlarge',
+                  desktop: 'xxlarge',
+                }}
+                minHeight={0}
+                minWidth={0}
+                maxWidth="container.medium"
+                marginX="auto"
+              >
+                <AddToPathProvider part={contentField.key}>
+                  <InnerFormValueContentFromPreviewProps
+                    forceValidation={forceValidation}
+                    {...props.fields[contentField.key]}
+                  />
+                </AddToPathProvider>
+              </Box>
+            </ScrollView>
+            <ScrollView>
+              <Grid
+                gap="xlarge"
+                padding={{
+                  mobile: 'medium',
+                  tablet: 'xlarge',
+                  desktop: 'xxlarge',
+                }}
+              >
+                {Object.entries(props.fields).map(([key, propVal]) =>
+                  key === contentField.key ? null : (
+                    <AddToPathProvider key={key} part={key}>
+                      <InnerFormValueContentFromPreviewProps
+                        forceValidation={forceValidation}
+                        {...propVal}
+                      />
+                    </AddToPathProvider>
+                  )
+                )}
+              </Grid>
+            </ScrollView>
+          </ContentPanelLayout>
+        </SlugFieldProvider>
+      </PathContextProvider>
     );
   }
 
   return (
-    <Box height="100%" ref={ref}>
-      <ScrollView>
-        <AppShellContainer
-          paddingY={{ mobile: 'medium', tablet: 'xlarge', desktop: 'xxlarge' }}
-        >
-          <FormValueContentFromPreviewProps
-            // autoFocus
-            forceValidation={forceValidation}
-            slugField={slugField}
-            {...props}
-          />
-        </AppShellContainer>
-      </ScrollView>
-    </Box>
+    <ScrollView>
+      <AppShellContainer
+        paddingY={{ mobile: 'medium', tablet: 'xlarge', desktop: 'xxlarge' }}
+      >
+        <FormValueContentFromPreviewProps
+          // autoFocus
+          forceValidation={forceValidation}
+          slugField={slugField}
+          {...props}
+        />
+      </AppShellContainer>
+    </ScrollView>
   );
 }

--- a/packages/keystatic/src/app/shell/header.tsx
+++ b/packages/keystatic/src/app/shell/header.tsx
@@ -8,7 +8,7 @@ import { panelLeftCloseIcon } from '@keystar/ui/icon/icons/panelLeftCloseIcon';
 import { panelRightOpenIcon } from '@keystar/ui/icon/icons/panelRightOpenIcon';
 import { panelRightCloseIcon } from '@keystar/ui/icon/icons/panelRightCloseIcon';
 import { Box, Flex } from '@keystar/ui/layout';
-import { breakpointQueries, css, tokenSchema } from '@keystar/ui/style';
+import { css, tokenSchema } from '@keystar/ui/style';
 
 import { useSidebar } from './sidebar';
 import { AppShellContainer } from '.';
@@ -42,9 +42,7 @@ export const AppShellHeader = ({ children }: PropsWithChildren) => {
             onPress={sidebarState.toggle}
             ref={menuButtonRef}
             UNSAFE_className={css({
-              [breakpointQueries.above.tablet]: {
-                marginInlineStart: `calc(${tokenSchema.size.space.regular} * -1)`,
-              },
+              marginInlineStart: `calc(${tokenSchema.size.space.regular} * -1)`,
             })}
           >
             <Icon src={icon} />

--- a/packages/keystatic/src/app/shell/index.tsx
+++ b/packages/keystatic/src/app/shell/index.tsx
@@ -105,7 +105,7 @@ export function EmptyState(props: EmptyStateProps) {
       gap="large"
       justifyContent="center"
       minHeight="scale.3000"
-      padding={{ mobile: 'regular', tablet: 'xlarge' }}
+      paddingX={{ mobile: 'medium', tablet: 'xlarge', desktop: 'xxlarge' }}
     >
       {'children' in props ? (
         props.children
@@ -188,7 +188,7 @@ export const AppShellContainer = (props: BoxProps) => {
       minWidth={0}
       maxWidth={maxWidth}
       // marginX="auto"
-      paddingX={{ mobile: 'regular', tablet: 'xlarge' }}
+      paddingX={{ mobile: 'medium', tablet: 'xlarge', desktop: 'xxlarge' }}
       {...props}
     />
   );

--- a/packages/keystatic/src/app/shell/topbar.tsx
+++ b/packages/keystatic/src/app/shell/topbar.tsx
@@ -182,7 +182,8 @@ function HeaderOuter({ children }: { children: ReactNode }) {
       flexShrink={0}
       gap="small"
       height={{ mobile: 'element.large', tablet: 'scale.700' }}
-      paddingX={{ mobile: 'regular', tablet: 'xlarge' }}
+      paddingX={{ mobile: 'medium', tablet: 'xlarge' }}
+      paddingEnd={{ desktop: 'xxlarge' }}
     >
       {children}
     </Flex>


### PR DESCRIPTION
Adhere to Figma designs (as best as possible) and tidy some things:

- Collection page: render empty state when no results from search
- Item page: fix bug where a single column layout flashes when `entryLayout=content` on desktop