### PR TITLE
Website component blocks cleanup

### DIFF
--- a/docs/keystatic.config.tsx
+++ b/docs/keystatic.config.tsx
@@ -1,174 +1,16 @@
-import {
-  config,
-  fields,
-  collection,
-  singleton,
-  component,
-  NotEditable,
-} from '@keystatic/core';
+import { config, fields, collection, singleton } from '@keystatic/core';
 import { __experimental_markdoc_field } from '@keystatic/core/form/fields/markdoc';
-import { CloudImagePreview } from './src/components/previews/CloudImagePreview';
-import { Config } from '@markdoc/markdoc';
 import { cloudImage } from '@keystatic/core/component-blocks';
+import { Config } from '@markdoc/markdoc';
+
+import { aside, embed, fieldDemo, tags } from './src/component-blocks';
 
 export const componentBlocks = {
-  aside: component({
-    preview: props => {
-      return (
-        <div
-          style={{
-            display: 'flex',
-            gap: '0.5rem',
-            borderLeft: '3px',
-            borderLeftStyle: 'solid',
-            borderLeftColor: '#eee',
-            paddingLeft: '0.5rem',
-          }}
-        >
-          <NotEditable>{props.fields.icon.value}</NotEditable>
-          <div>{props.fields.content.element}</div>
-        </div>
-      );
-    },
-    label: 'Aside',
-    schema: {
-      icon: fields.text({
-        label: 'Emoji icon...',
-      }),
-      content: fields.child({
-        kind: 'block',
-        placeholder: 'Aside...',
-        formatting: {
-          inlineMarks: 'inherit',
-          softBreaks: 'inherit',
-          listTypes: 'inherit',
-        },
-        links: 'inherit',
-      }),
-    },
-  }),
-  'cloud-image': component({
-    preview: CloudImagePreview,
-    label: 'Cloud image',
-    schema: {
-      href: fields.text({
-        label: 'Href *',
-        validation: {
-          length: {
-            min: 1,
-          },
-        },
-      }),
-      alt: fields.text({
-        label: 'Alt text',
-        description:
-          'Include an alt text description or leave blank for decorative images',
-      }),
-      height: fields.text({
-        label: 'Height',
-        description:
-          'The intrinsic height of the image, in pixels. Must be an integer without a unit - e.g. 100',
-      }),
-      width: fields.text({
-        label: 'Width',
-        description:
-          'The intrinsic width of the image, in pixels. Must be an integer without a unit - e.g. 100',
-      }),
-      srcSet: fields.text({
-        label: 'Srcset',
-        description: 'Optionally override the defualt srcset',
-      }),
-      sizes: fields.text({
-        label: 'Sizes',
-        description: 'Optionally override the default sizes',
-      }),
-      caption: fields.text({
-        label: 'Caption',
-        description:
-          'Optionally add a caption to display in small text below the image',
-      }),
-    },
-    chromeless: false,
-  }),
-  'cloud-image-2': cloudImage({ label: 'Cloud image 2' }),
-  tags: component({
-    preview: props => {
-      return (
-        <div style={{ display: 'flex', gap: '1rem' }}>
-          {props.fields.tags.value.map(tag => (
-            <span
-              style={{
-                border: 'solid 1px #ddd',
-                padding: '0.25rem 0.5rem',
-                borderRadius: '20px',
-                fontSize: '11px',
-              }}
-            >
-              {tag}
-            </span>
-          ))}
-        </div>
-      );
-    },
-    label: 'Project',
-    schema: {
-      tags: fields.multiselect({
-        label: 'Project tags',
-        options: [
-          { label: 'Local', value: 'Local' },
-          { label: 'Github', value: 'github' },
-          { label: 'New project', value: 'New project' },
-          { label: 'Existing project', value: 'Existing project' },
-          { label: 'Astro', value: 'Astro' },
-          { label: 'Next.js', value: 'Next.js' },
-        ],
-      }),
-    },
-    chromeless: false,
-  }),
-  fieldDemo: component({
-    preview: props => {
-      return <div>{props.fields.field.value}</div>;
-    },
-    label: 'Field demo',
-    schema: {
-      field: fields.select({
-        label: 'Field',
-        defaultValue: 'text',
-        options: [
-          { label: 'Date', value: 'date' },
-          { label: 'Datetime', value: 'datetime' },
-          { label: 'File', value: 'file' },
-          { label: 'Image', value: 'image' },
-          { label: 'Integer', value: 'integer' },
-          { label: 'Multiselect', value: 'multiselect' },
-          { label: 'Select', value: 'select' },
-          { label: 'Slug', value: 'slug' },
-          { label: 'Text', value: 'text' },
-          { label: 'URL', value: 'url' },
-        ],
-      }),
-    },
-    chromeless: false,
-  }),
-  embed: component({
-    label: 'Embed',
-    preview: props => <div>{props.fields.embedCode.value}</div>,
-    schema: {
-      mediaType: fields.select({
-        label: 'Media type',
-        options: [
-          { label: 'Video', value: 'video' },
-          { label: 'Tweet', value: 'tweet' },
-        ],
-        defaultValue: 'video',
-      }),
-      embedCode: fields.text({
-        label: 'Embed code',
-        multiline: true,
-      }),
-    },
-  }),
+  aside,
+  'cloud-image': cloudImage({ label: 'Cloud Image' }),
+  tags,
+  'field-demo': fieldDemo,
+  embed,
 };
 
 const formatting = {
@@ -227,7 +69,7 @@ const markdocConfig: Config = {
   },
 };
 
-const shouldUseCloudStorage = true; // process.env.NODE_ENV === 'production';
+const shouldUseCloudStorage = process.env.NODE_ENV === 'production';
 const pathPrefix = shouldUseCloudStorage ? 'docs/' : '';
 export const readerPath = shouldUseCloudStorage
   ? process.cwd().replace(/\/docs/, '')

--- a/docs/src/component-blocks/aside.tsx
+++ b/docs/src/component-blocks/aside.tsx
@@ -1,0 +1,33 @@
+import { fields, component, NotEditable } from '@keystatic/core';
+
+export const aside = component({
+  preview: props => {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          gap: '0.5rem',
+        }}
+      >
+        <NotEditable>{props.fields.icon.value}</NotEditable>
+        <div>{props.fields.content.element}</div>
+      </div>
+    );
+  },
+  label: 'Aside',
+  schema: {
+    icon: fields.text({
+      label: 'Emoji icon...',
+    }),
+    content: fields.child({
+      kind: 'block',
+      placeholder: 'Aside...',
+      formatting: {
+        inlineMarks: 'inherit',
+        softBreaks: 'inherit',
+        listTypes: 'inherit',
+      },
+      links: 'inherit',
+    }),
+  },
+});

--- a/docs/src/component-blocks/embed.tsx
+++ b/docs/src/component-blocks/embed.tsx
@@ -1,0 +1,32 @@
+import { fields, component, NotEditable } from '@keystatic/core';
+
+const codeFontFamily =
+  'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace';
+
+export const embed = component({
+  label: 'Embed',
+  preview: props => (
+    <NotEditable
+      style={{
+        fontFamily: codeFontFamily,
+        fontSize: '0.8rem',
+      }}
+    >
+      {props.fields.embedCode.value || '(no embed code set)'}
+    </NotEditable>
+  ),
+  schema: {
+    mediaType: fields.select({
+      label: 'Media type',
+      options: [
+        { label: 'Video', value: 'video' },
+        { label: 'Tweet', value: 'tweet' },
+      ],
+      defaultValue: 'video',
+    }),
+    embedCode: fields.text({
+      label: 'Embed code',
+      multiline: true,
+    }),
+  },
+});

--- a/docs/src/component-blocks/field-demo.tsx
+++ b/docs/src/component-blocks/field-demo.tsx
@@ -1,0 +1,30 @@
+import { fields, component, NotEditable } from '@keystatic/core';
+
+export const fieldDemo = component({
+  preview: props => {
+    return (
+      <NotEditable>
+        Field: {props.fields.field.value || '(none selected)'}
+      </NotEditable>
+    );
+  },
+  label: 'Field demo',
+  schema: {
+    field: fields.select({
+      label: 'Field',
+      defaultValue: 'text',
+      options: [
+        { label: 'Date', value: 'date' },
+        { label: 'Datetime', value: 'datetime' },
+        { label: 'File', value: 'file' },
+        { label: 'Image', value: 'image' },
+        { label: 'Integer', value: 'integer' },
+        { label: 'Multiselect', value: 'multiselect' },
+        { label: 'Select', value: 'select' },
+        { label: 'Slug', value: 'slug' },
+        { label: 'Text', value: 'text' },
+        { label: 'URL', value: 'url' },
+      ],
+    }),
+  },
+});

--- a/docs/src/component-blocks/index.ts
+++ b/docs/src/component-blocks/index.ts
@@ -1,0 +1,4 @@
+export { aside } from './aside';
+export { embed } from './embed';
+export { fieldDemo } from './field-demo';
+export { tags } from './tags';

--- a/docs/src/component-blocks/tags.tsx
+++ b/docs/src/component-blocks/tags.tsx
@@ -1,0 +1,39 @@
+import { fields, component, NotEditable } from '@keystatic/core';
+
+export const tags = component({
+  preview: props => {
+    return (
+      <NotEditable>
+        <div style={{ display: 'flex', gap: '1rem' }}>
+          {props.fields.tags.value.map(tag => (
+            <span
+              style={{
+                border: 'solid 1px #ddd',
+                padding: '0.25rem 0.5rem',
+                borderRadius: '20px',
+                fontSize: '11px',
+              }}
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </NotEditable>
+    );
+  },
+  label: 'Project',
+  schema: {
+    tags: fields.multiselect({
+      label: 'Project tags',
+      options: [
+        { label: 'Local', value: 'Local' },
+        { label: 'Github', value: 'github' },
+        { label: 'New project', value: 'New project' },
+        { label: 'Existing project', value: 'Existing project' },
+        { label: 'Astro', value: 'Astro' },
+        { label: 'Next.js', value: 'Next.js' },
+      ],
+    }),
+  },
+  chromeless: false,
+});

--- a/docs/src/components/document-renderer.tsx
+++ b/docs/src/components/document-renderer.tsx
@@ -162,7 +162,6 @@ const componentBlockRenderers: InferRenderersForComponentBlocks<
         src={src}
         height={height ?? undefined}
         width={width ?? imgMaxWidthPx}
-        sizes={`(max-width: 375px) 375px, ${imgMaxWidthPx}px`}
         className="rounded-lg my-2"
       />
     );

--- a/docs/src/components/document-renderer.tsx
+++ b/docs/src/components/document-renderer.tsx
@@ -153,31 +153,7 @@ const componentBlockRenderers: InferRenderersForComponentBlocks<
       </div>
     );
   },
-  'cloud-image': ({
-    href: src,
-    alt,
-    sizes,
-    height,
-    width,
-    srcSet,
-    caption,
-  }) => {
-    const imgMaxWidthPx = `${parseFloat(CONTENT_MAX_WIDTH_DESKTOP) * 16}`;
-
-    return (
-      <CloudImage
-        alt={alt}
-        src={src}
-        height={height}
-        width={width ?? imgMaxWidthPx}
-        srcSet={srcSet}
-        sizes={sizes || `(max-width: 375px) 375px, ${imgMaxWidthPx}px`}
-        className="rounded-lg my-2"
-        caption={caption}
-      />
-    );
-  },
-  'cloud-image-2': ({ src, alt, height, width }) => {
+  'cloud-image': ({ src, alt, height, width }) => {
     const imgMaxWidthPx = `${parseFloat(CONTENT_MAX_WIDTH_DESKTOP) * 16}`;
 
     return (
@@ -186,6 +162,7 @@ const componentBlockRenderers: InferRenderersForComponentBlocks<
         src={src}
         height={height ?? undefined}
         width={width ?? imgMaxWidthPx}
+        sizes={`(max-width: 375px) 375px, ${imgMaxWidthPx}px`}
         className="rounded-lg my-2"
       />
     );
@@ -206,7 +183,7 @@ const componentBlockRenderers: InferRenderersForComponentBlocks<
       </div>
     );
   },
-  fieldDemo: ({ field }) => {
+  'field-demo': ({ field }) => {
     switch (field) {
       case 'text':
         return <TextFieldDemo />;

--- a/docs/src/content/pages/entry-layout.mdoc
+++ b/docs/src/content/pages/entry-layout.mdoc
@@ -31,10 +31,10 @@ blog: collection({
 With the above config, the `blog` entry layout will put the `body` field front and center. All the other fields will be placed in a sidebar:
 
 {% cloud-image
-   href="https://keystatic.io/images/keystatic-docs/entrylayout-content.png"
+   src="https://keystatic.io/images/keystatic-docs/entrylayout-content.png"
    alt="Screenshot of Keystatic's \"content\" entry layout."
-   height="939"
-   width="1496" /%}
+   height=939
+   width=1496 /%}
 
 You can think about&nbsp;`entryLayout: "content"`&nbsp;as the "focus" copywriting mode!
 

--- a/docs/src/content/pages/fields/date.mdoc
+++ b/docs/src/content/pages/fields/date.mdoc
@@ -2,7 +2,7 @@
 title: Date field
 summary: The date field stores a Date string.
 ---
-{% fieldDemo field="date" /%}
+{% field-demo field="date" /%}
 
 The `date` field stores a Date string, collected from an `<input type="date">` form field.
 

--- a/docs/src/content/pages/fields/datetime.mdoc
+++ b/docs/src/content/pages/fields/datetime.mdoc
@@ -2,7 +2,7 @@
 title: Datetime field
 summary: The datetime field stores a Datetime string.
 ---
-{% fieldDemo field="datetime" /%}
+{% field-demo field="datetime" /%}
 
 The `datetime` field stores a Datetime string, collected from an `<input type="datetime-local" />` form field.
 

--- a/docs/src/content/pages/fields/file.mdoc
+++ b/docs/src/content/pages/fields/file.mdoc
@@ -2,7 +2,7 @@
 title: File field
 summary: The file field is used to store a file.
 ---
-{% fieldDemo field="file" /%}
+{% field-demo field="file" /%}
 
 The `file` field is used to store a file. In the Admin UI it renders a file picker component.
 

--- a/docs/src/content/pages/fields/image.mdoc
+++ b/docs/src/content/pages/fields/image.mdoc
@@ -2,7 +2,7 @@
 title: Image field
 summary: The image field is used to store an image.
 ---
-{% fieldDemo field="image" /%}
+{% field-demo field="image" /%}
 
 The `image` field is used to store an image. In the Admin UI it renders an image picker component.
 

--- a/docs/src/content/pages/fields/integer.mdoc
+++ b/docs/src/content/pages/fields/integer.mdoc
@@ -2,7 +2,7 @@
 title: Integer field
 summary: The integer field is used to store a number.
 ---
-{% fieldDemo field="integer" /%}
+{% field-demo field="integer" /%}
 
 The `integer` field is used to store a number.
 

--- a/docs/src/content/pages/fields/multiselect.mdoc
+++ b/docs/src/content/pages/fields/multiselect.mdoc
@@ -2,7 +2,7 @@
 title: Multiselect field
 summary: The multiselect field allows you to select zero, one or multiple options.
 ---
-{% fieldDemo field="multiselect" /%}
+{% field-demo field="multiselect" /%}
 
 The `multiselect` field is similar to the [select field](/docs/fields/select) but allows you to select zero, one or multiple options.
 

--- a/docs/src/content/pages/fields/select.mdoc
+++ b/docs/src/content/pages/fields/select.mdoc
@@ -2,7 +2,7 @@
 title: Select field
 summary: The select field is used for single option selection.
 ---
-{% fieldDemo field="select" /%}
+{% field-demo field="select" /%}
 
 The `select` field displays a select input for single option selection.
 

--- a/docs/src/content/pages/fields/slug.mdoc
+++ b/docs/src/content/pages/fields/slug.mdoc
@@ -4,7 +4,7 @@ summary: >-
   The slug field auto-generates a URL-friendly string alongside another text
   string.
 ---
-{% fieldDemo field="slug" /%}
+{% field-demo field="slug" /%}
 
 The `slug` field auto-generates a URL-friendly string alongside another text string.
 

--- a/docs/src/content/pages/fields/text.mdoc
+++ b/docs/src/content/pages/fields/text.mdoc
@@ -2,7 +2,7 @@
 title: Text field
 summary: The text field is used to store a text string.
 ---
-{% fieldDemo field="text" /%}
+{% field-demo field="text" /%}
 
 The `text` field is used to store a text string. It renders a single line `<input type="text">` in the Admin UI by default.
 

--- a/docs/src/content/pages/fields/url.mdoc
+++ b/docs/src/content/pages/fields/url.mdoc
@@ -2,7 +2,7 @@
 title: URL field
 summary: The url field stores a string that is a sanitised URL.
 ---
-{% fieldDemo field="url" /%}
+{% field-demo field="url" /%}
 
 The `url` field stores a string that is a sanitised URL. It uses `@braintree/sanitize-url` under the hood.
 

--- a/docs/src/content/pages/github-mode.mdoc
+++ b/docs/src/content/pages/github-mode.mdoc
@@ -34,10 +34,10 @@ With `github` mode on, visit the `/keystatic` route. You will be prompted to log
 The first time you click this button will initiate the setup process:
 
 {% cloud-image
-   href="https://keystatic.io/images/keystatic-docs/keystatic-setup.png"
+   src="https://keystatic.io/images/keystatic-docs/keystatic-setup.png"
    alt="Screenshot of Keystatic App setup"
-   height="1480"
-   width="1468" /%}
+   height=1480
+   width=1468 /%}
 
 If you happen to know the URL of your deployed project and/or the GitHub repo is owned by a GitHub organization, you can fill in those fields.
 
@@ -52,16 +52,16 @@ The next step will walk you through creating a GitHub App. Choose a name for you
 Next, you will need to grant this new GitHub App access to your GitHub repo:
 
 {% cloud-image
-   href="https://keystatic.io/images/keystatic-docs/keystatic-installed.png"
+   src="https://keystatic.io/images/keystatic-docs/keystatic-installed.png"
    alt="Screenshot of successful Keystatic App installation"
-   height="666"
-   width="892" /%}
+   height=666
+   width=892 /%}
 
 {% cloud-image
-   href="https://keystatic.io/images/keystatic-docs/authorize-app.png"
+   src="https://keystatic.io/images/keystatic-docs/authorize-app.png"
    alt="Screenshot of GitHub custom app authorization UI"
-   height="1902"
-   width="1348" /%}
+   height=1902
+   width=1348 /%}
 
 Finally, you will be taken back to your local Keystatic Admin UI... running in `github` mode!
 


### PR DESCRIPTION
This cleans up our docs website config considerably.

* Component blocks are defined in their own files now, which makes the config easier to understand
* The old cloud images field has been removed the new one is compatible with the existing images (and I've updated the tags to use the new `src` prop, and integers for `width` and `height`)
* The `field-demo` tag casing is consistent with the other tags now
* The previews correctly use `NotEditable`