### PR TITLE
Add meta tag to prevent automatic zoom on mobile

### DIFF
--- a/.changeset/rude-apes-work.md
+++ b/.changeset/rude-apes-work.md
@@ -1,0 +1,5 @@
+---
+"@keystatic/core": patch
+---
+
+Add meta tag to prevent automatic zoom on mobile

--- a/packages/keystatic/src/app/provider.tsx
+++ b/packages/keystatic/src/app/provider.tsx
@@ -240,10 +240,7 @@ export default function Provider({
           href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet"
         />
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
-        />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <UrqlProvider value={useMemo(() => createUrqlClient(config), [config])}>
           {children}
         </UrqlProvider>

--- a/packages/keystatic/src/app/provider.tsx
+++ b/packages/keystatic/src/app/provider.tsx
@@ -240,6 +240,10 @@ export default function Provider({
           href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet"
         />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+        />
         <UrqlProvider value={useMemo(() => createUrqlClient(config), [config])}>
           {children}
         </UrqlProvider>


### PR DESCRIPTION
I've been doing some testing on mobile, and on iOS our Admin UI zooms in on the focused text field slightly, which makes for some weird layout effects in our responsive UI.

Adding this meta tag to the provider (at least in my testing on iOS 16) fixes the issue and makes the mobile experience feel more robust, although it doesn't actually prevent manual zooming (iOS ignores the instruction to prevent zooming entirely, but it does fix the auto-zoom on focus behaviour)

Preventing zooming entirely [isn't recommended](https://www.boia.org/blog/web-accessibility-tips-dont-disable-zooming-yes-even-on-mobile) for accessibility reasons, but this seems like an OK trade-off, since it doesn't _actually_ prevent zoom, and the user experience feels much less broken given the responsive UI otherwise works quite well.

Arguably, we should look at upping the input font size to 16px which would also prevent the default zooming behaviour cc/ @tuan23 @jossmac 