### PR TITLE
Add `storage.pathPrefix` option

### DIFF
--- a/.changeset/brave-dingos-pay.md
+++ b/.changeset/brave-dingos-pay.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Add `storage.pathPrefix` option

--- a/docs/keystatic.config.tsx
+++ b/docs/keystatic.config.tsx
@@ -70,15 +70,11 @@ const markdocConfig: Config = {
 };
 
 const shouldUseCloudStorage = process.env.NODE_ENV === 'production';
-const pathPrefix = shouldUseCloudStorage ? 'docs/' : '';
-export const readerPath = shouldUseCloudStorage
-  ? process.cwd().replace(/\/docs/, '')
-  : process.cwd();
 
 export default config({
-  storage: {
-    kind: shouldUseCloudStorage ? 'cloud' : 'local',
-  },
+  storage: shouldUseCloudStorage
+    ? { kind: 'cloud', pathPrefix: 'docs' }
+    : { kind: 'local' },
   cloud: {
     project: 'thinkmill-labs/keystatic-site',
   },
@@ -91,7 +87,7 @@ export default config({
       slugField: 'title',
       entryLayout: 'content',
       format: { contentField: 'content' },
-      path: `${pathPrefix}src/content/pages/**`,
+      path: 'src/content/pages/**',
       schema: {
         title: fields.slug({ name: { label: 'Title' } }),
         summary: fields.text({
@@ -116,7 +112,7 @@ export default config({
     blog: collection({
       label: 'Blog posts',
       slugField: 'title',
-      path: `${pathPrefix}src/content/blog/**`,
+      path: 'src/content/blog/**',
       entryLayout: 'content',
       format: {
         contentField: 'content',
@@ -178,7 +174,7 @@ export default config({
     authors: collection({
       label: 'Authors',
       slugField: 'name',
-      path: `${pathPrefix}src/content/authors/**`,
+      path: 'src/content/authors/**',
       schema: {
         name: fields.slug({
           name: {
@@ -205,7 +201,7 @@ export default config({
     projects: collection({
       label: 'Projects (Showcase)',
       slugField: 'title',
-      path: `${pathPrefix}src/content/projects/*`,
+      path: 'src/content/projects/*',
       format: { contentField: 'content' },
       entryLayout: 'content',
       schema: {
@@ -254,7 +250,7 @@ export default config({
       label: 'Pages with new editor',
       slugField: 'title',
       format: { contentField: 'content' },
-      path: `${pathPrefix}src/content/pages/**`,
+      path: 'src/content/pages/**',
       schema: {
         title: fields.slug({ name: { label: 'Title' } }),
         summary: fields.text({
@@ -275,7 +271,7 @@ export default config({
     // ------------------------------
     navigation: singleton({
       label: 'Navigation',
-      path: `${pathPrefix}src/content/navigation`,
+      path: 'src/content/navigation',
       schema: {
         navGroups: fields.array(
           fields.object({

--- a/docs/src/content/pages/content-organisation.mdoc
+++ b/docs/src/content/pages/content-organisation.mdoc
@@ -151,3 +151,29 @@ coverImage: fields.image({
 ```
 
 Regardless of where the `posts` entries are created, the `coverImage` image will be generated in `public/images/posts/{post-slug}`.
+
+---
+
+## Path prefix
+
+If you're in a monorepo, you can use the `storage.pathPrefix` option to scope Keystatic to a specific directory instead of adding a prefix to every `path` option.
+
+For example, this config will look for posts in `somewhere/my-site/content/posts`:
+
+```js
+export default config({
+  storage: {
+    kind: 'github',
+    repo: 'my-org/my-repo',
+    pathPrefix: 'somewhere/my-site'
+  },
+  collections: {
+    posts: collection({
+      label: 'Posts',
+      path: 'content/posts/*/',
+      // ...
+    })
+  },
+})
+```
+

--- a/docs/src/utils/reader.ts
+++ b/docs/src/utils/reader.ts
@@ -1,7 +1,7 @@
 import { createReader } from '@keystatic/core/reader';
-import keystaticConfig, { readerPath } from '../../keystatic.config';
+import keystaticConfig from '../../keystatic.config';
 
-export const reader = createReader(readerPath, keystaticConfig);
+export const reader = createReader(process.cwd(), keystaticConfig);
 
 export async function getNavigationMap() {
   const navigation = await reader.singletons.navigation.read();

--- a/packages/keystatic/src/app/create-item.tsx
+++ b/packages/keystatic/src/app/create-item.tsx
@@ -27,16 +27,13 @@ import { CreateBranchDuringUpdateDialog } from './ItemPage';
 import l10nMessages from './l10n/index.json';
 import { useRouter } from './router';
 import { PageRoot, PageHeader, PageBody } from './shell/page';
-import { useBaseCommit, useTree } from './shell/data';
-import { TreeNode } from './trees';
+import { useBaseCommit } from './shell/data';
 import { useSlugsInCollection } from './useSlugsInCollection';
 import { ForkRepoDialog } from './fork-repo';
 import { useUpsertItem } from './updating';
 import { FormForEntry, containerWidthForEntryLayout } from './entry-form';
 import { notFound } from './not-found';
 import { useItemData } from './useItemData';
-
-const emptyMap = new Map<string, TreeNode>();
 
 function CreateItemWrapper(props: {
   collection: string;
@@ -190,8 +187,6 @@ function CreateItem(props: {
 
   const baseCommit = useBaseCommit();
 
-  const tree = useTree();
-
   const slug = getSlugFromState(collectionConfig, state);
 
   const formatInfo = getCollectionFormat(props.config, props.collection);
@@ -203,8 +198,6 @@ function CreateItem(props: {
     schema: collectionConfig.schema,
     format: formatInfo,
     currentLocalTreeKey: undefined,
-    currentTree:
-      tree.current.kind === 'loaded' ? tree.current.data.tree : emptyMap,
     slug: { field: collectionConfig.slugField, value: slug },
   });
   const createItem = useEventCallback(_createItem);

--- a/packages/keystatic/src/app/path-utils.ts
+++ b/packages/keystatic/src/app/path-utils.ts
@@ -139,3 +139,10 @@ export type FormatInfo = {
     | undefined;
   dataLocation: 'index' | 'outer';
 };
+
+export function getPathPrefix(storage: Config['storage']) {
+  if (storage.kind === 'local' || !storage.pathPrefix) {
+    return undefined;
+  }
+  return fixPath(storage.pathPrefix) + '/';
+}

--- a/packages/keystatic/src/app/shell/path-prefix.tsx
+++ b/packages/keystatic/src/app/shell/path-prefix.tsx
@@ -1,0 +1,30 @@
+import { Config } from '../../config';
+import { getPathPrefix } from '../path-utils';
+import { treeEntriesToTreeNodes, TreeEntry, TreeNode } from '../trees';
+
+export function scopeEntriesWithPathPrefix(
+  tree: {
+    entries: Map<string, TreeEntry>;
+    tree: Map<string, TreeNode>;
+  },
+  config: Config
+): {
+  entries: Map<string, TreeEntry>;
+  tree: Map<string, TreeNode>;
+} {
+  const prefix = getPathPrefix(config.storage);
+  if (!prefix) return tree;
+  const newEntries = [];
+  for (const entry of tree.entries.values()) {
+    if (entry.path.startsWith(prefix)) {
+      newEntries.push({
+        ...entry,
+        path: entry.path.slice(prefix.length),
+      });
+    }
+  }
+  return {
+    entries: new Map(newEntries.map(entry => [entry.path, entry])),
+    tree: treeEntriesToTreeNodes(newEntries),
+  };
+}

--- a/packages/keystatic/src/app/updating.tsx
+++ b/packages/keystatic/src/app/updating.tsx
@@ -384,11 +384,12 @@ export function useDeleteItem(args: {
           return false;
         }
         setState({ kind: 'loading' });
+        const deletions = args.initialFiles.map(
+          x => getPathPrefix(args.storage) + x
+        );
         const updatedTree = await updateTreeWithChanges(unscopedTree, {
           additions: [],
-          deletions: args.initialFiles.map(
-            x => getPathPrefix(args.storage) + x
-          ),
+          deletions,
         });
         await hydrateTreeCacheWithEntries(updatedTree.entries);
         if (args.storage.kind === 'github' || args.storage.kind === 'cloud') {
@@ -403,7 +404,7 @@ export function useDeleteItem(args: {
               message: { headline: `Delete ${args.basePath}` },
               expectedHeadOid: baseCommit,
               fileChanges: {
-                deletions: args.initialFiles.map(path => ({ path })),
+                deletions: deletions.map(path => ({ path })),
               },
             },
           });
@@ -421,7 +422,7 @@ export function useDeleteItem(args: {
             },
             body: JSON.stringify({
               additions: [],
-              deletions: args.initialFiles.map(path => ({ path })),
+              deletions: deletions.map(path => ({ path })),
             }),
           });
           if (!res.ok) {

--- a/packages/keystatic/src/app/useData.ts
+++ b/packages/keystatic/src/app/useData.ts
@@ -71,6 +71,16 @@ export function useData<T>(
   return stateToReturn;
 }
 
+export function mapDataState<Input, Output>(
+  state: DataState<Input>,
+  func: (data: Input) => Output
+): DataState<Output> {
+  if (state.kind === 'error' || state.kind === 'loading') {
+    return state;
+  }
+  return { kind: 'loaded', data: func(state.data) };
+}
+
 export function mergeDataStates<T extends Record<string, unknown>>(input: {
   [K in keyof T]: DataState<T[K]>;
 }): DataState<T> {

--- a/packages/keystatic/src/config.tsx
+++ b/packages/keystatic/src/config.tsx
@@ -46,6 +46,7 @@ export type GitHubConfig<
   storage: {
     kind: 'github';
     repo: RepoConfig;
+    pathPrefix?: string;
   };
   collections?: Collections;
   singletons?: Singletons;
@@ -82,7 +83,7 @@ export type CloudConfig<
     [key: string]: Singleton<Record<string, ComponentSchema>>;
   }
 > = {
-  storage: { kind: 'cloud' };
+  storage: { kind: 'cloud'; pathPrefix?: string };
   cloud: { project: string };
   collections?: Collections;
   singletons?: Singletons;
@@ -105,8 +106,9 @@ export type Config<
     | {
         kind: 'github';
         repo: RepoConfig;
+        pathPrefix?: string;
       }
-    | { kind: 'cloud' };
+    | { kind: 'cloud'; pathPrefix?: string };
   collections?: Collections;
   singletons?: Singletons;
 } & ({} extends Collections ? {} : { collections: Collections }) &


### PR DESCRIPTION
This simplifies using Keystatic in monorepos by scoping all paths to a particular directory


```js
export default config({
  storage: {
    kind: 'github',
    repo: 'my-org/my-repo',
    pathPrefix: 'somewhere/my-site'
  },
  collections: {
    posts: collection({
      label: 'Posts',
      path: 'content/posts/*/',
      // ...
    })
  },
})
```
