### PR TITLE
Center loading indicator on Keystatic Cloud auth callback page

### DIFF
--- a/.changeset/new-rivers-sit.md
+++ b/.changeset/new-rivers-sit.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Center loading indicator on Keystatic Cloud auth callback page

--- a/packages/keystatic/src/app/cloud-auth-callback.tsx
+++ b/packages/keystatic/src/app/cloud-auth-callback.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { Config } from '../config';
 import { useRouter } from './router';
 import { KEYSTATIC_CLOUD_API_URL, KEYSTATIC_CLOUD_HEADERS } from './utils';
+import { Flex } from '@keystar/ui/layout';
 
 const storedStateSchema = z.object({
   state: z.string(),
@@ -91,8 +92,12 @@ export function KeystaticCloudAuthCallback({ config }: { config: Config }) {
     return <Text>{error.message}</Text>;
   }
   return (
-    <div>
-      <ProgressCircle isIndeterminate aria-label="Authenticating" />
-    </div>
+    <Flex justifyContent="center" alignItems="center" height="100vh">
+      <ProgressCircle
+        size="large"
+        isIndeterminate
+        aria-label="Authenticating"
+      />
+    </Flex>
   );
 }


### PR DESCRIPTION
<img width="1840" alt="blank webpage with a loading indicator in the center" src="https://github.com/Thinkmill/keystatic/assets/11481355/de0ac9e8-7b2f-4f20-b50f-5618a1b25214">
