### PR TITLE
Replace manually created pages for Keystatic with Astro integration that injects routes

### DIFF
--- a/.changeset/rude-clocks-change.md
+++ b/.changeset/rude-clocks-change.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/templates-astro': patch
+---
+
+Replace manually created pages for Keystatic with Astro integration that injects routes

--- a/templates/astro/astro.config.mjs
+++ b/templates/astro/astro.config.mjs
@@ -1,10 +1,10 @@
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
-
 import markdoc from '@astrojs/markdoc';
+import keystatic from '@keystatic/astro';
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [react(), markdoc()],
+  integrations: [react(), markdoc(), keystatic()],
   output: 'hybrid',
 });

--- a/templates/astro/keystatic.page.ts
+++ b/templates/astro/keystatic.page.ts
@@ -1,4 +1,0 @@
-import { makePage } from '@keystatic/astro/ui';
-import keystaticConfig from './keystatic.config';
-
-export const Keystatic = makePage(keystaticConfig);

--- a/templates/astro/src/pages/api/keystatic/[...params].ts
+++ b/templates/astro/src/pages/api/keystatic/[...params].ts
@@ -1,9 +1,0 @@
-// src/pages/api/keystatic/[...params].ts
-import { makeHandler } from '@keystatic/astro/api';
-import keystaticConfig from '../../../../keystatic.config';
-
-export const all = makeHandler({
-  config: keystaticConfig,
-});
-
-export const prerender = false;

--- a/templates/astro/src/pages/keystatic/[...params].astro
+++ b/templates/astro/src/pages/keystatic/[...params].astro
@@ -1,7 +1,0 @@
----
-import { Keystatic } from '../../../keystatic.page'
-
-export const prerender = false
----
-
-<Keystatic client:only />


### PR DESCRIPTION
#620 seems to work okay, so looks like we can use it here