### PR TITLE
Cloud image constrain proportions

### DIFF
--- a/.changeset/popular-moles-clap.md
+++ b/.changeset/popular-moles-clap.md
@@ -1,0 +1,6 @@
+---
+'@keystatic/core': patch
+'@keystar/ui': patch
+---
+
+Support constrained proportions on cloud image block. Refactor `Tooltip` styles to allow consumer overrides via style props.

--- a/.changeset/popular-moles-clap.md
+++ b/.changeset/popular-moles-clap.md
@@ -3,4 +3,4 @@
 '@keystar/ui': patch
 ---
 
-Support constrained proportions on cloud image block. Refactor `Tooltip` styles to allow consumer overrides via style props.
+Support constrained proportions on cloud image block and field. Refactor `Tooltip` styles to allow consumer overrides via style props.

--- a/design-system/pkg/src/tooltip/Tooltip.tsx
+++ b/design-system/pkg/src/tooltip/Tooltip.tsx
@@ -106,6 +106,10 @@ export const Tooltip: ForwardRefExoticComponent<
           backgroundColor: tokenSchema.color.background.inverse,
           color: tokenSchema.color.foreground.inverse,
           borderRadius: tokenSchema.size.radius.small,
+          maxWidth: tokenSchema.size.alias.singleLineWidth,
+          minHeight: tokenSchema.size.element.small,
+          paddingBlock: tokenSchema.size.space.regular,
+          paddingInline: tokenSchema.size.space.regular,
           opacity: 0,
           pointerEvents: 'none',
           transition: transition(['opacity', 'transform']),
@@ -163,10 +167,6 @@ export const Tooltip: ForwardRefExoticComponent<
           boxSizing: 'border-box',
           display: 'flex',
           gap: tokenSchema.size.space.small,
-          maxInlineSize: tokenSchema.size.alias.singleLineWidth,
-          minBlockSize: tokenSchema.size.element.small,
-          paddingBlock: tokenSchema.size.space.regular,
-          paddingInline: tokenSchema.size.space.regular,
         })}
       >
         <SlotProvider slots={slots}>

--- a/packages/keystatic/src/component-blocks/cloud-image-preview.tsx
+++ b/packages/keystatic/src/component-blocks/cloud-image-preview.tsx
@@ -9,10 +9,13 @@ import {
   Button,
   ButtonGroup,
   ClearButton,
+  ToggleButton,
 } from '@keystar/ui/button';
 import { Dialog, DialogContainer, DialogTrigger } from '@keystar/ui/dialog';
 import { Icon } from '@keystar/ui/icon';
 import { imageIcon } from '@keystar/ui/icon/icons/imageIcon';
+import { link2Icon } from '@keystar/ui/icon/icons/link2Icon';
+import { link2OffIcon } from '@keystar/ui/icon/icons/link2OffIcon';
 import { pencilIcon } from '@keystar/ui/icon/icons/pencilIcon';
 import { trash2Icon } from '@keystar/ui/icon/icons/trash2Icon';
 import { undo2Icon } from '@keystar/ui/icon/icons/undo2Icon';
@@ -90,6 +93,7 @@ function ImageDialog(props: {
   const { image, onCancel, onChange, onClose } = props;
   const [state, setState] = useState<CloudImageProps>(image ?? emptyImageData);
   const [status, setStatus] = useState<ImageStatus>(image ? 'good' : '');
+  const [constrainProportions, setConstrainProportions] = useState(true);
   const [dimensions, setDimensions] = useState<ImageDimensions>(emptyImageData);
   const formId = useId();
   const imageLibraryURL = useImageLibraryURL();
@@ -205,14 +209,49 @@ function ImageDialog(props: {
                   width="scale.1600"
                   formatOptions={{ maximumFractionDigits: 0 }}
                   value={state.width}
-                  onChange={width => setState(state => ({ ...state, width }))}
+                  onChange={width => {
+                    if (constrainProportions) {
+                      setState(state => ({
+                        ...state,
+                        width,
+                        height: Math.round(width / getAspectRatio(state)),
+                      }));
+                    } else {
+                      setState(state => ({ ...state, width }));
+                    }
+                  }}
                 />
+                <TooltipTrigger>
+                  <ToggleButton
+                    isSelected={constrainProportions}
+                    aria-label="Constrain proportions"
+                    prominence="low"
+                    onPress={() => {
+                      setConstrainProportions(state => !state);
+                    }}
+                  >
+                    <Icon
+                      src={constrainProportions ? link2Icon : link2OffIcon}
+                    />
+                  </ToggleButton>
+                  <Tooltip>Constrain proportions</Tooltip>
+                </TooltipTrigger>
                 <NumberField
                   label="Height"
                   width="scale.1600"
                   formatOptions={{ maximumFractionDigits: 0 }}
                   value={state.height}
-                  onChange={height => setState(state => ({ ...state, height }))}
+                  onChange={height => {
+                    if (constrainProportions) {
+                      setState(state => ({
+                        ...state,
+                        height,
+                        width: Math.round(height * getAspectRatio(state)),
+                      }));
+                    } else {
+                      setState(state => ({ ...state, height }));
+                    }
+                  }}
                 />
                 <TooltipTrigger>
                   <ActionButton
@@ -228,7 +267,7 @@ function ImageDialog(props: {
                   >
                     <Icon src={undo2Icon} />
                   </ActionButton>
-                  <Tooltip>{revertLabel}</Tooltip>
+                  <Tooltip maxWidth="100%">{revertLabel}</Tooltip>
                 </TooltipTrigger>
               </HStack>
             </>
@@ -444,4 +483,9 @@ export function useImageLibraryURL() {
   if (!isCloudConfig(config)) return 'https://keystatic.cloud/';
   const { project, team } = getSplitCloudProject(config);
   return `https://keystatic.cloud/teams/${team}/project/${project}/images`;
+}
+
+function getAspectRatio(state: CloudImageProps) {
+  if (!state.width || !state.height) return 1;
+  return state.width / state.height;
 }


### PR DESCRIPTION
Support constrained proportions on cloud image block and field. Refactor `Tooltip` styles to allow consumer overrides via style props.