### PR TITLE
More component blocks cleanup

### DIFF
--- a/docs/src/component-blocks/aside.preview.tsx
+++ b/docs/src/component-blocks/aside.preview.tsx
@@ -1,0 +1,13 @@
+import { NotEditable, PreviewProps, ObjectField } from '@keystatic/core';
+import { Flex } from '@keystar/ui/layout';
+
+import type { schema } from './aside';
+
+export function preview(props: PreviewProps<ObjectField<typeof schema>>) {
+  return (
+    <Flex gap="medium">
+      <NotEditable>{props.fields.icon.value}</NotEditable>
+      <div>{props.fields.content.element}</div>
+    </Flex>
+  );
+}

--- a/docs/src/component-blocks/aside.tsx
+++ b/docs/src/component-blocks/aside.tsx
@@ -1,33 +1,25 @@
-import { fields, component, NotEditable } from '@keystatic/core';
+import { fields, component } from '@keystatic/core';
+
+import { preview } from './aside.preview';
+
+export const schema = {
+  icon: fields.text({
+    label: 'Emoji icon...',
+  }),
+  content: fields.child({
+    kind: 'block',
+    placeholder: 'Aside...',
+    formatting: {
+      inlineMarks: 'inherit',
+      softBreaks: 'inherit',
+      listTypes: 'inherit',
+    },
+    links: 'inherit',
+  }),
+};
 
 export const aside = component({
-  preview: props => {
-    return (
-      <div
-        style={{
-          display: 'flex',
-          gap: '0.5rem',
-        }}
-      >
-        <NotEditable>{props.fields.icon.value}</NotEditable>
-        <div>{props.fields.content.element}</div>
-      </div>
-    );
-  },
   label: 'Aside',
-  schema: {
-    icon: fields.text({
-      label: 'Emoji icon...',
-    }),
-    content: fields.child({
-      kind: 'block',
-      placeholder: 'Aside...',
-      formatting: {
-        inlineMarks: 'inherit',
-        softBreaks: 'inherit',
-        listTypes: 'inherit',
-      },
-      links: 'inherit',
-    }),
-  },
+  schema,
+  preview,
 });

--- a/docs/src/component-blocks/embed.tsx
+++ b/docs/src/component-blocks/embed.tsx
@@ -1,18 +1,12 @@
 import { fields, component, NotEditable } from '@keystatic/core';
 
-const codeFontFamily =
-  'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace';
-
 export const embed = component({
   label: 'Embed',
   preview: props => (
-    <NotEditable
-      style={{
-        fontFamily: codeFontFamily,
-        fontSize: '0.8rem',
-      }}
-    >
-      {props.fields.embedCode.value || '(no embed code set)'}
+    <NotEditable>
+      <pre>
+        <code>{props.fields.embedCode.value || '(no embed code set)'}</code>
+      </pre>
     </NotEditable>
   ),
   schema: {

--- a/docs/src/component-blocks/field-demo.tsx
+++ b/docs/src/component-blocks/field-demo.tsx
@@ -4,7 +4,13 @@ export const fieldDemo = component({
   preview: props => {
     return (
       <NotEditable>
-        Field: {props.fields.field.value || '(none selected)'}
+        {props.fields.field.value ? (
+          <>
+            Field: <code>{props.fields.field.value}</code>
+          </>
+        ) : (
+          '(no field selected)'
+        )}
       </NotEditable>
     );
   },

--- a/docs/src/component-blocks/tags.preview.tsx
+++ b/docs/src/component-blocks/tags.preview.tsx
@@ -1,0 +1,24 @@
+import { NotEditable, PreviewProps, ObjectField } from '@keystatic/core';
+
+import type { schema } from './tags';
+
+export function preview(props: PreviewProps<ObjectField<typeof schema>>) {
+  return (
+    <NotEditable>
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        {props.fields.tags.value.map(tag => (
+          <span
+            style={{
+              border: 'solid 1px #ddd',
+              padding: '0.25rem 0.5rem',
+              borderRadius: '20px',
+              fontSize: '11px',
+            }}
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+    </NotEditable>
+  );
+}

--- a/docs/src/component-blocks/tags.tsx
+++ b/docs/src/component-blocks/tags.tsx
@@ -1,39 +1,24 @@
-import { fields, component, NotEditable } from '@keystatic/core';
+import { fields, component } from '@keystatic/core';
+
+import { preview } from './tags.preview';
+
+export const schema = {
+  tags: fields.multiselect({
+    label: 'Project tags',
+    options: [
+      { label: 'Local', value: 'Local' },
+      { label: 'Github', value: 'github' },
+      { label: 'New project', value: 'New project' },
+      { label: 'Existing project', value: 'Existing project' },
+      { label: 'Astro', value: 'Astro' },
+      { label: 'Next.js', value: 'Next.js' },
+    ],
+  }),
+};
 
 export const tags = component({
-  preview: props => {
-    return (
-      <NotEditable>
-        <div style={{ display: 'flex', gap: '1rem' }}>
-          {props.fields.tags.value.map(tag => (
-            <span
-              style={{
-                border: 'solid 1px #ddd',
-                padding: '0.25rem 0.5rem',
-                borderRadius: '20px',
-                fontSize: '11px',
-              }}
-            >
-              {tag}
-            </span>
-          ))}
-        </div>
-      </NotEditable>
-    );
-  },
   label: 'Project',
-  schema: {
-    tags: fields.multiselect({
-      label: 'Project tags',
-      options: [
-        { label: 'Local', value: 'Local' },
-        { label: 'Github', value: 'github' },
-        { label: 'New project', value: 'New project' },
-        { label: 'Existing project', value: 'Existing project' },
-        { label: 'Astro', value: 'Astro' },
-        { label: 'Next.js', value: 'Next.js' },
-      ],
-    }),
-  },
+  schema,
+  preview,
   chromeless: false,
 });


### PR DESCRIPTION
Just some more minor refactoring for the docs site component blocks, now demonstrating how to separate the preview into a different file while still using the correct prop types.