### PR TITLE
Cloud image component block

### DIFF
--- a/.changeset/sharp-tools-bathe.md
+++ b/.changeset/sharp-tools-bathe.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fixes and improvements to the cloud image block.

--- a/docs/src/components/document-renderer.tsx
+++ b/docs/src/components/document-renderer.tsx
@@ -183,7 +183,7 @@ const componentBlockRenderers: InferRenderersForComponentBlocks<
       <CloudImage
         alt={alt}
         src={src}
-        height={height}
+        height={height ?? undefined}
         width={width ?? imgMaxWidthPx}
         className="rounded-lg my-2"
       />

--- a/packages/keystatic/src/component-blocks/cloud-image-preview.tsx
+++ b/packages/keystatic/src/component-blocks/cloud-image-preview.tsx
@@ -133,19 +133,7 @@ function ImageDialog(props: {
 
   return (
     <Dialog>
-      <Heading>{image ? 'Edit' : 'Insert'} Cloud Image</Heading>
-      <Header>
-        <Button
-          href={imageLibraryURL}
-          target="_blank"
-          rel="noreferrer"
-          prominence="low"
-          tone="accent"
-        >
-          <Text>Open Image Library</Text>
-          <Icon src={externalLinkIcon} />
-        </Button>
-      </Header>
+      <Heading>Cloud image</Heading>
       <Content>
         <Flex
           elementType="form"
@@ -166,13 +154,24 @@ function ImageDialog(props: {
             onKeyDown={e => {
               if (e.code === 'Backspace' || e.code === 'Delete') {
                 setState(cleanImageData());
+              } else {
+                e.continuePropagation();
               }
             }}
             value={state.src}
             description={
-              image
-                ? undefined
-                : 'Copy an Image URL from the Image Library and paste into this field to insert it.'
+              <Text>
+                Copy an image URL from the{' '}
+                <TextLink
+                  prominence="high"
+                  href={imageLibraryURL}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Image Library
+                </TextLink>{' '}
+                and paste it into this field.
+              </Text>
             }
             endElement={
               status === 'loading' ? (
@@ -189,12 +188,10 @@ function ImageDialog(props: {
                   />
                 </Flex>
               ) : state.src ? (
-                <ActionButton
-                  prominence="low"
+                <ClearButton
                   onPress={() => setState(cleanImageData())}
-                >
-                  <Icon src={xIcon} />
-                </ActionButton>
+                  preventFocus
+                />
               ) : null
             }
           />

--- a/packages/keystatic/src/component-blocks/cloud-image-schema.tsx
+++ b/packages/keystatic/src/component-blocks/cloud-image-schema.tsx
@@ -1,3 +1,4 @@
+import { integer } from '../form/fields/integer';
 import { text } from '../form/fields/text';
 
 export const cloudImageSchema = {
@@ -12,10 +13,10 @@ export const cloudImageSchema = {
   alt: text({
     label: 'Alt text',
   }),
-  height: text({
+  height: integer({
     label: 'Height',
   }),
-  width: text({
+  width: integer({
     label: 'Width',
   }),
 };


### PR DESCRIPTION
Fixes and improvements to the cloud image block:

- switch to `integer` for dimension attributes
- improve the appearance and UX of the dialog UI
- insert opens the dialog and reveals a simplified, non-interactive placeholder
- escape/cancel closes the dialog and removes the unused block (when no URL provided)
- minor aesthetic improvements to the image preview