### PR TITLE
Add `previewUrl` option

### DIFF
--- a/.changeset/hungry-yaks-dance.md
+++ b/.changeset/hungry-yaks-dance.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Add `previewUrl` option

--- a/docs/keystatic.config.tsx
+++ b/docs/keystatic.config.tsx
@@ -88,6 +88,7 @@ export default config({
       entryLayout: 'content',
       format: { contentField: 'content' },
       path: 'src/content/pages/**',
+      previewUrl: '/docs/{slug}',
       schema: {
         title: fields.slug({ name: { label: 'Title' } }),
         summary: fields.text({
@@ -117,6 +118,7 @@ export default config({
       format: {
         contentField: 'content',
       },
+      previewUrl: '/blog/{slug}',
       schema: {
         title: fields.slug({
           name: {

--- a/packages/keystatic/src/config.tsx
+++ b/packages/keystatic/src/config.tsx
@@ -14,6 +14,7 @@ export type Collection<
   path?: `${string}/${Glob}` | `${string}/${Glob}/${string}`;
   entryLayout?: EntryLayout;
   format?: Format;
+  previewUrl?: `${string}{slug}${string}`;
   slugField: SlugField;
   schema: Schema;
 };
@@ -23,6 +24,7 @@ export type Singleton<Schema extends Record<string, ComponentSchema>> = {
   path?: string;
   entryLayout?: EntryLayout;
   format?: Format;
+  previewUrl?: string;
   schema: Schema;
 };
 


### PR DESCRIPTION
This adds a `previewUrl` option to collections and singletons that adds a link to where a user should see the output for the entry. For collections, `{slug}` can be used in the string to interpolate the slug.

This also aligns the header buttons on singletons with collections