### PR TITLE
KEY-193: Fix custom attributes on headings in `fields.document`

### DIFF
--- a/.changeset/quick-chefs-arrive.md
+++ b/.changeset/quick-chefs-arrive.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fix custom attributes on headings in `fields.document`

--- a/packages/keystatic/src/form/fields/document/markdoc/to-markdoc.tsx
+++ b/packages/keystatic/src/form/fields/document/markdoc/to-markdoc.tsx
@@ -296,7 +296,7 @@ function toMarkdoc(
           undefined,
           config.slug,
           false
-        )
+        ).value
       );
     }
     const markdocNode = new Ast.Node(


### PR DESCRIPTION
I started doing a bunch of refactoring to do this "properly" so that e.g. images would work here but it didn't turn out great and really people mostly just want ids here so this is probably good enough until the markdoc field is really usable