### PR TITLE
Use minimal router in `@keystatic/core` over different ones for each framework

### DIFF
--- a/.changeset/curly-cows-press.md
+++ b/.changeset/curly-cows-press.md
@@ -1,0 +1,8 @@
+---
+'@keystatic/astro': major
+'@keystatic/remix': major
+'@keystatic/next': major
+'@keystatic/core': minor
+---
+
+Update router integration between `@keystatic/core` and framework integration packages to improve performance

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -48,7 +48,6 @@
     "@babel/runtime": "^7.18.3",
     "@types/react": "^18.2.8",
     "cookie": "^0.5.0",
-    "react-router-dom": "^6.8.1",
     "set-cookie-parser": "^2.5.1"
   },
   "devDependencies": {

--- a/packages/astro/src/ui.tsx
+++ b/packages/astro/src/ui.tsx
@@ -1,82 +1,14 @@
-import React, {
-  AnchorHTMLAttributes,
-  forwardRef,
-  Ref,
-  useContext,
-  useMemo,
-} from 'react';
+import React from 'react';
 import { Config } from '@keystatic/core';
-import { Keystatic as GenericKeystatic, Router } from '@keystatic/core/ui';
-import {
-  createBrowserRouter,
-  Link,
-  RouterProvider,
-  useHref,
-  useLocation,
-  useNavigate,
-} from 'react-router-dom';
-
-const KeystaticLink = forwardRef(function KeystaticLink(
-  {
-    href,
-    ...props
-  }: { href: string } & AnchorHTMLAttributes<HTMLAnchorElement>,
-  ref: Ref<HTMLAnchorElement>
-) {
-  return <Link to={href} {...props} ref={ref} />;
-});
-
-function ReactRouterKeystatic() {
-  const config = useContext(ConfigContext)!;
-  const navigate = useNavigate();
-  const location = useLocation();
-  const href = useHref(location);
-  const keystaticRouter = useMemo((): Router => {
-    const replaced = location.pathname.replace(/^\/keystatic\/?/, '');
-    const params =
-      replaced === '' ? [] : replaced.split('/').map(decodeURIComponent);
-
-    return {
-      push(path) {
-        navigate(path);
-      },
-      replace(path) {
-        navigate(path, { replace: true });
-      },
-      href,
-      params,
-    };
-  }, [navigate, href, location.pathname]);
-  return (
-    <GenericKeystatic
-      router={keystaticRouter}
-      config={config}
-      link={KeystaticLink}
-      appSlug={appSlug}
-    />
-  );
-}
+import { Keystatic as GenericKeystatic } from '@keystatic/core/ui';
 
 const appSlug = {
   envName: 'PUBLIC_KEYSTATIC_GITHUB_APP_SLUG',
   value: import.meta.env.PUBLIC_KEYSTATIC_GITHUB_APP_SLUG,
 };
 
-const ConfigContext = React.createContext<Config<any, any> | null>(null);
-
-const router = createBrowserRouter([
-  {
-    path: '/keystatic/*',
-    element: <ReactRouterKeystatic />,
-  },
-]);
-
 export function makePage(config: Config<any, any>) {
   return function Keystatic() {
-    return (
-      <ConfigContext.Provider value={config}>
-        <RouterProvider router={router} />
-      </ConfigContext.Provider>
-    );
+    return <GenericKeystatic config={config} appSlug={appSlug} />;
   };
 }

--- a/packages/keystatic/src/app/router.tsx
+++ b/packages/keystatic/src/app/router.tsx
@@ -1,4 +1,12 @@
-import { createContext, ReactNode, useContext } from 'react';
+import React, {
+  createContext,
+  ReactNode,
+  startTransition,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 export type Router = {
   push: (path: string) => void;
@@ -9,9 +17,52 @@ export type Router = {
 
 const RouterContext = createContext<Router | null>(null);
 
-export function RouterProvider(props: { router: Router; children: ReactNode }) {
+export function RouterProvider(props: { children: ReactNode }) {
+  const [url, setUrl] = useState(() => window.location.href);
+
+  const router = useMemo((): Router => {
+    function navigate(url: string, replace: boolean) {
+      const newUrl = new URL(url, window.location.href);
+      if (
+        newUrl.origin !== window.location.origin ||
+        !newUrl.pathname.startsWith('/keystatic')
+      ) {
+        window.location.assign(newUrl);
+        return;
+      }
+      window.history[replace ? 'replaceState' : 'pushState'](null, '', newUrl);
+      startTransition(() => {
+        setUrl(newUrl.toString());
+      });
+    }
+    const replaced = location.pathname.replace(/^\/keystatic\/?/, '');
+    const params =
+      replaced === '' ? [] : replaced.split('/').map(decodeURIComponent);
+    const parsedUrl = new URL(url);
+    return {
+      href: parsedUrl.pathname + parsedUrl.search,
+      replace(path) {
+        navigate(path, true);
+      },
+      push(path) {
+        navigate(path, false);
+      },
+      params,
+    };
+  }, [url]);
+  useEffect(() => {
+    const handleNavigate = () => {
+      startTransition(() => {
+        setUrl(window.location.href);
+      });
+    };
+    window.addEventListener('popstate', handleNavigate);
+    return () => {
+      window.removeEventListener('popstate', handleNavigate);
+    };
+  }, []);
   return (
-    <RouterContext.Provider value={props.router}>
+    <RouterContext.Provider value={router}>
       {props.children}
     </RouterContext.Provider>
   );

--- a/packages/next/src/ui/app.tsx
+++ b/packages/next/src/ui/app.tsx
@@ -1,53 +1,9 @@
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import Link from 'next/link';
-import { useEffect, useMemo, useState } from 'react';
 import { Config } from '@keystatic/core';
-import { Keystatic, Router } from '@keystatic/core/ui';
-
-let _isClient = false;
-function useIsClient() {
-  const [isClient, setIsClient] = useState(_isClient);
-  useEffect(() => {
-    _isClient = true;
-    setIsClient(true);
-  }, []);
-  return isClient;
-}
+import { Keystatic } from '@keystatic/core/ui';
 
 export function makePage(config: Config<any, any>) {
   return function Page() {
-    const isClient = useIsClient();
-    const router = useRouter();
-    const pathname = usePathname()!;
-    let href = pathname;
-    const searchParams = useSearchParams()!.toString();
-    if (searchParams) {
-      href += `?${searchParams}`;
-    }
-    const keystaticRouter = useMemo((): Router => {
-      const replaced = pathname.replace(/^\/keystatic\/?/, '');
-      const params =
-        replaced === '' ? [] : replaced.split('/').map(decodeURIComponent);
-      return {
-        href,
-        params,
-        push: async path => {
-          router.push(path);
-        },
-        replace: async path => {
-          router.replace(path);
-        },
-      };
-    }, [href, router, pathname]);
-    if (!isClient) return null;
-    return (
-      <Keystatic
-        router={keystaticRouter}
-        config={config}
-        link={Link}
-        appSlug={appSlug}
-      />
-    );
+    return <Keystatic config={config} appSlug={appSlug} />;
   };
 }
 

--- a/packages/next/src/ui/pages.tsx
+++ b/packages/next/src/ui/pages.tsx
@@ -1,38 +1,9 @@
-import { useRouter } from 'next/router';
-import Link from 'next/link';
-import { useMemo } from 'react';
 import { Config } from '@keystatic/core';
-import { Keystatic, Router } from '@keystatic/core/ui';
+import { Keystatic } from '@keystatic/core/ui';
 
 export function makePage(config: Config<any, any>) {
   return function Page() {
-    const router = useRouter();
-    const keystaticRouter = useMemo((): null | Router => {
-      if (!router.isReady) return null;
-      const params = (router.query.params ??
-        router.query.rest ??
-        []) as string[];
-
-      return {
-        href: router.asPath,
-        params,
-        push: path => {
-          router.push(path);
-        },
-        replace: path => {
-          router.replace(path);
-        },
-      };
-    }, [router]);
-    if (!keystaticRouter) return null;
-    return (
-      <Keystatic
-        router={keystaticRouter}
-        config={config}
-        link={Link}
-        appSlug={appSlug}
-      />
-    );
+    return <Keystatic config={config} appSlug={appSlug} />;
   };
 }
 

--- a/packages/remix/src/ui.tsx
+++ b/packages/remix/src/ui.tsx
@@ -1,63 +1,8 @@
-import { Link, useNavigate, useLocation, useHref } from '@remix-run/react';
-import {
-  AnchorHTMLAttributes,
-  forwardRef,
-  Ref,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
 import { Config } from '@keystatic/core';
-import { Keystatic, Router } from '@keystatic/core/ui';
-
-let _isClient = false;
-function useIsClient() {
-  const [isClient, setIsClient] = useState(_isClient);
-  useEffect(() => {
-    _isClient = true;
-    setIsClient(true);
-  }, []);
-  return isClient;
-}
-
-const KeystaticLink = forwardRef(function KeystaticLink(
-  {
-    href,
-    ...props
-  }: { href: string } & AnchorHTMLAttributes<HTMLAnchorElement>,
-  ref: Ref<HTMLAnchorElement>
-) {
-  return <Link to={href} {...props} ref={ref} />;
-});
+import { Keystatic } from '@keystatic/core/ui';
 
 export function makePage(config: Config<any, any>) {
   return function Page() {
-    const isClient = useIsClient();
-    const location = useLocation();
-    const href = useHref(location);
-    const navigate = useNavigate();
-    const keystaticRouter = useMemo((): Router => {
-      const replaced = location.pathname.replace(/^\/keystatic\/?/, '');
-      const params =
-        replaced === '' ? [] : replaced.split('/').map(decodeURIComponent);
-      return {
-        href,
-        params,
-        push: async path => {
-          navigate(path);
-        },
-        replace: async path => {
-          navigate(path, { replace: true });
-        },
-      };
-    }, [href, navigate, location.pathname]);
-    if (!isClient) return null;
-    return (
-      <Keystatic
-        router={keystaticRouter}
-        config={config}
-        link={KeystaticLink}
-      />
-    );
+    return <Keystatic config={config} />;
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -722,13 +722,11 @@ importers:
       cookie: ^0.5.0
       react: ^18.2.0
       react-dom: ^18.2.0
-      react-router-dom: ^6.8.1
       set-cookie-parser: ^2.5.1
     dependencies:
       '@babel/runtime': 7.22.15
       '@types/react': 18.2.21
       cookie: 0.5.0
-      react-router-dom: 6.15.0_biqbaboplfbrettd7655fr4n2y
       set-cookie-parser: 2.6.0
     devDependencies:
       '@keystatic/core': link:../keystatic
@@ -6415,11 +6413,6 @@ packages:
   /@remix-run/router/1.7.2:
     resolution: {integrity: sha512-7Lcn7IqGMV+vizMPoEl5F0XDshcdDYtMI6uJLQdQz5CfZAwy3vvGKYSUk789qndt5dEC4HfSjviSYlSoHGL2+A==}
     engines: {node: '>=14'}
-
-  /@remix-run/router/1.8.0:
-    resolution: {integrity: sha512-mrfKqIHnSZRyIzBcanNJmVQELTnX+qagEDlcKO90RgRBVOZGSGvZKeDihTRfWcqoDn5N/NkUcwWTccnpN18Tfg==}
-    engines: {node: '>=14.0.0'}
-    dev: false
 
   /@remix-run/serve/1.19.3:
     resolution: {integrity: sha512-RUVEy7EBYvHO1hIuyVQJyIYZeFfXecC+Uaw6GvZscLywIGnhcAj+5dpeK6HVayNuV4kKLvBp0F4ZGHbwW1oWaA==}
@@ -18446,19 +18439,6 @@ packages:
       react-dom: 18.2.0_react@18.2.0
       react-router: 6.14.2_react@18.2.0
 
-  /react-router-dom/6.15.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-aR42t0fs7brintwBGAv2+mGlCtgtFQeOzK0BM1/OiqEzRejOZtpMZepvgkscpMUnKb8YO84G7s3LsHnnDNonbQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.8.0
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      react-router: 6.15.0_react@18.2.0
-    dev: false
-
   /react-router/6.14.2_react@18.2.0:
     resolution: {integrity: sha512-09Zss2dE2z+T1D03IheqAFtK4UzQyX8nFPWx6jkwdYzGLXd5ie06A6ezS2fO6zJfEb/SpG6UocN2O1hfD+2urQ==}
     engines: {node: '>=14'}
@@ -18467,16 +18447,6 @@ packages:
     dependencies:
       '@remix-run/router': 1.7.2
       react: 18.2.0
-
-  /react-router/6.15.0_react@18.2.0:
-    resolution: {integrity: sha512-NIytlzvzLwJkCQj2HLefmeakxxWHWAP+02EGqWEZy+DgfHHKQMUoBBjUQLOtFInBMhWtb3hiUy6MfFgwLjXhqg==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.8.0
-      react: 18.2.0
-    dev: false
 
   /react-style-singleton/2.2.1_gq4reeurwxuj4hvyerswzzqthy:
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}


### PR DESCRIPTION
This improves performance of navigating around Keystatic by avoiding using different routers for each framework and instead has some minimal pushState & popstate handling in Keystatic itself. It's particularly good in the Next app directory because it avoids fetching the server component payload on each payload (that takes e.g. 300ms for me on https://keystatic.com/keystatic). It's a breaking change for the different framework packages since they need the newer version of `@keystatic/core`.