### PR TITLE
cloud image component block deletion

### DIFF
--- a/packages/keystatic/src/component-blocks/cloud-image-preview.tsx
+++ b/packages/keystatic/src/component-blocks/cloud-image-preview.tsx
@@ -265,7 +265,7 @@ function Placeholder(props: {
   const closeAndCleanup = () => {
     state.close();
     focusWithPreviousSelection(editor);
-    editor.deleteBackward('block');
+    props.onRemove();
   };
 
   return (


### PR DESCRIPTION
Works in all browsers. Some undesirable cursor movement, but better than before.