### PR TITLE
Hide dashboard header on desktop

### DIFF
--- a/.changeset/polite-lizards-share.md
+++ b/.changeset/polite-lizards-share.md
@@ -1,0 +1,5 @@
+---
+"@keystatic/core": patch
+---
+
+Hide dashboard header on desktop

--- a/packages/keystatic/src/app/dashboard/DashboardPage.tsx
+++ b/packages/keystatic/src/app/dashboard/DashboardPage.tsx
@@ -20,7 +20,7 @@ export function DashboardPage(props: { config: Config; basePath: string }) {
 
   return (
     <AppShellRoot containerWidth="large">
-      <AppShellHeader>
+      <AppShellHeader onlyShowOnMobile>
         <Breadcrumbs flex minWidth={0}>
           <Item key="dashboard">{stringFormatter.format('dashboard')}</Item>
         </Breadcrumbs>

--- a/packages/keystatic/src/app/shell/header.tsx
+++ b/packages/keystatic/src/app/shell/header.tsx
@@ -13,7 +13,12 @@ import { css, tokenSchema } from '@keystar/ui/style';
 import { useSidebar } from './sidebar';
 import { AppShellContainer } from '.';
 
-export const AppShellHeader = ({ children }: PropsWithChildren) => {
+type AppShellHeaderProps = { onlyShowOnMobile?: boolean } & PropsWithChildren;
+
+export const AppShellHeader = ({
+  children,
+  onlyShowOnMobile,
+}: AppShellHeaderProps) => {
   const sidebarState = useSidebar();
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const { direction } = useLocale();
@@ -28,6 +33,7 @@ export const AppShellHeader = ({ children }: PropsWithChildren) => {
       borderBottom="muted"
       elementType="header"
       height={{ mobile: 'element.large', tablet: 'scale.700' }}
+      isHidden={onlyShowOnMobile ? { above: 'mobile' } : undefined}
       flexShrink={0}
     >
       <AppShellContainer>


### PR DESCRIPTION
@jossmac this is a pretty blunt prop to add to the `AppShellHeader` component...

... but the dashboard header has been annoying me on desktop views, it feels like useless decoration (compared to the list and entry views where the toolbar has useful navigation / actions in it)

So this approach hides it on above the mobile breakpoint, but shows it when the navigation collapses, which means we keep the header and UI to show the sidebar menu on mobile.

<img width="1180" alt="image" src="https://github.com/Thinkmill/keystatic/assets/872310/775aa53f-c43b-4f33-8ee8-f3430d695447">