### PR TITLE
Fix incorrect `format` option of Documents in the docs

### DIFF
--- a/docs/src/content/pages/fields/document.mdoc
+++ b/docs/src/content/pages/fields/document.mdoc
@@ -20,9 +20,9 @@ document: fields.document({
 
 ## Formatting options
 
-The WYSIWYG toolbar can be customised to allow a range of formatting options. This is done via the `format` option on the `document` field.
+The WYSIWYG toolbar can be customised to allow a range of formatting options. This is done via the `formatting` option on the `document` field.
 
-Setting `format: true` will enable all formatting options, but you can also specify only a specific subset of options you want to allow.
+Setting `formatting: true` will enable all formatting options, but you can also specify only a specific subset of options you want to allow.
 
 ```ts
 document: fields.document({


### PR DESCRIPTION
Small typo/inconsistency fix :)
Keep up the great work 🙌🏻