### PR TITLE
Field types

### DIFF
--- a/.changeset/shy-rabbits-behave.md
+++ b/.changeset/shy-rabbits-behave.md
@@ -1,0 +1,5 @@
+---
+'@keystar/ui': patch
+---
+
+Fix field types.

--- a/design-system/pkg/src/checkbox/types.ts
+++ b/design-system/pkg/src/checkbox/types.ts
@@ -4,7 +4,6 @@ import {
   InputBase,
   FocusableProps,
   Orientation,
-  Validation,
 } from '@react-types/shared';
 import { ReactNode } from 'react';
 
@@ -20,6 +19,8 @@ export type ToggleProps = {
    * Whether the element should be selected (uncontrolled).
    */
   defaultSelected?: boolean;
+  /** Whether user input is required on the input before form submission. */
+  isRequired?: boolean;
   /**
    * Whether the element should be selected (controlled).
    */
@@ -37,7 +38,6 @@ export type ToggleProps = {
    */
   name?: string;
 } & InputBase &
-  Pick<Validation, 'isRequired'> &
   FocusableProps;
 
 export type CheckboxProps = {

--- a/design-system/pkg/src/field/types.tsx
+++ b/design-system/pkg/src/field/types.tsx
@@ -1,10 +1,5 @@
 import { LabelAria } from '@react-aria/label';
-import {
-  AriaLabelingProps,
-  DOMProps,
-  InputBase,
-  Validation,
-} from '@react-types/shared';
+import { AriaLabelingProps, DOMProps, InputBase } from '@react-types/shared';
 import { HTMLAttributes, ReactElement, ReactNode } from 'react';
 
 import { BaseStyleProps } from '@keystar/ui/style';
@@ -33,10 +28,11 @@ export type FieldProps = {
    * criteria.
    */
   errorMessage?: ReactNode;
+  /** Whether user input is required on the input before form submission. */
+  isRequired?: boolean;
   /** Concisely label the field. */
   label?: ReactNode;
 } & InputBase &
-  Pick<Validation, 'isRequired'> &
   AriaLabelingProps &
   BaseStyleProps &
   DOMProps;


### PR DESCRIPTION
The type `require("@react-types/shared").Validation` is now a generic. We don't need the other stuff, so just replace with inline types.