### PR TITLE
Fix `@keystatic/astro/api` CommonJS output

### DIFF
--- a/.changeset/neat-walls-pump.md
+++ b/.changeset/neat-walls-pump.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/astro': patch
+---
+
+Fix `@keystatic/astro/api` CommonJS output

--- a/packages/astro/src/api.tsx
+++ b/packages/astro/src/api.tsx
@@ -9,10 +9,15 @@ export function makeHandler(_config: APIRouteConfig) {
   const handler = makeGenericAPIRouteHandler(
     {
       ..._config,
-      clientId: _config.clientId ?? import.meta.env.KEYSTATIC_GITHUB_CLIENT_ID,
+      clientId:
+        _config.clientId ??
+        tryOrUndefined(() => import.meta.env.KEYSTATIC_GITHUB_CLIENT_ID),
       clientSecret:
-        _config.clientSecret ?? import.meta.env.KEYSTATIC_GITHUB_CLIENT_SECRET,
-      secret: _config.secret ?? import.meta.env.KEYSTATIC_SECRET,
+        _config.clientSecret ??
+        tryOrUndefined(() => import.meta.env.KEYSTATIC_GITHUB_CLIENT_SECRET),
+      secret:
+        _config.secret ??
+        tryOrUndefined(() => import.meta.env.KEYSTATIC_SECRET),
     },
     {
       slugEnvName: 'PUBLIC_KEYSTATIC_GITHUB_APP_SLUG',
@@ -77,4 +82,12 @@ export function makeHandler(_config: APIRouteConfig) {
       ),
     });
   };
+}
+
+function tryOrUndefined<T>(fn: () => T): T | undefined {
+  try {
+    return fn();
+  } catch {
+    return undefined;
+  }
 }


### PR DESCRIPTION
Ref: https://thinkmill.slack.com/archives/C04CLQBUF29/p1693987161543119?thread_ts=1693982871.802299&cid=C04CLQBUF29

I'm not quite sure how the CommonJS output was used here but it was and that broke things because Preconstruct outputs `import.meta.whatever` as `undefined` in CommonJS (since `import.meta` is only an ESM thing and it can't really know what else to output there) so this try catches reading from `import.meta.env`