### PR TITLE
Fix astro integration

### DIFF
--- a/.changeset/odd-paws-exist.md
+++ b/.changeset/odd-paws-exist.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/astro': patch
+---
+
+Fix `@keystatic/astro` integration

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -29,10 +29,14 @@ export default function keystatic(): AstroIntegration {
             entries: ['keystatic.config.*', '.astro/keystatic-imports.js'],
           },
         };
+        const dotAstroDir = path.join(fileURLToPath(config.root), '.astro');
+        await fs.mkdir(dotAstroDir, { recursive: true });
         await fs.writeFile(
-          path.join(fileURLToPath(config.root), '.astro/keystatic-imports.js'),
-          `import '@keystatic/astro/api';
-import '@keystatic/astro/ui';`
+          path.join(dotAstroDir, 'keystatic-imports.js'),
+          `import "@keystatic/astro/ui";
+import "@keystatic/astro/api";
+import "@keystatic/core/ui";
+`
         );
         updateConfig({
           vite,

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -1,10 +1,13 @@
 import type { AstroIntegration, ViteUserConfig } from 'astro';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs/promises';
 
 export default function keystatic(): AstroIntegration {
   return {
     name: 'keystatic',
     hooks: {
-      'astro:config:setup': ({ injectRoute, updateConfig, config }) => {
+      'astro:config:setup': async ({ injectRoute, updateConfig, config }) => {
         if (config.output !== 'hybrid') {
           throw new Error(
             "Keystatic requires `output: 'hybrid'` in your Astro config"
@@ -22,7 +25,15 @@ export default function keystatic(): AstroIntegration {
               },
             },
           ],
+          optimizeDeps: {
+            entries: ['keystatic.config.*', '.astro/keystatic-imports.js'],
+          },
         };
+        await fs.writeFile(
+          path.join(fileURLToPath(config.root), '.astro/keystatic-imports.js'),
+          `import '@keystatic/astro/api';
+import '@keystatic/astro/ui';`
+        );
         updateConfig({
           vite,
         });


### PR DESCRIPTION
This generates a file into `.astro` (since that will already be gitignored) with imports to Keystatic packages and tells Vite to look at it for discovering dependencies to pre-bundle which fixes the problem of getting errors from Vite trying to load CommonJS modules as ESM

I'm not going to update the template to use this just yet, I'd like to get this released first to make sure that it definitely works first (though from the snapshot release, it seems to)

Snapshot release for testing: `@keystatic/astro@0.0.0-test-20230907032149`, https://github.com/Thinkmill/keystatic/actions/runs/6105022202/job/16567883939#step:7:33

Fixes  #580