### PR TITLE
Docs: Add hint to changelog to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Follow [@thekeystatic](https://twitter.com/thekeystatic) on Twitter, and
 [subscribe to our mailing list](https://keystatic.com/#mailing-list) for
 updates.
 
+Changes and releases are documented in [our changelog](https://github.com/Thinkmill/keystatic/blob/main/docs/CHANGELOG.md).
+
 Feedback on how we're going, what you're looking for, and what you'd like to see
 next is super helpful as we progress!
 [Join the discussion on GitHub](https://github.com/Thinkmill/keystatic/discussions)


### PR DESCRIPTION
I was looking for the changelog on the Repo page in Github and could not find it easily. ~~It is "hidden" in the docs in this Repo, which is a bit unusual IMO. This add the search term to the readme so people who cmd+f for "changelog" will find it faster. (I did find it using the file search…).~~

Update: Sorry, this is wrong. There are multiple changelogs.