### PR TITLE
Fix website reader path in production

### DIFF
--- a/docs/keystatic.config.tsx
+++ b/docs/keystatic.config.tsx
@@ -227,8 +227,11 @@ const markdocConfig: Config = {
   },
 };
 
-const shouldUseCloudStorage = process.env.NODE_ENV === 'production';
+const shouldUseCloudStorage = true; // process.env.NODE_ENV === 'production';
 const pathPrefix = shouldUseCloudStorage ? 'docs/' : '';
+export const readerPath = shouldUseCloudStorage
+  ? process.cwd().replace(/\/docs/, '')
+  : process.cwd();
 
 export default config({
   storage: {

--- a/docs/src/app/(public)/docs/[...slug]/page.tsx
+++ b/docs/src/app/(public)/docs/[...slug]/page.tsx
@@ -1,13 +1,11 @@
-import { createReader } from '@keystatic/core/reader';
-import { TableOfContents } from '../../../../components/navigation/table-of-contents';
-import DocumentRenderer from '../../../../components/document-renderer';
-import keystaticConfig from '../../../../../keystatic.config';
 import { notFound } from 'next/navigation';
 import { Metadata, ResolvingMetadata } from 'next';
-import { H1_ID } from '../../../../constants';
 import slugify from '@sindresorhus/slugify';
 
-const reader = createReader(process.cwd(), keystaticConfig);
+import { TableOfContents } from '../../../../components/navigation/table-of-contents';
+import DocumentRenderer from '../../../../components/document-renderer';
+import { reader } from '../../../../utils/reader';
+import { H1_ID } from '../../../../constants';
 
 type DocsProps = {
   params: { slug: string[] };

--- a/docs/src/utils/reader.ts
+++ b/docs/src/utils/reader.ts
@@ -1,7 +1,7 @@
 import { createReader } from '@keystatic/core/reader';
-import keystaticConfig from '../../keystatic.config';
+import keystaticConfig, { readerPath } from '../../keystatic.config';
 
-export const reader = createReader(process.cwd(), keystaticConfig);
+export const reader = createReader(readerPath, keystaticConfig);
 
 export async function getNavigationMap() {
   const navigation = await reader.singletons.navigation.read();


### PR DESCRIPTION
This fixes the 404s in the docs website, and removes a duplicate `reader` creation.

Background:

* We updated the collection paths in production to get keystatic working when deployed from the monorepo
* However, the reader is basing its paths on `process.cwd()` which is _not_ expected to be the root of the monorepo
* This was causing the Reder to fail to find `.mdoc` files in collections that were found in development mode