### PR TITLE
`toolbarIcon` option in component blocks

### DIFF
--- a/.changeset/tiny-garlics-chew.md
+++ b/.changeset/tiny-garlics-chew.md
@@ -1,0 +1,6 @@
+---
+'@keystatic/core': patch
+---
+
+Add `toolbarIcon` option to component blocks and show `cloudImage` component in
+toolbar

--- a/packages/keystatic/src/component-blocks/blank-for-react-server.tsx
+++ b/packages/keystatic/src/component-blocks/blank-for-react-server.tsx
@@ -1,1 +1,3 @@
 export function CloudImagePreview() {}
+
+export let cloudImageToolbarIcon = undefined;

--- a/packages/keystatic/src/component-blocks/cloud-image-preview.tsx
+++ b/packages/keystatic/src/component-blocks/cloud-image-preview.tsx
@@ -577,3 +577,5 @@ function getAspectRatio(state: ImageDimensions) {
   if (!state.width || !state.height) return 1;
   return state.width / state.height;
 }
+
+export const cloudImageToolbarIcon = imageIcon;

--- a/packages/keystatic/src/component-blocks/cloud-image.tsx
+++ b/packages/keystatic/src/component-blocks/cloud-image.tsx
@@ -1,5 +1,5 @@
 import { component } from '..';
-import { CloudImagePreview } from '#cloud-image-preview';
+import { CloudImagePreview, cloudImageToolbarIcon } from '#cloud-image-preview';
 import { cloudImageSchema } from './cloud-image-schema';
 
 /** @deprecated Experimental */
@@ -10,5 +10,6 @@ export function cloudImage(args: { label: string }) {
     preview: CloudImagePreview,
     chromeless: true,
     toolbar: null,
+    toolbarIcon: cloudImageToolbarIcon,
   });
 }

--- a/packages/keystatic/src/form/api.tsx
+++ b/packages/keystatic/src/form/api.tsx
@@ -280,6 +280,7 @@ export type ComponentBlock<
   preview: (props: any) => ReactElement | null;
   schema: Fields;
   label: string;
+  toolbarIcon?: ReactElement;
 } & (
   | {
       chromeless: true;
@@ -451,6 +452,8 @@ export function component<
     schema: Schema;
     /** The label to show in the insert menu and chrome around the block if chromeless is false */
     label: string;
+    /** An icon to show in the toolbar for this component block. Component blocks with `toolbarIcon` are shown in the toolbar directly instead of the insert menu */
+    toolbarIcon?: ReactElement;
   } & (
     | {
         chromeless: true;


### PR DESCRIPTION
<img width="1820" alt="keystatic with the cursor over a button in the editor toolbar with an image icon and a tooltip saying cloud image" src="https://github.com/Thinkmill/keystatic/assets/11481355/1a59fe27-4762-42aa-93b8-744079b85095">
