### PR TITLE
Revert "Add "use client" to style entrypoint in keystar-ui"

### DIFF
--- a/.changeset/neat-waves-shout.md
+++ b/.changeset/neat-waves-shout.md
@@ -1,0 +1,5 @@
+---
+"@keystar/ui": patch
+---
+
+Revert adding `"use client"` to `@keystar/ui/style`

--- a/design-system/pkg/src/style/index.ts
+++ b/design-system/pkg/src/style/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { css, keyframes, injectGlobal, cache } from '@emotion/css'; // simplify dependencies + ensure the same version of emotion is used
 
 export { transition } from './animation';


### PR DESCRIPTION
Reverts Thinkmill/keystatic#597

Adding `'use client'` to this is misleading, `@keystar/ui/style` won't work in a server components and adding `'use client'` doesn't change that