### PR TITLE
Mispelling in content organization documentation

### DIFF
--- a/docs/src/content/pages/content-organisation.mdoc
+++ b/docs/src/content/pages/content-organisation.mdoc
@@ -111,7 +111,7 @@ If not specified, the default `path` value for singletons will be `{singleton-na
 
 ### Singleton paths ending with a trailing slash `/`
 
-If the path ends with a trailing slash `/`, the singleton's content ill be created in its own directory named after the slug:
+If the path ends with a trailing slash `/`, the singleton's content will be created in its own directory named after the slug:
 
 ```yaml
 singleton-name


### PR DESCRIPTION
This is a simple misspelling but thought it would nevertheless be worth fixing.