### PR TITLE
Adding changeset for document field changes

### DIFF
--- a/.changeset/three-bears-weep.md
+++ b/.changeset/three-bears-weep.md
@@ -1,0 +1,41 @@
+---
+'@keystatic/core': patch
+---
+
+The `document` field defaults for formatting have changed to exclude options that require custom Markdoc tags.
+
+See https://keystatic.com/docs/fields/document#formatting-options for the new defaults.
+
+When updating, if you have configured a document field with shorthand for the `formatting` config:
+
+```ts
+fields.document({
+  // ...
+  formatting: true,
+})
+```
+
+To keep the same options you'll need to change you config to:
+
+```ts
+fields.document({
+  // ...
+  formatting: {
+    alignment: true,
+    inlineMarks: {
+      bold: true,
+      code: true,
+      italic: true,
+      keyboard: true,
+      strikethrough: true,
+      subscript: true,
+      superscript: true,
+      underline: true,
+    },
+    listTypes: true,
+    headingLevels: true,
+    blockTypes: true,
+    softBreaks: true,
+  },
+})
+```


### PR DESCRIPTION
These changes were merged to `main` without a changeset, so catching up with this PR (and will review branch protection rules tomorrow!)

**TL;DR** I've updated the document field defaults, and the associated documentation, as mentioned in #531

This closes #504

I'd like to spend some more time with the docs to better explain how to set up custom tags in Markdoc properly if you opt into the (now-off) additional formatting options, so #531 remains open until then, but this means we have one less footman in the meantime.