### PR TITLE
Main panel layout

### DIFF
--- a/.changeset/dull-ties-battle.md
+++ b/.changeset/dull-ties-battle.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Refactor `MainPanelLayout` to improve UX.

--- a/packages/keystatic/src/app/shell/panels.tsx
+++ b/packages/keystatic/src/app/shell/panels.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@keystar/ui/layout';
 import {
   SplitView,
   SplitPanePrimary,
@@ -27,32 +26,24 @@ export const MainPanelLayout = (props: {
   let ref = useRef<HTMLDivElement>(null);
   let context = useContentPanelState(ref);
 
-  // no split view on small devices
-  if (isBelowDesktop) {
-    return (
-      <ContentPanelProvider value={context}>
-        <SidebarDialog hrefBase={basePath} config={config} />
-        <Box flex ref={ref}>
-          {children}
-        </Box>
-      </ContentPanelProvider>
-    );
-  }
-
   return (
     <ContentPanelProvider value={context}>
       <SplitView
         autoSaveId="keystatic-app-split-view"
-        isCollapsed={!sidebarState.isOpen}
+        isCollapsed={isBelowDesktop || !sidebarState.isOpen}
         onCollapseChange={sidebarState.toggle}
         defaultSize={260}
         minSize={180}
         maxSize={400}
         flex
       >
-        <SplitPanePrimary>
-          <SidebarPanel hrefBase={basePath} config={config} />
-        </SplitPanePrimary>
+        {isBelowDesktop ? (
+          <SidebarDialog hrefBase={basePath} config={config} />
+        ) : (
+          <SplitPanePrimary>
+            <SidebarPanel hrefBase={basePath} config={config} />
+          </SplitPanePrimary>
+        )}
         <SplitPaneSecondary ref={ref}>{children}</SplitPaneSecondary>
       </SplitView>
     </ContentPanelProvider>


### PR DESCRIPTION
Users may resize their window on larger devices to be below the "desktop" breakpoint, which previously caused a re-render of the entire tree. Avoid conditional rendering wherever possible, and strictly limit to leaf nodes when necessary.