### PR TITLE
Don't pin peer dependency to exact next.js version

### DIFF
--- a/.changeset/chatty-bags-relate.md
+++ b/.changeset/chatty-bags-relate.md
@@ -1,0 +1,5 @@
+---
+"@keystar/ui": patch
+---
+
+Fix `next` peer dependency being pinned to an exact version

--- a/design-system/pkg/package.json
+++ b/design-system/pkg/package.json
@@ -6241,7 +6241,7 @@
     "tsx": "^3.8.0"
   },
   "peerDependencies": {
-    "next": "^14.0.0",
+    "next": "13 || 14",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/design-system/pkg/package.json
+++ b/design-system/pkg/package.json
@@ -6241,7 +6241,7 @@
     "tsx": "^3.8.0"
   },
   "peerDependencies": {
-    "next": "14.0.0",
+    "next": "^14.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
don't pin next.js peer dependency to exact version to avoid errors like:

```
 WARN  Issues with peer dependencies found
.
└─┬ @keystatic/core 0.1.9
  └─┬ @keystar/ui 0.4.0
    └── ✕ unmet peer next@14.0.0: found 14.0.1

```