### PR TITLE
Update panel size max for sidebar

### DIFF
--- a/.changeset/few-rockets-invite.md
+++ b/.changeset/few-rockets-invite.md
@@ -1,0 +1,5 @@
+---
+"@keystatic/core": patch
+---
+
+Reduced sidebar panel max size

--- a/packages/keystatic/src/app/shell/panels.tsx
+++ b/packages/keystatic/src/app/shell/panels.tsx
@@ -241,10 +241,10 @@ export const ContentPanelLayout = ({
 
 const SIDEBAR_MIN_PERCENT = 14;
 const SIDEBAR_DEFAULT_PERCENT = 20;
-const SIDEBAR_MAX_PERCENT = 48;
+const SIDEBAR_MAX_PERCENT = 40;
 const SIDEBAR_MIN_PX = 180;
 const SIDEBAR_DEFAULT_PX = 260;
-const SIDEBAR_MAX_PX = 600;
+const SIDEBAR_MAX_PX = 360;
 
 const calcDefault = (t: number) =>
   toFixedNumber((SIDEBAR_DEFAULT_PX / t) * 100, 0);


### PR DESCRIPTION
This isn't a particularly big change or comprehensive fix or anything, but it's been annoying me that when I resize windows, the navigation sidebar always ends up too big and then I have to drag it smaller.

So after some tinkering (you're right @jossmac this is really fiddly) I ended up just reducing the maximums to make it "feel better". Let's shrink it and see if anyone comes up with a use-case for it to be meaningfully wider than the new max?

Otherwise it really eats into content entry space when you resize the window, on a normal 13" screen viewport.

**Before**:

<img width="1582" alt="image" src="https://github.com/Thinkmill/keystatic/assets/872310/9a6f675d-10b2-497d-9298-e13a9a5decf6">

**After**:

<img width="1582" alt="image" src="https://github.com/Thinkmill/keystatic/assets/872310/112f9714-e2be-4380-aaad-7cc6e146d078">
