### PR TITLE
Contextual help

### DIFF
--- a/.changeset/shaggy-teachers-tickle.md
+++ b/.changeset/shaggy-teachers-tickle.md
@@ -1,0 +1,7 @@
+---
+'@keystar/ui': patch
+---
+
+New package "@keystar/ui/contextual-help" exposes `ContextualHelp` component.
+
+Support "contextualHelp" prop on field components, `Field` and `FieldPrimitive`.

--- a/design-system/pkg/contextual-help/package.json
+++ b/design-system/pkg/contextual-help/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/keystar-ui-contextual-help.cjs.js",
+  "module": "dist/keystar-ui-contextual-help.esm.js"
+}

--- a/design-system/pkg/package.json
+++ b/design-system/pkg/package.json
@@ -798,6 +798,11 @@
       "module": "./password-field/dist/keystar-ui-password-field.esm.js",
       "default": "./password-field/dist/keystar-ui-password-field.cjs.js"
     },
+    "./contextual-help": {
+      "types": "./contextual-help/dist/keystar-ui-contextual-help.cjs.js",
+      "module": "./contextual-help/dist/keystar-ui-contextual-help.esm.js",
+      "default": "./contextual-help/dist/keystar-ui-contextual-help.cjs.js"
+    },
     "./icon/icons/albumIcon": {
       "types": "./icon/icons/albumIcon/dist/keystar-ui-icon-icons-albumIcon.cjs.js",
       "module": "./icon/icons/albumIcon/dist/keystar-ui-icon-icons-albumIcon.esm.js",

--- a/design-system/pkg/src/contextual-help/ContextualHelp.tsx
+++ b/design-system/pkg/src/contextual-help/ContextualHelp.tsx
@@ -18,10 +18,7 @@ import { classNames, css, tokenSchema } from '@keystar/ui/style';
 import localizedMessages from './l10n.json';
 import { ContextualHelpProps } from './types';
 
-/**
- * Contextual help shows a user extra information about the state of an adjacent
- * component, or a total view.
- */
+/** Contextual help shows a user extra information about an adjacent component. */
 export const ContextualHelp: ForwardRefExoticComponent<
   ContextualHelpProps & { ref?: Ref<HTMLButtonElement> }
 > = forwardRef(function ContextualHelp(

--- a/design-system/pkg/src/contextual-help/ContextualHelp.tsx
+++ b/design-system/pkg/src/contextual-help/ContextualHelp.tsx
@@ -1,0 +1,62 @@
+import { useLocalizedStringFormatter } from '@react-aria/i18n';
+import { mergeProps, useLabels } from '@react-aria/utils';
+import {
+  ForwardRefExoticComponent,
+  ForwardedRef,
+  Ref,
+  forwardRef,
+} from 'react';
+
+import { ActionButton } from '@keystar/ui/button';
+import { Dialog, DialogTrigger } from '@keystar/ui/dialog';
+import { Icon } from '@keystar/ui/icon';
+import { helpCircleIcon } from '@keystar/ui/icon/icons/helpCircleIcon';
+import { infoIcon } from '@keystar/ui/icon/icons/infoIcon';
+import { ClearSlots } from '@keystar/ui/slots';
+import { classNames, css, tokenSchema } from '@keystar/ui/style';
+
+import localizedMessages from './l10n.json';
+import { ContextualHelpProps } from './types';
+
+/**
+ * Contextual help shows a user extra information about the state of an adjacent
+ * component, or a total view.
+ */
+export const ContextualHelp: ForwardRefExoticComponent<
+  ContextualHelpProps & { ref?: Ref<HTMLButtonElement> }
+> = forwardRef(function ContextualHelp(
+  props: ContextualHelpProps,
+  ref: ForwardedRef<HTMLButtonElement>
+) {
+  let { children, variant = 'help', ...otherProps } = props;
+
+  let stringFormatter = useLocalizedStringFormatter(localizedMessages);
+  let labelProps = useLabels(otherProps, stringFormatter.format(variant));
+
+  let icon = variant === 'info' ? infoIcon : helpCircleIcon;
+
+  return (
+    <DialogTrigger {...otherProps} type="popover">
+      <ActionButton
+        {...mergeProps(otherProps, labelProps, { isDisabled: false })}
+        ref={ref}
+        UNSAFE_className={classNames(
+          css({
+            borderRadius: tokenSchema.size.radius.small,
+            height: tokenSchema.size.element.small,
+            minWidth: 'unset',
+            paddingInline: 0,
+            width: tokenSchema.size.element.small,
+          }),
+          otherProps.UNSAFE_className
+        )}
+        prominence="low"
+      >
+        <Icon src={icon} />
+      </ActionButton>
+      <ClearSlots>
+        <Dialog>{children}</Dialog>
+      </ClearSlots>
+    </DialogTrigger>
+  );
+});

--- a/design-system/pkg/src/contextual-help/docs/index.md
+++ b/design-system/pkg/src/contextual-help/docs/index.md
@@ -1,0 +1,81 @@
+---
+title: Contextual help
+description:
+  Contextual help shows a user extra information about an adjacent component.
+category: Overlays
+---
+
+## Example
+
+```jsx {% live=true %}
+<ContextualHelp>
+  <Heading>Need help?</Heading>
+  <Content>
+    <Text>
+      If you're having issues accessing your account, contact our customer
+      support team for help.
+    </Text>
+  </Content>
+</ContextualHelp>
+```
+
+## Slots
+
+Use [slots](/package/slots) to populate the context help dialog by providing the
+following components as children to `ContextualHelp`.
+
+### Heading
+
+The [Heading](/package/typography/heading) is required, it acts as the title for
+the dialog, providing context for what the user should expect.
+
+### Content
+
+`Content` is also required. It acts as the "body" of the dialog: this is where
+you'll compose children.
+
+### Footer
+
+You may optionally provide a `Footer` component which will be rendered below the
+content. Use the [footer for providing links](#help) to additional information.
+
+## Props
+
+### Variant
+
+#### Info
+
+Use the info variant for brief, specific, contextual guidance. This is best for
+supplemental or nice-to-know information, in-line with a label or a component
+(if there is no label).
+
+```jsx {% live=true %}
+<ContextualHelp variant="info">
+  <Heading>Permission required</Heading>
+  <Content>
+    <Text>
+      Your admin must grant you permission before you can assign roles.
+    </Text>
+  </Content>
+</ContextualHelp>
+```
+
+#### Help
+
+This is the default. Use the help variant for content that offers more detailed,
+in-depth guidance about a task, UI element, tool, or keyboard shortcuts.
+
+```jsx {% live=true %}
+<ContextualHelp variant="help">
+  <Heading>Role disabled?</Heading>
+  <Content>
+    <Text>
+      There must be at least one owner in the team. Assign another user as an
+      owner before changing this role.
+    </Text>
+  </Content>
+  <Footer>
+    <TextLink prominence="high">Learn more about roles</TextLink>
+  </Footer>
+</ContextualHelp>
+```

--- a/design-system/pkg/src/contextual-help/index.ts
+++ b/design-system/pkg/src/contextual-help/index.ts
@@ -1,0 +1,5 @@
+'use client';
+
+export { ContextualHelp } from './ContextualHelp';
+
+export type { ContextualHelpProps } from './types';

--- a/design-system/pkg/src/contextual-help/l10n.json
+++ b/design-system/pkg/src/contextual-help/l10n.json
@@ -1,0 +1,138 @@
+{
+  "ar-AE": {
+    "help": "مساعدة",
+    "info": "معلومات"
+  },
+  "bg-BG": {
+    "help": "Помощ",
+    "info": "Информация"
+  },
+  "cs-CZ": {
+    "help": "Nápověda",
+    "info": "Informace"
+  },
+  "da-DK": {
+    "help": "Hjælp",
+    "info": "Oplysninger"
+  },
+  "de-DE": {
+    "help": "Hilfe",
+    "info": "Informationen"
+  },
+  "el-GR": {
+    "help": "Βοήθεια",
+    "info": "Πληροφορίες"
+  },
+  "en-US": {
+    "info": "Information",
+    "help": "Help"
+  },
+  "es-ES": {
+    "help": "Ayuda",
+    "info": "Información"
+  },
+  "et-EE": {
+    "help": "Spikker",
+    "info": "Teave"
+  },
+  "fi-FI": {
+    "help": "Ohje",
+    "info": "Tiedot"
+  },
+  "fr-FR": {
+    "help": "Aide",
+    "info": "Informations"
+  },
+  "he-IL": {
+    "help": "עזרה",
+    "info": "מידע"
+  },
+  "hr-HR": {
+    "help": "Pomoć",
+    "info": "Informacije"
+  },
+  "hu-HU": {
+    "help": "Súgó",
+    "info": "Információ"
+  },
+  "it-IT": {
+    "help": "Aiuto",
+    "info": "Informazioni"
+  },
+  "ja-JP": {
+    "help": "ヘルプ",
+    "info": "情報"
+  },
+  "ko-KR": {
+    "help": "도움말",
+    "info": "정보"
+  },
+  "lt-LT": {
+    "help": "Žinynas",
+    "info": "Informacija"
+  },
+  "lv-LV": {
+    "help": "Palīdzība",
+    "info": "Informācija"
+  },
+  "nb-NO": {
+    "help": "Hjelp",
+    "info": "Informasjon"
+  },
+  "nl-NL": {
+    "help": "Help",
+    "info": "Informatie"
+  },
+  "pl-PL": {
+    "help": "Pomoc",
+    "info": "Informacja"
+  },
+  "pt-BR": {
+    "help": "Ajuda",
+    "info": "Informações"
+  },
+  "pt-PT": {
+    "help": "Ajuda",
+    "info": "Informação"
+  },
+  "ro-RO": {
+    "help": "Ajutor",
+    "info": "Informaţii"
+  },
+  "ru-RU": {
+    "help": "Справка",
+    "info": "Информация"
+  },
+  "sk-SK": {
+    "help": "Pomoc",
+    "info": "Informácie"
+  },
+  "sl-SI": {
+    "help": "Pomoč",
+    "info": "Informacije"
+  },
+  "sr-SP": {
+    "help": "Pomoć",
+    "info": "Informacije"
+  },
+  "sv-SE": {
+    "help": "Hjälp",
+    "info": "Information"
+  },
+  "tr-TR": {
+    "help": "Yardım",
+    "info": "Bilgiler"
+  },
+  "uk-UA": {
+    "help": "Довідка",
+    "info": "Інформація"
+  },
+  "zh-CN": {
+    "help": "帮助",
+    "info": "信息"
+  },
+  "zh-TW": {
+    "help": "說明",
+    "info": "資訊"
+  }
+}

--- a/design-system/pkg/src/contextual-help/stories/ContextualHelp.stories.tsx
+++ b/design-system/pkg/src/contextual-help/stories/ContextualHelp.stories.tsx
@@ -1,0 +1,107 @@
+import { StoryObj } from '@keystar/ui-storybook';
+import { Content, Footer } from '@keystar/ui/slots';
+import { TextLink } from '@keystar/ui/link';
+import { Heading, Text } from '@keystar/ui/typography';
+
+import { ContextualHelp } from '../index';
+
+type ContextualHelpStory = StoryObj<typeof ContextualHelp>;
+
+export default {
+  title: 'Components/ContextualHelp',
+  component: ContextualHelp as any,
+  argTypes: {
+    onOpenChange: {
+      action: 'openChange',
+      table: { disable: true },
+    },
+    placement: {
+      control: 'select',
+      defaultValue: 'bottom',
+      options: [
+        'bottom',
+        'bottom left',
+        'bottom right',
+        'bottom start',
+        'bottom end',
+        'top',
+        'top left',
+        'top right',
+        'top start',
+        'top end',
+        'left',
+        'left top',
+        'left bottom',
+        'start',
+        'start top',
+        'start bottom',
+        'right',
+        'right top',
+        'right bottom',
+        'end',
+        'end top',
+        'end bottom',
+      ],
+    },
+    variant: {
+      control: 'select',
+      defaultValue: 'help',
+      options: ['help', 'info'],
+    },
+    offset: {
+      control: 'number',
+      min: -500,
+      max: 500,
+    },
+    crossOffset: {
+      control: 'number',
+      min: -500,
+      max: 500,
+    },
+    containerPadding: {
+      control: 'number',
+      min: -500,
+      max: 500,
+    },
+    shouldFlip: {
+      control: 'boolean',
+    },
+    children: {
+      table: { disable: true },
+    },
+  },
+};
+
+const helpText = () => (
+  <Text>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet
+    tristique risus. In sit amet suscipit lorem.
+  </Text>
+);
+
+export const Default: ContextualHelpStory = {
+  args: {
+    children: (
+      <>
+        <Heading>Help title</Heading>
+        <Content>{helpText()}</Content>
+      </>
+    ),
+  },
+  name: 'default',
+};
+
+export const WithLink: ContextualHelpStory = {
+  args: {
+    children: (
+      <>
+        <Heading>Help title</Heading>
+        <Content>{helpText()}</Content>
+        <Footer>
+          <TextLink prominence="high">Learn more</TextLink>
+        </Footer>
+      </>
+    ),
+  },
+  name: 'with link',
+};

--- a/design-system/pkg/src/contextual-help/types.ts
+++ b/design-system/pkg/src/contextual-help/types.ts
@@ -1,0 +1,28 @@
+import {
+  OverlayTriggerProps,
+  Placement,
+  PositionProps,
+} from '@react-types/overlays';
+import { AriaLabelingProps, DOMProps } from '@react-types/shared';
+import { ReactNode } from 'react';
+
+import { BaseStyleProps } from '@keystar/ui/style';
+
+export type ContextualHelpProps = {
+  /** Contents of the Contextual Help popover. */
+  children: ReactNode;
+  /**
+   * The placement of the popover with respect to the action button.
+   * @default 'bottom start'
+   */
+  placement?: Placement;
+  /**
+   * Indicates whether contents are informative or provides helpful guidance.
+   * @default 'help'
+   */
+  variant?: 'help' | 'info';
+} & OverlayTriggerProps &
+  PositionProps &
+  BaseStyleProps &
+  DOMProps &
+  AriaLabelingProps;

--- a/design-system/pkg/src/field/stories/Field.stories.tsx
+++ b/design-system/pkg/src/field/stories/Field.stories.tsx
@@ -1,54 +1,84 @@
-import { ComponentMeta, ComponentStoryObj } from '@keystar/ui-storybook';
+import { StoryObj } from '@keystar/ui-storybook';
+import { ContextualHelp } from '@keystar/ui/contextual-help';
+import { Content } from '@keystar/ui/slots';
+import { Heading, Text } from '@keystar/ui/typography';
 
-import { Field } from '..';
+import { Field } from '../index';
 
-type FieldStory = ComponentStoryObj<typeof Field>;
-
-const argTypes = {
-  label: {
-    control: 'text',
-  },
-  description: {
-    control: 'text',
-  },
-  errorMessage: {
-    control: 'text',
-  },
-  isDisabled: {
-    control: 'boolean',
-    defaultValue: false,
-  },
-  isRequired: {
-    control: 'boolean',
-    defaultValue: true,
-  },
-  width: {
-    control: 'radio',
-    defaultValue: undefined,
-    options: ['100px', 'size.container.xsmall', undefined],
-  },
-};
+type FieldStory = StoryObj<typeof Field>;
 
 export default {
   title: 'Components/Field',
-  component: Field,
+  component: Field as any,
   args: {
     children: (props: any) => <input {...props} />,
-  },
-  argTypes: argTypes,
-} as ComponentMeta<typeof Field>;
-
-export let Default: FieldStory = {
-  args: {
     label: 'Label text',
-    description:
-      'Description text provides information to assist the user in completing a field.',
-    errorMessage:
-      'Error messages inform the user when the input does not meet validation criteria.',
+  },
+  argTypes: {
+    children: { table: { disable: true } },
+    contextualHelp: { table: { disable: true } },
+    label: {
+      control: 'text',
+    },
+    description: {
+      control: 'text',
+    },
+    errorMessage: {
+      control: 'text',
+    },
+    isDisabled: {
+      control: 'boolean',
+      defaultValue: false,
+    },
+    isRequired: {
+      control: 'boolean',
+      defaultValue: true,
+    },
+    width: {
+      control: 'radio',
+      defaultValue: undefined,
+      options: ['100px', 'size.container.xsmall', undefined],
+    },
   },
 };
 
-export let AriaLabel: FieldStory = {
+export const Default: FieldStory = {};
+
+export const Description: FieldStory = {
+  args: {
+    description:
+      'Description text provides information to assist the user in completing a field.',
+  },
+  name: 'description',
+};
+
+export const ErrorMessage: FieldStory = {
+  args: {
+    isRequired: true,
+    errorMessage:
+      'Error messages inform the user when the input does not meet validation criteria.',
+  },
+  name: 'errorMessage',
+};
+
+export const WithContextualHelp: FieldStory = {
+  args: {
+    contextualHelp: (
+      <ContextualHelp>
+        <Heading>Help title</Heading>
+        <Content>
+          <Text>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit
+            amet tristique risus. In sit amet suscipit lorem.
+          </Text>
+        </Content>
+      </ContextualHelp>
+    ),
+  },
+  name: 'contextualHelp',
+};
+
+export const AriaLabel: FieldStory = {
   args: {
     label: undefined,
     'aria-label': 'Hidden label',
@@ -58,6 +88,7 @@ export let AriaLabel: FieldStory = {
       control: { disable: true },
     },
   },
+  name: 'aria-label',
 };
 
 export const AriaDescribedBy = {
@@ -72,6 +103,7 @@ export const AriaDescribedBy = {
     },
     'aria-describedby': { control: { disable: true } },
   },
+  name: 'aria-describedby',
   decorators: [
     // @ts-ignore
     (Story, Context) => (

--- a/design-system/pkg/src/field/types.tsx
+++ b/design-system/pkg/src/field/types.tsx
@@ -5,9 +5,10 @@ import {
   InputBase,
   Validation,
 } from '@react-types/shared';
-import { ReactElement, ReactNode } from 'react';
+import { HTMLAttributes, ReactElement, ReactNode } from 'react';
 
 import { BaseStyleProps } from '@keystar/ui/style';
+import { HTMLTag } from '@keystar/ui/utils/ts';
 
 type FieldRenderInputProps = LabelAria['fieldProps'] & {
   disabled?: boolean;
@@ -20,6 +21,8 @@ export type FieldRenderProp = (
 ) => ReactElement;
 
 export type FieldProps = {
+  /** A `ContextualHelp` element to place next to the label. */
+  contextualHelp?: ReactElement;
   /**
    * Description text provides information to assist the user in completing a
    * field.
@@ -37,3 +40,23 @@ export type FieldProps = {
   AriaLabelingProps &
   BaseStyleProps &
   DOMProps;
+
+export type FieldPrimitiveProps = {
+  children: ReactElement;
+  /** A `ContextualHelp` element to place next to the label. */
+  contextualHelp?: ReactElement;
+  isRequired?: boolean;
+  label?: ReactNode;
+  labelElementType?: HTMLTag;
+  labelProps?: HTMLAttributes<HTMLElement>;
+  description?: ReactNode;
+  descriptionProps?: HTMLAttributes<HTMLElement>;
+  errorMessage?: ReactNode;
+  errorMessageProps?: HTMLAttributes<HTMLElement>;
+  /**
+   * For controls that DO NOT use a semantic element for user input. In these
+   * cases the "required" state would not otherwise be announced to users of
+   * assistive technology.
+   */
+  supplementRequiredState?: boolean;
+} & BaseStyleProps;


### PR DESCRIPTION
New package "@keystar/ui/contextual-help" exposes `ContextualHelp` component. 

> Contextual help shows a user extra information about an adjacent component.

Support "contextualHelp" prop on field components, `Field` and `FieldPrimitive`.