### PR TITLE
Forward ref legacy attributes

### DIFF
--- a/.changeset/modern-clocks-reply.md
+++ b/.changeset/modern-clocks-reply.md
@@ -1,0 +1,5 @@
+---
+'@keystar/ui': patch
+---
+
+omit legacy attributes from `forwardRefWithAs` util

--- a/design-system/pkg/src/utils/ts/forwardRefWithAs.ts
+++ b/design-system/pkg/src/utils/ts/forwardRefWithAs.ts
@@ -13,13 +13,7 @@ export type PropsWithElementType<P = unknown> = P & {
 };
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
-type LegacyAttributes =
-  | 'background'
-  | 'bgColor'
-  | 'color'
-  | 'height'
-  | 'width'
-  | 'manifest';
+type LegacyAttributes = 'background' | 'bgColor' | 'color' | 'height' | 'width';
 
 export type CompWithAsProp<
   BaseProps,

--- a/design-system/pkg/src/utils/ts/forwardRefWithAs.ts
+++ b/design-system/pkg/src/utils/ts/forwardRefWithAs.ts
@@ -12,19 +12,32 @@ export type PropsWithElementType<P = unknown> = P & {
   elementType?: ElementType;
 };
 
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
+type LegacyAttributes =
+  | 'background'
+  | 'bgColor'
+  | 'color'
+  | 'height'
+  | 'width'
+  | 'manifest';
+
 export type CompWithAsProp<
   BaseProps,
   // this is unused for now but kept for future use
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   DefaultElementType extends HTMLTag
 > = (
-  props: BaseProps & {
-    // these types are less specific than they could be but for now
-    // typescript not being ridiculously slow is more important
-    // they could possibly get more specific later
-    elementType?: HTMLTag;
-    ref?: React.Ref<HTMLElement>;
-  } & Omit<AllHTMLAttributes<HTMLElement>, keyof BaseProps>
+  props: Omit<
+    AllHTMLAttributes<HTMLElement>,
+    keyof BaseProps | LegacyAttributes
+  > &
+    BaseProps & {
+      // these types are less specific than they could be but for now
+      // typescript not being ridiculously slow is more important
+      // they could possibly get more specific later
+      elementType?: HTMLTag;
+      ref?: React.Ref<HTMLElement>;
+    }
 ) => ReactElement | null;
 
 /**


### PR DESCRIPTION
Omit legacy attributes from `forwardRefWithAs` utility. Avoid issues like:

```jsx
<Flex color={string | undefined} />
```