### PR TITLE
Remove status column in collection view in local mode

### DIFF
--- a/packages/keystatic/src/app/CollectionPage.tsx
+++ b/packages/keystatic/src/app/CollectionPage.tsx
@@ -37,6 +37,7 @@ import { useTree, TreeData } from './shell/data';
 import { PageRoot, PageHeader } from './shell/page';
 import { getCollectionPath, getEntriesInCollectionWithTreeKey } from './utils';
 import { notFound } from './not-found';
+import { Flex } from '@keystar/ui/layout';
 
 type CollectionPageProps = {
   collection: string;
@@ -263,6 +264,19 @@ function CollectionTable(
     return [...filteredItems].sort(sortByDescriptor(sortDescriptor));
   }, [filteredItems, sortDescriptor]);
 
+  const columns =
+    props.config.storage.kind === 'local'
+      ? [{ name: 'Name', key: 'name' }]
+      : [
+          { name: 'Name', key: 'name' },
+          {
+            name: 'Status',
+            key: 'status',
+            minWidth: 140,
+            width: '20%',
+          },
+        ];
+
   return (
     <TableView
       aria-labelledby="page-title"
@@ -298,17 +312,7 @@ function CollectionTable(
         },
       })}
     >
-      <TableHeader
-        columns={[
-          { name: 'Name', key: 'name' },
-          {
-            name: 'Status',
-            key: 'status',
-            minWidth: 140,
-            width: '20%',
-          },
-        ]}
-      >
+      <TableHeader columns={columns}>
         {({ name, key, ...options }) => (
           <Column key={key} isRowHeader allowsSorting {...options}>
             {name}
@@ -318,14 +322,24 @@ function CollectionTable(
       <TableBody items={sortedItems}>
         {item => (
           <Row key={item.name}>
-            <Cell textValue={item.name}>
-              <Text weight="medium">{item.name}</Text>
-            </Cell>
-            <Cell textValue={item.status}>
-              <StatusLight tone={statusTones[item.status]}>
-                {item.status}
-              </StatusLight>
-            </Cell>
+            {props.config.storage.kind === 'local' ? (
+              <Cell textValue={item.name}>
+                <Flex height="element.small" alignItems="center">
+                  <Text weight="medium">{item.name}</Text>
+                </Flex>
+              </Cell>
+            ) : (
+              <>
+                <Cell textValue={item.name}>
+                  <Text weight="medium">{item.name}</Text>
+                </Cell>
+                <Cell textValue={item.status}>
+                  <StatusLight tone={statusTones[item.status]}>
+                    {item.status}
+                  </StatusLight>
+                </Cell>
+              </>
+            )}
           </Row>
         )}
       </TableBody>


### PR DESCRIPTION
I noticed that since the latest UI refresh, we're showing "unchanged" status for all the collection items in the list view when in local mode (i.e `{ storage: { mode: 'local' } }`)

That's really misleading, so this PR fixes it.

tbh not my finest work, the layout (esp. with row columns) is pretty finicky but I couldn't pull the cells out into a separate component without messing around with types (i.e the type of `item` is just inferred from the scope, so specifying it as a prop type in another component is beyond me but I'd love to see how it's done)

I also added a flex container to the label cells matching the height of the `StatusLight` component because otherwise the rows squish up and it's not my intention that the layout actually changes in local mode.

So, happy to get advice on how to structure this better, but it's definitely an improvement to not show invalid status now:
<img width="1582" alt="image" src="https://github.com/Thinkmill/keystatic/assets/872310/7b91247a-8bcd-4131-90a7-324e5b23ff10">

(on another note, I found [NodeGit](https://www.nodegit.org) and we ... could actually pull the changed status for local mode, but that feels like an adventure for another time)
