### PR TITLE
Improve cloud image component editing

### DIFF
--- a/packages/keystatic/src/component-blocks/cloud-image-preview.tsx
+++ b/packages/keystatic/src/component-blocks/cloud-image-preview.tsx
@@ -61,7 +61,7 @@ function ImageDialog(props: {
 }) {
   const { image, onCancel, onChange, onClose } = props;
   const [state, setState] = useState<ImageData>(cleanImageData(image));
-  const [status, setStatus] = useState<ImageStatus>('');
+  const [status, setStatus] = useState<ImageStatus>(image ? 'good' : '');
   const [dimensions, setDimensions] = useState<ImageDimensions>(
     cleanImageData()
   );


### PR DESCRIPTION
Simple fix to make the "edit image" modal show the Alt, Width and Height immediately; speeds up the workflow quite a bit.

The image URL is still requested in the background, which means that by the time you interact with the fields, the size detection works as expected.