### PR TITLE
Update astro-disable-admin-ui-in-production.mdoc

### DIFF
--- a/docs/src/content/pages/recipes/astro-disable-admin-ui-in-production.mdoc
+++ b/docs/src/content/pages/recipes/astro-disable-admin-ui-in-production.mdoc
@@ -35,20 +35,29 @@ export const prerender = false
 
 You will need to do the same for the `api/keystatic` routes:
 
-```jsx
+```diff
 // src/pages/api/keystatic/[...params].ts
 import { makeHandler } from '@keystatic/astro/api'
 import keystaticConfig from '../../../../keystatic.config'
++ import { APIContext } from 'astro'
 
-export const all = makeHandler({
-  config: keystaticConfig,
-})
+- export const all = makeHandler({
+-  config: keystaticConfig,
+- })
+
++ export const all = ({ ...params }: APIContext) => {
++  if (import.meta.env.MODE === 'production') {
++    return params.redirect('/', 307)
++  }
+
++  return makeHandler({
++    config: keystaticConfig,
++  })(params)
++}
+
 
 export const prerender = false
 
-+ if (import.meta.env.MODE === 'production') {
-+   return Astro.redirect('/')
-+ }
 ```
 
 ## Excluding routes from sitemap


### PR DESCRIPTION
The API route disable in production code seems to be invalid. 

Correcting it by adding a wrapper around the `makeHandler` in the call. If there's a better API that does this then please let me know and I'll make the needed corrections 