### PR TITLE
Fix Firefox bug cleaning up cloud image components

### DIFF
--- a/packages/keystatic/src/component-blocks/cloud-image-preview.tsx
+++ b/packages/keystatic/src/component-blocks/cloud-image-preview.tsx
@@ -265,7 +265,7 @@ function Placeholder(props: {
   const closeAndCleanup = () => {
     state.close();
     focusWithPreviousSelection(editor);
-    editor.deleteBackward('block');
+    props.onRemove();
   };
 
   return (
@@ -277,9 +277,12 @@ function Placeholder(props: {
         gap="regular"
         height="element.large"
         paddingX="large"
+        onClick={() => {
+          if (!state.isOpen) state.open();
+        }}
       >
         <Icon src={imageIcon} />
-        <Text>Cloud image, awaiting configuration…</Text>
+        <Text>Cloud image{state.isOpen ? '' : ' (click to configure)'}</Text>
       </Flex>
       <DialogContainer onDismiss={closeAndCleanup}>
         {state.isOpen && (
@@ -338,11 +341,7 @@ function ImagePreview({
             borderTop={selected ? 'color.alias.borderFocused' : 'neutral'}
           >
             <VStack flex="1" gap="medium" justifyContent="center">
-              {image.alt ? (
-                <Text truncate={2}>{image.alt}</Text>
-              ) : (
-                <Text truncate>(missing alt text)</Text>
-              )}
+              {image.alt ? <Text truncate={2}>{image.alt}</Text> : null}
               <Text color="neutralTertiary" size="small">
                 {image.width} × {image.height}
               </Text>


### PR DESCRIPTION
This fixes a bug where Firefox doesn't handle Slate focus as expected, and leaves the image placeholder.

It also adds some defensive text and a handler so you can clearly click on an image placeholder to bring up the dialog if you somehow end up with an invalid tag in your Markdoc document.

(and I removed the "no alt text" state, not a fan tbh)

@jossmac over to you for review, there may be better ways of handling this generally but this does make Firefox more robust for now.