### PR TITLE
Rename astro-content package

### DIFF
--- a/dev-projects/astro-content/package.json
+++ b/dev-projects/astro-content/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "astro-content",
+  "name": "@example/astro",
   "type": "module",
   "version": "0.0.2",
   "private": true,


### PR DESCRIPTION
Just updating this so it's consistent with other `dev-project` packages, realised it was inconsistent when I was reviewing a changeset.