### PR TITLE
Dashboard UI update

### DIFF
--- a/.changeset/long-apricots-sort.md
+++ b/.changeset/long-apricots-sort.md
@@ -3,4 +3,17 @@
 '@keystar/ui': patch
 ---
 
-dashboard ui update
+Update dashboard page to use card-like interface elements for collections and singletons.
+
+Related app changes:
+
+- declare side and main app panels as "inline-size" containers
+- less obtrusive change indicators on sidebar singleton
+- create `useLocalizedString` hook, which abstracts l10n message import to one location
+
+Related component library changes:
+
+- adjust `AnchorDOMProps` type; require "href" property and remove (MIME) "type" property
+- support "href" (and friends) on `ActionButton` component
+- expose `containerQueries` from "style" package
+- fix class list declaration issue, which was causing a warning from `FieldButton` component

--- a/.changeset/long-apricots-sort.md
+++ b/.changeset/long-apricots-sort.md
@@ -1,0 +1,6 @@
+---
+'@keystatic/core': patch
+'@keystar/ui': patch
+---
+
+dashboard ui update

--- a/design-system/pkg/src/button/ActionButton.tsx
+++ b/design-system/pkg/src/button/ActionButton.tsx
@@ -130,6 +130,9 @@ const BaseButton = forwardRef(function BaseActionButton(
 // Utils
 // -----------------------------------------------------------------------------
 
+let iconClassName = actionButtonClassList.declare('icon');
+let textClassName = actionButtonClassList.declare('text');
+
 export const useActionButtonChildren = (
   props: CommonActionButtonProps,
   alternateSlots?: SlotContextType
@@ -139,15 +142,16 @@ export const useActionButtonChildren = (
   // avoid unnecessary re-renders
   const slots = useMemo(() => {
     return {
+      ...alternateSlots,
       icon: {
-        UNSAFE_className: actionButtonClassList.declare('icon'),
+        UNSAFE_className: iconClassName,
         ...alternateSlots?.icon,
       },
       text: {
         color: 'inherit',
         overflow: 'unset',
         trim: false,
-        UNSAFE_className: actionButtonClassList.declare('text'),
+        UNSAFE_className: textClassName,
         ...alternateSlots?.text,
       },
     } as const;

--- a/design-system/pkg/src/button/Button.tsx
+++ b/design-system/pkg/src/button/Button.tsx
@@ -30,19 +30,11 @@ export const Button = forwardRef(function Button(
   props = useSlotProps(props, 'button');
   const children = useButtonChildren(props);
   const domRef = useObjectRef(forwardedRef);
-  // let hasLabel = useHasChild('.ksv-text', domRef);
-  // let hasIcon = useHasChild('.ksv-icon', domRef);
-  // let contents = hasIcon && hasLabel ? 'mixed' : hasLabel ? 'text' : 'icon';
-  let contents = 'unknown';
 
   if ('href' in props && props.href) {
     return (
       <FocusRing autoFocus={props.autoFocus}>
-        <LinkButton
-          data-contents={contents}
-          ref={domRef as ForwardedRef<HTMLAnchorElement>}
-          {...props}
-        >
+        <LinkButton ref={domRef as ForwardedRef<HTMLAnchorElement>} {...props}>
           {children}
         </LinkButton>
       </FocusRing>
@@ -51,11 +43,7 @@ export const Button = forwardRef(function Button(
 
   return (
     <FocusRing autoFocus={props.autoFocus}>
-      <BaseButton
-        data-contents={contents}
-        ref={domRef as ForwardedRef<HTMLButtonElement>}
-        {...props}
-      >
+      <BaseButton ref={domRef as ForwardedRef<HTMLButtonElement>} {...props}>
         {children}
       </BaseButton>
     </FocusRing>

--- a/design-system/pkg/src/button/Button.tsx
+++ b/design-system/pkg/src/button/Button.tsx
@@ -13,7 +13,7 @@ import { isReactText } from '@keystar/ui/utils';
 import {
   ButtonElementProps,
   ButtonProps,
-  CommonProps,
+  CommonButtonProps,
   LinkElementProps,
 } from './types';
 import { buttonClassList, useButtonStyles } from './useButtonStyles';
@@ -35,7 +35,7 @@ export const Button = forwardRef(function Button(
   // let contents = hasIcon && hasLabel ? 'mixed' : hasLabel ? 'text' : 'icon';
   let contents = 'unknown';
 
-  if ('href' in props) {
+  if ('href' in props && props.href) {
     return (
       <FocusRing autoFocus={props.autoFocus}>
         <LinkButton
@@ -138,7 +138,7 @@ const BaseButton = forwardRef(function Button(
 // Utils
 // -----------------------------------------------------------------------------
 
-export const useButtonChildren = (props: CommonProps) => {
+export const useButtonChildren = (props: CommonButtonProps) => {
   const { children } = props;
 
   // avoid unnecessary re-renders

--- a/design-system/pkg/src/button/stories/ActionButton.stories.tsx
+++ b/design-system/pkg/src/button/stories/ActionButton.stories.tsx
@@ -84,6 +84,29 @@ StaticDark.story = {
   name: 'static: dark',
 };
 
+export const Anchor = () => (
+  <Flex direction="column" gap="regular">
+    <Flex gap="regular">
+      <ActionButton href="https://example.com">Anchor</ActionButton>
+      <ActionButton isDisabled href="https://example.com">
+        Anchor
+      </ActionButton>
+    </Flex>
+    <Flex gap="regular">
+      <ActionButton prominence="low" href="https://example.com">
+        Anchor
+      </ActionButton>
+      <ActionButton prominence="low" isDisabled href="https://example.com">
+        Anchor
+      </ActionButton>
+    </Flex>
+  </Flex>
+);
+
+Anchor.story = {
+  name: 'anchor',
+};
+
 function render(label = 'Default', props: ActionButtonProps = {}) {
   return (
     <Flex gap="regular">

--- a/design-system/pkg/src/button/types.ts
+++ b/design-system/pkg/src/button/types.ts
@@ -10,7 +10,7 @@ import {
 import { ReactNode } from 'react';
 
 import { BaseStyleProps } from '@keystar/ui/style';
-import { AnchorDOMProps, Never, PartialRequired } from '@keystar/ui/types';
+import { AnchorDOMProps } from '@keystar/ui/types';
 
 export type ButtonProminence = 'default' | 'high' | 'low';
 export type ButtonTone = 'neutral' | 'accent' | 'critical';
@@ -44,9 +44,6 @@ type AriaProps = {
   form?: string;
 };
 
-// NOTE: omit mime "type" to avoid conflict with button "type"
-export type WithHref = PartialRequired<Omit<AnchorDOMProps, 'type'>, 'href'>;
-
 // ActionButton
 // -----------------------------------------------------------------------------
 
@@ -77,10 +74,10 @@ export type ActionButtonElementProps = {
 } & CommonActionButtonProps &
   AriaProps;
 
-export type ActionLinkElementProps = CommonActionButtonProps & WithHref;
+export type ActionLinkElementProps = CommonActionButtonProps & AnchorDOMProps;
 
 export type ActionButtonProps =
-  | (Never<WithHref> & ActionButtonElementProps)
+  | ActionButtonElementProps
   | ActionLinkElementProps;
 
 // ToggleButton
@@ -139,11 +136,9 @@ export type CommonButtonProps = {
 
 export type ButtonElementProps = CommonButtonProps & AriaProps;
 
-export type LinkElementProps = CommonButtonProps & WithHref;
+export type LinkElementProps = CommonButtonProps & AnchorDOMProps;
 
-export type ButtonProps =
-  | (Never<WithHref> & ButtonElementProps)
-  | LinkElementProps;
+export type ButtonProps = ButtonElementProps | LinkElementProps;
 
 // ButtonGroup
 // -----------------------------------------------------------------------------

--- a/design-system/pkg/src/button/types.ts
+++ b/design-system/pkg/src/button/types.ts
@@ -10,7 +10,7 @@ import {
 import { ReactNode } from 'react';
 
 import { BaseStyleProps } from '@keystar/ui/style';
-import { AnchorDOMProps, PartialRequired } from '@keystar/ui/types';
+import { AnchorDOMProps, Never, PartialRequired } from '@keystar/ui/types';
 
 export type ButtonProminence = 'default' | 'high' | 'low';
 export type ButtonTone = 'neutral' | 'accent' | 'critical';
@@ -44,16 +44,17 @@ type AriaProps = {
   form?: string;
 };
 
+// NOTE: omit mime "type" to avoid conflict with button "type"
+export type WithHref = PartialRequired<Omit<AnchorDOMProps, 'type'>, 'href'>;
+
 // ActionButton
 // -----------------------------------------------------------------------------
 
-export type ActionButtonProps = {
+export type CommonActionButtonProps = {
   /** The content to display in the button. */
   children?: ReactNode;
   /** Whether the button is disabled. */
   isDisabled?: boolean;
-  /** Whether the button is selected. */
-  isSelected?: boolean;
   /**
    * The static style to apply. Useful when the button appears over a
    * background.
@@ -68,8 +69,19 @@ export type ActionButtonProps = {
   FocusableProps &
   FocusableDOMProps &
   AriaLabelingProps &
-  AriaProps &
   BaseStyleProps;
+
+export type ActionButtonElementProps = {
+  /** Whether the button is selected. */
+  isSelected?: boolean;
+} & CommonActionButtonProps &
+  AriaProps;
+
+export type ActionLinkElementProps = CommonActionButtonProps & WithHref;
+
+export type ActionButtonProps =
+  | (Never<WithHref> & ActionButtonElementProps)
+  | ActionLinkElementProps;
 
 // ToggleButton
 // -----------------------------------------------------------------------------
@@ -99,7 +111,7 @@ export type FieldButtonProps = ActionButtonProps & {
 // Button
 // -----------------------------------------------------------------------------
 
-export type CommonProps = {
+export type CommonButtonProps = {
   /** The content to display in the button. */
   children?: ReactNode;
   /** Whether the button is disabled. */
@@ -125,14 +137,13 @@ export type CommonProps = {
   AriaLabelingProps &
   BaseStyleProps;
 
-export type ButtonElementProps = CommonProps & AriaProps;
+export type ButtonElementProps = CommonButtonProps & AriaProps;
 
-// NOTE: omit mime "type" to avoid conflict with button "type", and force
-// required "href" to ensure discriminated union. should be fine...
-export type LinkElementProps = CommonProps &
-  PartialRequired<Omit<AnchorDOMProps, 'type'>, 'href'>;
+export type LinkElementProps = CommonButtonProps & WithHref;
 
-export type ButtonProps = ButtonElementProps | LinkElementProps;
+export type ButtonProps =
+  | (Never<WithHref> & ButtonElementProps)
+  | LinkElementProps;
 
 // ButtonGroup
 // -----------------------------------------------------------------------------

--- a/design-system/pkg/src/button/useActionButtonStyles.tsx
+++ b/design-system/pkg/src/button/useActionButtonStyles.tsx
@@ -64,6 +64,9 @@ export function useActionButtonStyles(
           fontWeight: 'inherit',
           marginInline: tokenSchema.size.space.small,
         },
+        [`&:has(${actionButtonClassList.selector('icon')}:only-child)`]: {
+          paddingInline: 0,
+        },
 
         // FOCUS RING
         '--focus-ring-color': tokenSchema.color.alias.focusRing,

--- a/design-system/pkg/src/button/useActionButtonStyles.tsx
+++ b/design-system/pkg/src/button/useActionButtonStyles.tsx
@@ -64,9 +64,6 @@ export function useActionButtonStyles(
           fontWeight: 'inherit',
           marginInline: tokenSchema.size.space.small,
         },
-        [`&:has(${actionButtonClassList.selector('icon')}:only-child)`]: {
-          paddingInline: 0,
-        },
 
         // FOCUS RING
         '--focus-ring-color': tokenSchema.color.alias.focusRing,

--- a/design-system/pkg/src/button/useActionButtonStyles.tsx
+++ b/design-system/pkg/src/button/useActionButtonStyles.tsx
@@ -24,7 +24,8 @@ export function useActionButtonStyles(
 ) {
   const { prominence = 'default' } = props;
   const { isHovered, isPressed } = state;
-  const isSelected = props.isSelected || state.isSelected;
+  const isSelected =
+    ('isSelected' in props && props.isSelected) || state.isSelected;
   const styleProps = useStyleProps(props);
 
   return {

--- a/design-system/pkg/src/button/useButtonStyles.tsx
+++ b/design-system/pkg/src/button/useButtonStyles.tsx
@@ -64,9 +64,6 @@ export function useButtonStyles(props: ButtonProps, state: ButtonState) {
         },
 
         // contents
-        '&[data-contents=icon]': {
-          paddingInline: tokenSchema.size.space.regular,
-        },
         [buttonClassList.childSelector('text')]: {
           fontSize: 'inherit',
           fontWeight: 'inherit',

--- a/design-system/pkg/src/editor/stories/EditorPopover.stories.tsx
+++ b/design-system/pkg/src/editor/stories/EditorPopover.stories.tsx
@@ -21,7 +21,7 @@ export default {
 
 export const Default = () => {
   let [isOpen, setOpen] = useState(false);
-  let [triggerRef, setTriggerRef] = useState<HTMLButtonElement | null>(null);
+  let [triggerRef, setTriggerRef] = useState<HTMLElement | null>(null);
 
   return (
     <>
@@ -46,7 +46,7 @@ Default.story = {
 export const Refs = () => {
   let floating = useRef<EditorPopoverRef | null>(null);
   let [isOpen, setOpen] = useState(false);
-  let [triggerRef, setTriggerRef] = useState<HTMLButtonElement | null>(null);
+  let [triggerRef, setTriggerRef] = useState<HTMLElement | null>(null);
 
   return (
     <Flex gap="large">

--- a/design-system/pkg/src/link/TextLink/TextLinkAnchor.tsx
+++ b/design-system/pkg/src/link/TextLink/TextLinkAnchor.tsx
@@ -25,8 +25,8 @@ export const TextLinkAnchor = forwardRef<
     ...otherProps
   } = props;
 
+  const LinkComponent = useLinkComponent(forwardedRef);
   const domRef = useObjectRef(forwardedRef);
-  const LinkComponent = useLinkComponent(domRef);
   const { Wrapper, ...styleProps } = useTextLink(props);
   const { linkProps } = useLink(otherProps, domRef);
 

--- a/design-system/pkg/src/link/TextLink/TextLinkAnchor.tsx
+++ b/design-system/pkg/src/link/TextLink/TextLinkAnchor.tsx
@@ -21,7 +21,6 @@ export const TextLinkAnchor = forwardRef<
     referrerPolicy,
     rel,
     target,
-    type,
     ...otherProps
   } = props;
 
@@ -41,7 +40,6 @@ export const TextLinkAnchor = forwardRef<
         referrerPolicy={referrerPolicy}
         rel={rel}
         target={target}
-        type={type}
         {...mergeProps(linkProps, styleProps)}
       >
         {children}

--- a/design-system/pkg/src/link/TextLink/types.ts
+++ b/design-system/pkg/src/link/TextLink/types.ts
@@ -1,7 +1,7 @@
 import { DOMProps, FocusableProps, PressEvents } from '@react-types/shared';
 import { ReactNode } from 'react';
 
-import { AnchorDOMProps, PartialRequired } from '@keystar/ui/types';
+import { AnchorDOMProps } from '@keystar/ui/types';
 
 export type TextLinkProminence = 'default' | 'high';
 
@@ -17,7 +17,6 @@ export type TextLinkButtonProps = {
   PressEvents &
   FocusableProps;
 
-export type TextLinkAnchorProps = TextLinkButtonProps &
-  PartialRequired<AnchorDOMProps, 'href'>;
+export type TextLinkAnchorProps = TextLinkButtonProps & AnchorDOMProps;
 
 export type TextLinkProps = TextLinkButtonProps | TextLinkAnchorProps;

--- a/design-system/pkg/src/link/TextLink/useTextLink.ts
+++ b/design-system/pkg/src/link/TextLink/useTextLink.ts
@@ -49,6 +49,7 @@ export function useTextLink({
         textUnderlineOffset: tokenSchema.size.border.medium,
 
         '&[data-hover="true"], &[data-focus="visible"]': {
+          color: tokenSchema.color.foreground.neutralEmphasis,
           textDecorationColor: tokenSchema.color.foreground.neutral,
         },
         '&[data-focus="visible"]': {

--- a/design-system/pkg/src/style/index.ts
+++ b/design-system/pkg/src/style/index.ts
@@ -17,7 +17,7 @@ export {
   resolvePropWithPath,
   sizeResolver,
 } from './resolvers';
-export { breakpoints, breakpointQueries } from './responsive';
+export { breakpoints, breakpointQueries, containerQueries } from './responsive';
 export { tokenSchema } from './tokens';
 export { useIsMobileDevice } from './useIsMobileDevice';
 export { useMediaQuery } from './useMediaQuery';

--- a/design-system/pkg/src/style/responsive.ts
+++ b/design-system/pkg/src/style/responsive.ts
@@ -20,25 +20,39 @@ export const breakpoints: Record<Breakpoint, number> = {
 };
 
 // external stuff for composing responsive styles
-const above = (bp: number) => `@media (min-width: ${bp}px)`;
-const below = (bp: number) => `@media (max-width: ${bp - 1}px)`;
+const mediaAbove = (bp: number) => `@media (min-width: ${bp}px)`;
+const mediaBelow = (bp: number) => `@media (max-width: ${bp - 1}px)`;
+const containerAbove = (bp: number) => `@container (min-width: ${bp}px)`;
+const containerBelow = (bp: number) => `@container (max-width: ${bp - 1}px)`;
 export const breakpointQueries = {
   above: {
-    mobile: above(breakpoints.tablet),
-    tablet: above(breakpoints.desktop),
-    desktop: above(breakpoints.wide),
+    mobile: mediaAbove(breakpoints.tablet),
+    tablet: mediaAbove(breakpoints.desktop),
+    desktop: mediaAbove(breakpoints.wide),
   },
   below: {
-    tablet: below(breakpoints.tablet),
-    desktop: below(breakpoints.desktop),
-    wide: below(breakpoints.wide),
+    tablet: mediaBelow(breakpoints.tablet),
+    desktop: mediaBelow(breakpoints.desktop),
+    wide: mediaBelow(breakpoints.wide),
+  },
+};
+export const containerQueries = {
+  above: {
+    mobile: containerAbove(breakpoints.tablet),
+    tablet: containerAbove(breakpoints.desktop),
+    desktop: containerAbove(breakpoints.wide),
+  },
+  below: {
+    tablet: containerBelow(breakpoints.tablet),
+    desktop: containerBelow(breakpoints.desktop),
+    wide: containerBelow(breakpoints.wide),
   },
 };
 
 // internal stuff, mostly for `useStyleProps` hook
 const breakpointNames = typedKeys(breakpoints);
 const { mobile: _mobile, ...breakpointsWithoutMobile } = breakpoints;
-const mediaQueries = Object.values(breakpointsWithoutMobile).map(above);
+const mediaQueries = Object.values(breakpointsWithoutMobile).map(mediaAbove);
 export const mapToMediaQueries = facepaint(mediaQueries);
 
 // CSS Utils

--- a/design-system/pkg/src/types/dom.ts
+++ b/design-system/pkg/src/types/dom.ts
@@ -2,9 +2,9 @@ import { HTMLAttributeAnchorTarget, HTMLAttributeReferrerPolicy } from 'react';
 
 export interface AnchorDOMProps {
   /** Causes the browser to treat the linked URL as a download. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download) */
-  download?: any;
+  download?: boolean | string;
   /** The URL that the hyperlink points to. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href). */
-  href?: string;
+  href: string;
   /** Hints at the human language of the linked URL. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-hreflang). */
   hrefLang?: string;
   /** A space-separated list of URLs. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-ping).  */
@@ -15,6 +15,4 @@ export interface AnchorDOMProps {
   rel?: string;
   /** The browsing context (a tab, window, or <iframe>) in which to open the linked URL. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target). */
   target?: HTMLAttributeAnchorTarget;
-  /** Hints at the MIME type of the linked URL. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-type). */
-  type?: string;
 }

--- a/packages/keystatic/package.json
+++ b/packages/keystatic/package.json
@@ -152,6 +152,7 @@
     "@emotion/weak-memoize": "^0.3.0",
     "@floating-ui/react": "^0.24.0",
     "@hapi/iron": "^7.0.0",
+    "@internationalized/string": "^3.1.1",
     "@keystar/ui": "^0.1.2",
     "@markdoc/markdoc": "^0.3.0",
     "@react-aria/focus": "^3.13.0",

--- a/packages/keystatic/src/app/ItemPage.tsx
+++ b/packages/keystatic/src/app/ItemPage.tsx
@@ -378,10 +378,12 @@ function HeaderActions(props: {
       return isBelowTablet ? (
         <Box
           backgroundColor="pendingEmphasis"
-          height="scale.100"
-          width="scale.100"
+          height="scale.75"
+          width="scale.75"
           borderRadius="full"
-        />
+        >
+          <Text visuallyHidden>Unsaved</Text>
+        </Box>
       ) : (
         <Badge tone="pending">Unsaved</Badge>
       );

--- a/packages/keystatic/src/app/dashboard/BranchSection.tsx
+++ b/packages/keystatic/src/app/dashboard/BranchSection.tsx
@@ -1,0 +1,84 @@
+import { ActionButton } from '@keystar/ui/button';
+import { DialogTrigger } from '@keystar/ui/dialog';
+import { Icon } from '@keystar/ui/icon';
+import { gitBranchIcon } from '@keystar/ui/icon/icons/gitBranchIcon';
+import { gitBranchPlusIcon } from '@keystar/ui/icon/icons/gitBranchPlusIcon';
+import { gitPullRequestIcon } from '@keystar/ui/icon/icons/gitPullRequestIcon';
+import { Flex } from '@keystar/ui/layout';
+import { Text } from '@keystar/ui/typography';
+
+import { Config } from '../..';
+import { CreateBranchDialog } from '../branch-selection';
+import { DashboardSection } from './components';
+import { useRouter } from '../router';
+import { useBranchInfo } from '../shell/data';
+import { useLocalizedString } from '../shell/i18n';
+import { getRepoUrl, isLocalConfig } from '../utils';
+
+export function BranchSection(props: { config: Config }) {
+  let branchInfo = useBranchInfo();
+  let router = useRouter();
+  let localizedString = useLocalizedString();
+
+  if (isLocalConfig(props.config)) {
+    return null;
+  }
+
+  let repoURL = getRepoUrl(branchInfo);
+  let isDefaultBranch = branchInfo.currentBranch === branchInfo.defaultBranch;
+
+  return (
+    <DashboardSection title={localizedString.format('branches')}>
+      <Flex
+        alignItems="center"
+        gap="regular"
+        border="muted"
+        borderRadius="medium"
+        backgroundColor="canvas"
+        padding="large"
+      >
+        <Icon src={gitBranchIcon} color="neutralTertiary" />
+        <Flex direction="column" gap="regular">
+          <Text weight="medium">{branchInfo.currentBranch}</Text>
+          <Text size="small" color="neutralSecondary">
+            {isDefaultBranch
+              ? localizedString.format('defaultBranch')
+              : localizedString.format('currentBranch')}
+          </Text>
+        </Flex>
+      </Flex>
+      <Flex gap="regular" wrap>
+        <DialogTrigger>
+          <ActionButton>
+            <Icon src={gitBranchPlusIcon} />
+            <Text>{localizedString.format('newBranch')}</Text>
+          </ActionButton>
+          {close => (
+            <CreateBranchDialog
+              onDismiss={close}
+              onCreate={branchName => {
+                close();
+                router.push(
+                  router.href.replace(
+                    /\/branch\/[^/]+/,
+                    '/branch/' + encodeURIComponent(branchName)
+                  )
+                );
+              }}
+            />
+          )}
+        </DialogTrigger>
+
+        {!isDefaultBranch && (
+          <ActionButton
+            href={`${repoURL}/pull/new/${branchInfo.currentBranch}`}
+            target="_blank"
+          >
+            <Icon src={gitPullRequestIcon} />
+            <Text>{localizedString.format('createPullRequest')}</Text>
+          </ActionButton>
+        )}
+      </Flex>
+    </DashboardSection>
+  );
+}

--- a/packages/keystatic/src/app/dashboard/CollectionSection.tsx
+++ b/packages/keystatic/src/app/dashboard/CollectionSection.tsx
@@ -1,0 +1,75 @@
+import { Badge } from '@keystar/ui/badge';
+import { ActionButton } from '@keystar/ui/button';
+import { Icon } from '@keystar/ui/icon';
+import { plusIcon } from '@keystar/ui/icon/icons/plusIcon';
+import { Flex } from '@keystar/ui/layout';
+import { Text } from '@keystar/ui/typography';
+
+import { Config } from '../..';
+import { DashboardCard, DashboardGrid, DashboardSection } from './components';
+import { useChanged } from '../shell/data';
+import { useLocalizedString } from '../shell/i18n';
+import { keyedEntries, pluralize } from '../utils';
+
+export function CollectionSection(props: { config: Config; basePath: string }) {
+  let localizedString = useLocalizedString();
+  let changed = useChanged();
+  let collections = keyedEntries(props.config.collections ?? {});
+
+  return (
+    <DashboardSection title="Collections">
+      <DashboardGrid>
+        {collections.map(collection => {
+          let counts = changed.collections.get(collection.key);
+          let totalCount = counts?.totalCount ?? 0;
+          let changes = counts
+            ? counts.added.size + counts.changed.size + counts.removed.size
+            : 0;
+
+          return (
+            <DashboardCard
+              key={collection.key}
+              label={collection.label}
+              href={`${props.basePath}/collection/${encodeURIComponent(
+                collection.key
+              )}`}
+              endElement={
+                <ActionButton
+                  aria-label={localizedString.format('add')}
+                  href={`${props.basePath}/collection/${encodeURIComponent(
+                    collection.key
+                  )}/create`}
+                >
+                  <Icon src={plusIcon} />
+                </ActionButton>
+              }
+            >
+              <Flex
+                gap="regular"
+                alignItems="center"
+                minHeight="element.small"
+                flex
+                wrap
+              >
+                <Text>
+                  {pluralize(totalCount, {
+                    singular: 'entry',
+                    plural: 'entries',
+                  })}
+                </Text>
+                {changes > 0 && (
+                  <Badge tone="accent">
+                    {pluralize(changes, {
+                      singular: 'change',
+                      plural: 'changes',
+                    })}
+                  </Badge>
+                )}
+              </Flex>
+            </DashboardCard>
+          );
+        })}
+      </DashboardGrid>
+    </DashboardSection>
+  );
+}

--- a/packages/keystatic/src/app/dashboard/DashboardPage.tsx
+++ b/packages/keystatic/src/app/dashboard/DashboardPage.tsx
@@ -1,38 +1,22 @@
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
-import { useContext, useMemo } from 'react';
 
+import { Avatar } from '@keystar/ui/avatar';
 import { Breadcrumbs, Item } from '@keystar/ui/breadcrumbs';
-import { ActionButton } from '@keystar/ui/button';
-import { DialogTrigger } from '@keystar/ui/dialog';
-import { Icon } from '@keystar/ui/icon';
-import { plusIcon } from '@keystar/ui/icon/icons/plusIcon';
-import { Flex, Grid } from '@keystar/ui/layout';
-import { ListView } from '@keystar/ui/list-view';
-import { ProgressCircle } from '@keystar/ui/progress';
-import { Tooltip, TooltipTrigger } from '@keystar/ui/tooltip';
-import { Heading, Text } from '@keystar/ui/typography';
+import { Flex } from '@keystar/ui/layout';
+import { Heading } from '@keystar/ui/typography';
 
 import { Config } from '../../config';
-
-import { CreateBranchDialog } from '../branch-selection';
 import l10nMessages from '../l10n/index.json';
-import { useRouter } from '../router';
 import { AppShellBody, AppShellRoot } from '../shell';
-import { keyedEntries, pluralize } from '../utils';
-
-import { useChanged, BranchInfoContext } from '../shell/data';
 import { AppShellHeader } from '../shell/header';
+import { useViewer } from '../shell/viewer-data';
+import { BranchSection } from './BranchSection';
+import { CollectionSection } from './CollectionSection';
+import { SingletonSection } from './SingletonSection';
 
 export function DashboardPage(props: { config: Config; basePath: string }) {
-  const { config } = props;
-
   const stringFormatter = useLocalizedStringFormatter(l10nMessages);
-  const changes = useChanged();
-  const router = useRouter();
-
-  let link = (path: string) => props.basePath + path;
-  let collections = keyedEntries(config.collections ?? {});
-  let singletons = keyedEntries(config.singletons ?? {});
+  const user = useViewer();
 
   return (
     <AppShellRoot containerWidth="large">
@@ -42,246 +26,29 @@ export function DashboardPage(props: { config: Config; basePath: string }) {
         </Breadcrumbs>
       </AppShellHeader>
       <AppShellBody isScrollable>
-        <Flex direction="column" gap="xlarge">
-          <Grid
-            columns={{ tablet: '5fr 3fr', desktop: '3fr 1fr' }}
-            gap="xxlarge"
-          >
-            <Flex direction="column" gap="xxlarge" minWidth={0}>
-              <Grid gap="xlarge">
-                <Heading size="medium" id="collections-heading">
-                  {stringFormatter.format('collections')}
-                </Heading>
-                <ListView
-                  aria-labelledby="collections-heading"
-                  items={collections}
-                  onAction={key => {
-                    router.push(link(`/collection/${encodeURIComponent(key)}`));
-                  }}
-                >
-                  {ref => {
-                    const counts = getCountsForCollection({
-                      collection: ref.key,
-                      changes,
-                    });
-                    const allChangesCount =
-                      counts.changed + counts.added + counts.removed;
-
-                    return (
-                      <Item
-                        textValue={
-                          ref.label + allChangesCount
-                            ? ` (${allChangesCount} changed)`
-                            : undefined
-                        }
-                      >
-                        <Text>{ref.label}</Text>
-                        <Text slot="description">
-                          {pluralize(counts.total, {
-                            singular: 'entry',
-                            plural: 'entries',
-                          })}
-                          {allChangesCount ? (
-                            <>
-                              {' '}
-                              &middot;{' '}
-                              {pluralize(allChangesCount, {
-                                singular: 'change',
-                              })}
-                            </>
-                          ) : null}
-                          {counts.added || counts.removed ? (
-                            <> &middot; </>
-                          ) : null}
-                          {!!counts.added && (
-                            <Text color="positive" slot="none">
-                              +{counts.added}
-                            </Text>
-                          )}{' '}
-                          {!!counts.removed && (
-                            <Text color="critical" slot="none">
-                              -{counts.removed}
-                            </Text>
-                          )}
-                        </Text>
-                        <TooltipTrigger placement="start">
-                          <ActionButton
-                            onPress={() => {
-                              router.push(
-                                link(
-                                  `/collection/${encodeURIComponent(
-                                    ref.key
-                                  )}/create`
-                                )
-                              );
-                            }}
-                          >
-                            <Icon src={plusIcon} />
-                          </ActionButton>
-                          <Tooltip>{stringFormatter.format('add')}</Tooltip>
-                        </TooltipTrigger>
-                      </Item>
-                    );
-                  }}
-                </ListView>
-              </Grid>
-
-              {!!singletons.length && (
-                <Grid gap="large">
-                  <Heading size="medium" id="singletons-heading">
-                    {stringFormatter.format('singletons')}
-                  </Heading>
-
-                  <ListView
-                    aria-labelledby="singletons-heading"
-                    items={singletons}
-                    onAction={key => {
-                      router.push(link(`/singleton/${key}`));
-                    }}
-                  >
-                    {ref => {
-                      const description = changes.singletons.has(ref.key)
-                        ? 'Changed'
-                        : 'Unchanged';
-                      return (
-                        <Item textValue={`${ref.label} (${description})`}>
-                          <Text>{ref.label}</Text>
-                          <Text slot="description">{description}</Text>
-                        </Item>
-                      );
-                    }}
-                  </ListView>
-                </Grid>
-              )}
+        <Flex direction="column" gap="xxlarge">
+          {user && (
+            <Flex
+              alignItems="center"
+              gap="medium"
+              isHidden={{ below: 'tablet' }}
+            >
+              <Avatar
+                src={user.avatarUrl}
+                name={user.name ?? undefined}
+                size="medium"
+              />
+              <Heading size="large" elementType="p">
+                Hello, {user.name ?? user.login}!
+              </Heading>
             </Flex>
-            {props.config.storage.kind === 'github' && <Branches />}
-          </Grid>
+          )}
+
+          <BranchSection config={props.config} />
+          <CollectionSection basePath={props.basePath} config={props.config} />
+          <SingletonSection basePath={props.basePath} config={props.config} />
         </Flex>
       </AppShellBody>
     </AppShellRoot>
   );
-}
-
-function Branches() {
-  const stringFormatter = useLocalizedStringFormatter(l10nMessages);
-  const router = useRouter();
-  const branchInfo = useContext(BranchInfoContext);
-  let branches = useMemo(() => {
-    return branchInfo.allBranches
-      .map(name => {
-        return {
-          name,
-          description:
-            name === branchInfo.defaultBranch
-              ? stringFormatter.format('defaultBranch')
-              : undefined,
-        };
-      })
-      .sort(branch => {
-        if (branch.name === branchInfo.defaultBranch) {
-          return -1;
-        }
-        return 1;
-      });
-  }, [branchInfo.allBranches, branchInfo.defaultBranch, stringFormatter]);
-
-  return (
-    <Flex
-      elementType="section"
-      direction="column"
-      gap="xlarge"
-      order={{ mobile: -1, tablet: 1 }}
-      minWidth={0}
-    >
-      <Heading size="medium" id="branches-heading">
-        {stringFormatter.format('branches')}
-      </Heading>
-
-      {branchInfo.allBranches.length === 0 ? (
-        <Flex justifyContent="center">
-          <ProgressCircle
-            isIndeterminate
-            size="medium"
-            aria-label={stringFormatter.format('loading')}
-          />
-        </Flex>
-      ) : (
-        <Flex direction="column" gap="regular">
-          <ListView
-            aria-labelledby="branches-heading"
-            items={branches}
-            maxHeight="scale.3000"
-            selectionMode="single"
-            selectionStyle="highlight"
-            selectedKeys={[branchInfo.currentBranch]}
-            onSelectionChange={([key]) => {
-              if (typeof key === 'string') {
-                router.push(
-                  router.href.replace(
-                    /\/branch\/[^/]+/,
-                    '/branch/' + encodeURIComponent(key)
-                  )
-                );
-              }
-            }}
-          >
-            {ref => (
-              <Item key={ref.name} textValue={ref.name}>
-                <Text>{ref.name}</Text>
-                {ref.description && (
-                  <Text slot="description">{ref.description}</Text>
-                )}
-              </Item>
-            )}
-          </ListView>
-          <DialogTrigger>
-            <div>
-              <ActionButton>{stringFormatter.format('newBranch')}</ActionButton>
-            </div>
-            {close => (
-              <CreateBranchDialog
-                onDismiss={close}
-                onCreate={branchName => {
-                  close();
-                  router.push(
-                    router.href.replace(
-                      /\/branch\/[^/]+/,
-                      '/branch/' + encodeURIComponent(branchName)
-                    )
-                  );
-                }}
-              />
-            )}
-          </DialogTrigger>
-        </Flex>
-      )}
-    </Flex>
-  );
-}
-
-// Utils
-// ------------------------------
-
-type Changes = ReturnType<typeof useChanged>;
-
-function getCountsForCollection(options: {
-  collection: string;
-  changes: Changes;
-}) {
-  let { changes, collection } = options;
-  let added = 0;
-  let removed = 0;
-  let changed = 0;
-  let total = 0;
-
-  const collectionChanged = changes.collections.get(collection);
-
-  if (collectionChanged) {
-    added = collectionChanged.added.size;
-    removed = collectionChanged.removed.size;
-    changed = collectionChanged.changed.size;
-    total = collectionChanged.totalCount;
-  }
-
-  return { added, removed, changed, total };
 }

--- a/packages/keystatic/src/app/dashboard/SingletonSection.tsx
+++ b/packages/keystatic/src/app/dashboard/SingletonSection.tsx
@@ -1,0 +1,46 @@
+import { Badge } from '@keystar/ui/badge';
+import { Flex } from '@keystar/ui/layout';
+
+import { Config } from '../..';
+import { DashboardCard, DashboardGrid, DashboardSection } from './components';
+import { useChanged } from '../shell/data';
+import { keyedEntries } from '../utils';
+
+export function SingletonSection(props: { config: Config; basePath: string }) {
+  let changed = useChanged();
+  let singletons = keyedEntries(props.config.singletons ?? {});
+
+  return (
+    <DashboardSection title="Singletons">
+      <DashboardGrid>
+        {singletons.map(singleton => {
+          let changes = changed.singletons.has(singleton.key);
+
+          return (
+            <DashboardCard
+              key={singleton.key}
+              label={singleton.label}
+              href={`${props.basePath}/singleton/${encodeURIComponent(
+                singleton.key
+              )}`}
+            >
+              <Flex
+                gap="regular"
+                alignItems="center"
+                minHeight="element.small"
+                flex
+                wrap
+              >
+                {changes ? (
+                  <Badge tone="accent">Changed</Badge>
+                ) : (
+                  <Badge>Unchanged</Badge>
+                )}
+              </Flex>
+            </DashboardCard>
+          );
+        })}
+      </DashboardGrid>
+    </DashboardSection>
+  );
+}

--- a/packages/keystatic/src/app/dashboard/components.tsx
+++ b/packages/keystatic/src/app/dashboard/components.tsx
@@ -1,18 +1,96 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactElement } from 'react';
 
 import { Flex } from '@keystar/ui/layout';
-import { Text } from '@keystar/ui/typography';
+import { useLinkComponent } from '@keystar/ui/link';
+import { containerQueries, css, tokenSchema } from '@keystar/ui/style';
+import { Heading, Text } from '@keystar/ui/typography';
 
-export const SummaryBlock = ({ children }: PropsWithChildren) => {
+export const DashboardSection = ({
+  children,
+  title,
+}: PropsWithChildren<{ title: string }>) => {
   return (
-    <Flex direction="column" gap="large">
-      {Array.isArray(children)
-        ? children.map((paragraph, index) => (
-            <Text elementType="p" key={index}>
-              {paragraph}
-            </Text>
-          ))
-        : children}
+    <Flex elementType="section" direction="column" gap="medium">
+      <Text
+        casing="uppercase"
+        color="neutralTertiary"
+        size="small"
+        weight="bold"
+        elementType="h2"
+      >
+        {title}
+      </Text>
+      {children}
+    </Flex>
+  );
+};
+
+export const DashboardGrid = (props: PropsWithChildren) => {
+  return (
+    <div
+      className={css({
+        display: 'grid',
+        gap: tokenSchema.size.space.large,
+
+        [containerQueries.above.mobile]: {
+          gridTemplateColumns: '1fr 1fr',
+        },
+        [containerQueries.above.tablet]: {
+          gridTemplateColumns: '1fr 1fr 1fr',
+        },
+      })}
+      {...props}
+    />
+  );
+};
+
+export const DashboardCard = (
+  props: PropsWithChildren<{
+    endElement?: ReactElement;
+    href: string;
+    label: string;
+  }>
+) => {
+  let Link = useLinkComponent(null);
+
+  return (
+    <Flex
+      position="relative"
+      border="muted"
+      borderRadius="medium"
+      backgroundColor="canvas"
+      padding="large"
+    >
+      <Flex direction="column" gap="regular" flex>
+        <Heading elementType="h3" size="small" truncate>
+          <Link
+            href={props.href}
+            className={css({
+              color: tokenSchema.color.foreground.neutral,
+              textDecoration: 'underline',
+              textDecorationColor: 'transparent',
+              textDecorationThickness: tokenSchema.size.border.regular,
+              textUnderlineOffset: tokenSchema.size.border.medium,
+
+              '&:hover': {
+                color: tokenSchema.color.foreground.neutralEmphasis,
+                textDecorationColor: tokenSchema.color.foreground.neutral,
+              },
+
+              // fill the available space so that the card is clickable
+              '::before': {
+                content: '""',
+                position: 'absolute',
+                inset: 0,
+              },
+            })}
+          >
+            {props.label}
+          </Link>
+        </Heading>
+        {props.children}
+      </Flex>
+      {props.endElement}
     </Flex>
   );
 };

--- a/packages/keystatic/src/app/shell/data.tsx
+++ b/packages/keystatic/src/app/shell/data.tsx
@@ -32,7 +32,7 @@ import {
 import LRU from 'lru-cache';
 import { isDefined } from 'emery';
 import { getAuth } from '../auth';
-import { ViewerContext, SidebarFooter_viewer } from './sidebar-data';
+import { ViewerContext, SidebarFooter_viewer } from './viewer-data';
 import { parseRepoConfig, serializeRepoConfig } from '../repo-config';
 
 export function fetchLocalTree(sha: string) {

--- a/packages/keystatic/src/app/shell/i18n.tsx
+++ b/packages/keystatic/src/app/shell/i18n.tsx
@@ -1,0 +1,8 @@
+import { useLocalizedStringFormatter } from '@react-aria/i18n';
+
+import l10nMessages from '../l10n/index.json';
+
+export function useLocalizedString() {
+  let stringFormatter = useLocalizedStringFormatter(l10nMessages);
+  return stringFormatter;
+}

--- a/packages/keystatic/src/app/shell/panels.tsx
+++ b/packages/keystatic/src/app/shell/panels.tsx
@@ -179,7 +179,7 @@ export const MainPanelLayout = (props: {
               onCollapse={isCollapsed => sidebarState.setOpen(!isCollapsed)}
               ref={sidebarPanelRef}
               className={css({
-                containerName: 'sidebar-panel',
+                containerName: 'app-side-panel',
                 containerType: 'inline-size',
               })}
             >
@@ -195,7 +195,7 @@ export const MainPanelLayout = (props: {
           order={2}
           id={contentPanelId}
           className={css({
-            containerName: 'content-panel',
+            containerName: 'app-main-panel',
             containerType: 'inline-size',
           })}
         >

--- a/packages/keystatic/src/app/shell/panels.tsx
+++ b/packages/keystatic/src/app/shell/panels.tsx
@@ -178,6 +178,10 @@ export const MainPanelLayout = (props: {
               minSize={size.minSize}
               onCollapse={isCollapsed => sidebarState.setOpen(!isCollapsed)}
               ref={sidebarPanelRef}
+              className={css({
+                containerName: 'sidebar-panel',
+                containerType: 'inline-size',
+              })}
             >
               <SidebarPanel hrefBase={basePath} config={config} />
             </Panel>
@@ -187,7 +191,14 @@ export const MainPanelLayout = (props: {
             />
           </>
         )}
-        <Panel order={2} id={contentPanelId}>
+        <Panel
+          order={2}
+          id={contentPanelId}
+          className={css({
+            containerName: 'content-panel',
+            containerType: 'inline-size',
+          })}
+        >
           {children}
         </Panel>
       </PanelGroup>
@@ -298,6 +309,7 @@ function ResizeHandle(props: Omit<PanelResizeHandleProps, 'className'>) {
 
         // hide when disabled
         '&[data-panel-resize-handle-enabled=false]': {
+          position: 'absolute', // take no space when hidden
           visibility: 'hidden',
         },
 

--- a/packages/keystatic/src/app/shell/sidebar.tsx
+++ b/packages/keystatic/src/app/shell/sidebar.tsx
@@ -7,7 +7,7 @@ import {
 import { createContext, ReactNode, useContext, useEffect, useRef } from 'react';
 
 import { Badge } from '@keystar/ui/badge';
-import { Flex } from '@keystar/ui/layout';
+import { Box, Flex } from '@keystar/ui/layout';
 import { Blanket } from '@keystar/ui/overlays';
 import { NavList, NavItem, NavGroup } from '@keystar/ui/nav-list';
 import { css, tokenSchema, transition } from '@keystar/ui/style';
@@ -212,10 +212,10 @@ export function SidebarNav(props: { hrefBase: string; config: Config }) {
                       <Text>{allChangesCount}</Text>
                       <Text visuallyHidden>
                         {pluralize(allChangesCount, {
-                          singular: 'item',
+                          singular: 'change',
+                          plural: 'changes',
                           inclusive: false,
-                        })}{' '}
-                        changed
+                        })}
                       </Text>
                     </Badge>
                   )}
@@ -234,9 +234,15 @@ export function SidebarNav(props: { hrefBase: string; config: Config }) {
                     {collection.label}
                   </Text>
                   {changedData.singletons.has(key) && (
-                    <Badge tone="accent" marginStart="auto">
-                      Changed
-                    </Badge>
+                    <Box
+                      backgroundColor="accentEmphasis"
+                      height="scale.75"
+                      width="scale.75"
+                      borderRadius="full"
+                      marginStart="auto"
+                    >
+                      <Text visuallyHidden>Changed</Text>
+                    </Box>
                   )}
                 </NavItem>
               );

--- a/packages/keystatic/src/app/shell/topbar.tsx
+++ b/packages/keystatic/src/app/shell/topbar.tsx
@@ -46,7 +46,7 @@ import {
 import { ZapLogo } from './common';
 import { useConfig } from './context';
 import { BranchInfoContext, GitHubAppShellDataContext } from './data';
-import { ViewerContext } from './sidebar-data';
+import { useViewer } from './viewer-data';
 import { ColorScheme, useThemeContext } from './theme';
 import { serializeRepoConfig } from '../repo-config';
 
@@ -243,7 +243,7 @@ function ThemeMenu() {
 // -----------------------------------------------------------------------------
 
 function UserMenu() {
-  let user = useContext(ViewerContext);
+  let user = useViewer();
   let config = useConfig();
   const menuItems = useMemo(() => {
     let items = [

--- a/packages/keystatic/src/app/shell/viewer-data.ts
+++ b/packages/keystatic/src/app/shell/viewer-data.ts
@@ -1,5 +1,5 @@
 import { FragmentData, gql } from '@ts-gql/tag/no-transform';
-import { createContext } from 'react';
+import { createContext, useContext } from 'react';
 
 export const SidebarFooter_viewer = gql`
   fragment SidebarFooter_viewer on User {
@@ -14,3 +14,7 @@ export const SidebarFooter_viewer = gql`
 export const ViewerContext = createContext<
   FragmentData<typeof SidebarFooter_viewer> | undefined
 >(undefined);
+
+export function useViewer() {
+  return useContext(ViewerContext);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -625,6 +625,7 @@ importers:
       '@emotion/weak-memoize': ^0.3.0
       '@floating-ui/react': ^0.24.0
       '@hapi/iron': ^7.0.0
+      '@internationalized/string': ^3.1.1
       '@keystar/ui': ^0.1.2
       '@markdoc/markdoc': ^0.3.0
       '@react-aria/focus': ^3.13.0
@@ -711,6 +712,7 @@ importers:
       '@emotion/weak-memoize': 0.3.0
       '@floating-ui/react': 0.24.2_biqbaboplfbrettd7655fr4n2y
       '@hapi/iron': 7.0.1
+      '@internationalized/string': 3.1.1
       '@keystar/ui': link:../../design-system/pkg
       '@markdoc/markdoc': 0.3.0_i2bxsyfskhzbpjanbovidbfj7u
       '@react-aria/focus': 3.13.0_react@18.2.0


### PR DESCRIPTION
Update dashboard page to use card-like interface elements for collections and singletons.

Related app changes:

- declare side and main app panels as "inline-size" containers
- less obtrusive change indicators on sidebar singleton
- create `useLocalizedString` hook, which abstracts l10n message import to one location

Related component library changes:

- adjust `AnchorDOMProps` type; require "href" property and remove (MIME) "type" property
- support "href" (and friends) on `ActionButton` component
- expose `containerQueries` from "style" package
- fix class list declaration issue, which was causing a warning from `FieldButton` component