### PR TITLE
Use raw.githubusercontent.com to fetch files for public repos

### DIFF
--- a/.changeset/famous-mails-know.md
+++ b/.changeset/famous-mails-know.md
@@ -1,0 +1,5 @@
+---
+"@keystatic/core": patch
+---
+
+Improve performance of loading entries in public repositories

--- a/packages/keystatic/src/app/shell/data.tsx
+++ b/packages/keystatic/src/app/shell/data.tsx
@@ -320,8 +320,9 @@ export function GitHubAppShellProvider(props: {
     () => ({
       baseCommit: baseCommit || '',
       repositoryId: repo?.id ?? '',
+      isPrivate: repo?.isPrivate ?? true,
     }),
-    [baseCommit, repo?.id]
+    [baseCommit, repo?.id, repo?.isPrivate]
   );
   const pullRequestNumber =
     currentBranchRef?.associatedPullRequests.nodes?.[0]?.number;
@@ -386,7 +387,11 @@ export const AppShellErrorContext = createContext<CombinedError | undefined>(
   undefined
 );
 
-const BaseInfoContext = createContext({ baseCommit: '', repositoryId: '' });
+const BaseInfoContext = createContext({
+  baseCommit: '',
+  repositoryId: '',
+  isPrivate: true,
+});
 
 const ChangedContext = createContext<{
   collections: Map<
@@ -445,6 +450,10 @@ export function useBaseCommit() {
   return useContext(BaseInfoContext).baseCommit;
 }
 
+export function useIsRepoPrivate() {
+  return useContext(BaseInfoContext).isPrivate;
+}
+
 export function useRepositoryId() {
   return useContext(BaseInfoContext).repositoryId;
 }
@@ -476,6 +485,7 @@ export const Ref_base = gql`
 const BaseRepo = gql`
   fragment Repo_base on Repository {
     id
+    isPrivate
     owner {
       id
       login


### PR DESCRIPTION
This makes loading entries faster in public repos by using `raw.githubusercontent.com` to load files which is generally just faster than the blobs API we use otherwise and it doesn't have aggressive rate limits which means we don't need to provide an auth token so no CORS pre-flight requests are necessary which saves a whole round-trip. Of course since we're not providing an auth token, it only works for public repos. (we can't just always use it and provide an auth token because `raw.githubusercontent.com` doesn't respond to CORS pre-flight requests. It does have an alternative way of authenticating with short-lived tokens that go in the url but there isn't an API to explicitly generate them (it does seem like they're available in the `download_url` property of https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content but that seems a bit finicky so I'm not going to use that for now))