### PR TITLE
Export CloudImageProps

### DIFF
--- a/.changeset/seven-suits-train.md
+++ b/.changeset/seven-suits-train.md
@@ -1,0 +1,5 @@
+---
+"@keystatic/core": patch
+---
+
+Export `CloudImageProps` type from the `@keystatic/core/component-blocks` entrypoint

--- a/packages/keystatic/src/component-blocks/cloud-image-preview.tsx
+++ b/packages/keystatic/src/component-blocks/cloud-image-preview.tsx
@@ -31,16 +31,16 @@ import { useConfig } from '../app/shell/context';
 import { focusWithPreviousSelection } from '../form/fields/document/DocumentEditor/ui-utils';
 import { getSplitCloudProject, isCloudConfig } from '../app/utils';
 
-export type ImageData = {
+export type CloudImageProps = {
   src: string;
   width?: number;
   height?: number;
   alt: string;
 };
 
-type ImageDimensions = Pick<ImageData, 'width' | 'height'>;
+type ImageDimensions = Pick<CloudImageProps, 'width' | 'height'>;
 
-export function parseImageData(data: string): ImageData {
+export function parseImageData(data: string): CloudImageProps {
   try {
     const parsed: unknown = JSON.parse(data);
     if (
@@ -76,18 +76,18 @@ export function parseImageData(data: string): ImageData {
   return { src: data, alt: '' };
 }
 
-export const emptyImageData: ImageData = { src: '', alt: '' };
+export const emptyImageData: CloudImageProps = { src: '', alt: '' };
 
 type ImageStatus = '' | 'loading' | 'good' | 'error';
 
 function ImageDialog(props: {
-  image?: ImageData;
+  image?: CloudImageProps;
   onCancel: () => void;
-  onChange: (data: ImageData) => void;
+  onChange: (data: CloudImageProps) => void;
   onClose: () => void;
 }) {
   const { image, onCancel, onChange, onClose } = props;
-  const [state, setState] = useState<ImageData>(emptyImageData);
+  const [state, setState] = useState<CloudImageProps>(emptyImageData);
   const [status, setStatus] = useState<ImageStatus>(image ? 'good' : '');
   const [dimensions, setDimensions] = useState<ImageDimensions>(emptyImageData);
   const formId = useId();
@@ -250,7 +250,7 @@ function ImageDialog(props: {
 }
 
 function Placeholder(props: {
-  onChange: (data: ImageData) => void;
+  onChange: (data: CloudImageProps) => void;
   onRemove: () => void;
 }) {
   const editor = useSlateStatic();
@@ -301,8 +301,8 @@ function ImagePreview({
   onChange,
   onRemove,
 }: {
-  image: ImageData;
-  onChange: (data: ImageData) => void;
+  image: CloudImageProps;
+  onChange: (data: CloudImageProps) => void;
   onRemove: () => void;
 }) {
   const selected = useSelected();

--- a/packages/keystatic/src/component-blocks/cloud-image.tsx
+++ b/packages/keystatic/src/component-blocks/cloud-image.tsx
@@ -2,6 +2,8 @@ import { component } from '..';
 import { CloudImagePreview } from './cloud-image-preview';
 import { cloudImageSchema } from './cloud-image-schema';
 
+export type { CloudImageProps } from './cloud-image-preview';
+
 /** @deprecated Experimental */
 export function cloudImage(args: { label: string }) {
   return component({

--- a/packages/keystatic/src/component-blocks/cloud-image.tsx
+++ b/packages/keystatic/src/component-blocks/cloud-image.tsx
@@ -2,8 +2,6 @@ import { component } from '..';
 import { CloudImagePreview } from './cloud-image-preview';
 import { cloudImageSchema } from './cloud-image-schema';
 
-export type { CloudImageProps } from './cloud-image-preview';
-
 /** @deprecated Experimental */
 export function cloudImage(args: { label: string }) {
   return component({

--- a/packages/keystatic/src/component-blocks/index.tsx
+++ b/packages/keystatic/src/component-blocks/index.tsx
@@ -1,1 +1,2 @@
 export { cloudImage } from './cloud-image';
+export type { CloudImageProps } from './cloud-image-preview';

--- a/packages/keystatic/src/form/fields/cloudImage/ui.tsx
+++ b/packages/keystatic/src/form/fields/cloudImage/ui.tsx
@@ -18,18 +18,12 @@ import {
   emptyImageData,
   parseImageData,
   useImageLibraryURL,
+  CloudImageProps,
 } from '../../../component-blocks/cloud-image-preview';
 import { isValidURL } from '../document/DocumentEditor/isValidURL';
 import { useEventCallback } from '../document/DocumentEditor/ui-utils';
 
-type ImageData = {
-  src: string;
-  width?: number;
-  height?: number;
-  alt: string;
-};
-
-type ImageDimensions = Pick<ImageData, 'width' | 'height'>;
+type ImageDimensions = Pick<CloudImageProps, 'width' | 'height'>;
 
 type ImageStatus = '' | 'loading' | 'good' | 'error';
 
@@ -54,11 +48,11 @@ function useImageDimensions(src: string) {
 }
 
 function ImageField(props: {
-  image: ImageData;
+  image: CloudImageProps;
   isRequired?: boolean;
   forceValidation?: boolean;
   autoFocus?: boolean;
-  onChange: (data: ImageData) => void;
+  onChange: (data: CloudImageProps) => void;
 }) {
   const { image, onChange } = props;
   const [status, setStatus] = useState<ImageStatus>(image.src ? 'good' : '');


### PR DESCRIPTION
I was watching @lukebennett88 implement a `cloudImage` component block renderer in his site, and he had to guess/recreate this type in his front-end.

Seems better for us to export it and allow people to import the same definition we're using internally.

(I also consolidated the duplicate types between the component block and the field, since other code is also being shared)