### PR TITLE
Update card hover style

### DIFF
--- a/.changeset/spicy-seahorses-remember.md
+++ b/.changeset/spicy-seahorses-remember.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Update card style on dashboard

--- a/packages/keystatic/src/app/dashboard/components.tsx
+++ b/packages/keystatic/src/app/dashboard/components.tsx
@@ -78,7 +78,7 @@ export const DashboardCard = (
                 textDecorationColor: tokenSchema.color.foreground.neutral,
 
                 '::before': {
-                  borderColor: tokenSchema.color.border.accent,
+                  borderColor: tokenSchema.color.border.emphasis,
                 },
               },
               '&:active': {


### PR DESCRIPTION
@jossmac continuing the riff on styling, agree with you the `accent` colour for borders on hover isn't quite where it's at, and I couldn't find anything else I prefer aesthetically than this.

If you're also "this is better", let's go with the `emphasis` token for now, and pick it up back in design with @tuan23 