### PR TITLE
Field adornment fixes

### DIFF
--- a/.changeset/stupid-geckos-sniff.md
+++ b/.changeset/stupid-geckos-sniff.md
@@ -1,0 +1,5 @@
+---
+'@keystar/ui': patch
+---
+
+fixes a bug where non-interactive adornments block pointer events

--- a/design-system/pkg/src/number-field/StepButton.tsx
+++ b/design-system/pkg/src/number-field/StepButton.tsx
@@ -49,6 +49,7 @@ export const StepButton = forwardRef(function StepButton(
         css({
           alignItems: 'center',
           color: tokenSchema.color.alias.foregroundIdle,
+          cursor: 'default',
           display: 'flex',
           justifyContent: 'center',
           transition: transition('border-color'),

--- a/design-system/pkg/src/text-field/stories/TextField.stories.tsx
+++ b/design-system/pkg/src/text-field/stories/TextField.stories.tsx
@@ -1,5 +1,8 @@
 import { useMemo, useState } from 'react';
 import { action, Parameters, StoryObj } from '@keystar/ui-storybook';
+import { ActionButton } from '@keystar/ui/button';
+import { Flex } from '@keystar/ui/layout';
+import { Text } from '@keystar/ui/typography';
 
 import { TextField } from '..';
 
@@ -78,16 +81,30 @@ export const CustomWidth: Story = render({
     'Error messages inform the user when the input does not meet validation criteria.',
 });
 
+export const StaticElement: Story = render({
+  startElement: (
+    <Flex pointerEvents="none" alignSelf="center" marginStart="regular">
+      <Text color="neutralTertiary" size="small" weight="medium">
+        Prefix
+      </Text>
+    </Flex>
+  ),
+});
+
+export const InteractiveElement: Story = render({
+  endElement: <ActionButton prominence="low">Action</ActionButton>,
+});
+
 function render(props = {}) {
   return {
     render: (args: Parameters) => (
       <TextField
-        {...props}
         {...args}
         onChange={action('change')}
         onFocus={action('focus')}
         onBlur={action('blur')}
         UNSAFE_className="custom-class-name"
+        {...props}
       />
     ),
   };


### PR DESCRIPTION
Refactor the field primitive interaction model—fixes a bug where non-interactive adornments block pointer events on the perceived input bounding rect.

**Some context:**

It might seem like a good idea to have the input fill the container and layer absolutely positioned adornments on top, but that requires insetting the input's inline padding. This is fine when you know the element's dimensions ahead of time, but in cases where the adornment is dynamic, e.g. localised strings, you're forced to do awkward and often poorly performing measurements at runtime. Another benefit of this approach is that adornments avoid conflict with third-party extensions like password managers.