### PR TITLE
Fix incorrect repo URL

### DIFF
--- a/docs/src/app/(public)/showcase/page.tsx
+++ b/docs/src/app/(public)/showcase/page.tsx
@@ -91,7 +91,7 @@ function ProjectCard({ entry, slug }: Project) {
           {entry.repoUrl && (
             <ActionButton
               impact="light"
-              href={entry.url ?? ''}
+              href={entry.repoUrl}
               icon={GitHubOutlineIcon}
             >
               View on GitHub


### PR DESCRIPTION
At the moment, the "View on Github" button on https://keystatic.com/showcase incorrectly links to the project's URL. It should instead link to the repository URL. This pull request fixes that.