### PR TITLE
Fleshed out Keystatic Cloud documentation

### DIFF
--- a/docs/src/content/navigation.yaml
+++ b/docs/src/content/navigation.yaml
@@ -102,7 +102,7 @@ navGroups:
         link:
           discriminant: page
           value: user-interface
-        isNew: false
+        isNew: true
   - groupName: Fields API
     items:
       - label: Array

--- a/docs/src/content/navigation.yaml
+++ b/docs/src/content/navigation.yaml
@@ -125,6 +125,11 @@ navGroups:
           discriminant: page
           value: fields/child
         isNew: false
+      - label: Cloud Image
+        link:
+          discriminant: page
+          value: fields/cloud-image
+        isNew: true
       - label: Conditional
         link:
           discriminant: page

--- a/docs/src/content/navigation.yaml
+++ b/docs/src/content/navigation.yaml
@@ -45,15 +45,15 @@ navGroups:
           discriminant: page
           value: local-mode
         isNew: false
-      - label: GitHub mode
-        link:
-          discriminant: page
-          value: github-mode
-        isNew: false
       - label: Keystatic Cloud
         link:
           discriminant: page
           value: cloud
+        isNew: true
+      - label: GitHub mode
+        link:
+          discriminant: page
+          value: github-mode
         isNew: false
   - groupName: Recipes
     items:

--- a/docs/src/content/pages/cloud.mdoc
+++ b/docs/src/content/pages/cloud.mdoc
@@ -83,11 +83,7 @@ https://[IMAGE_URL]?width=240&height=480&fit=crop
 
 ### Cloud image field
 
-Keystatic provides a `cloudImage` field, which can be used instead of the [regular image field](/docs/fields/image) if Keystatic is running in cloud mode, and the Image Library is enabled for the project.
-
-{% aside icon="🚧" %}
-Documentation for the `cloudImage` field is coming soon.
-{% /aside %}
+Keystatic provides a [`cloudImage` field](/docs/fields/cloud-image), which can be used instead of the [regular image field](/docs/fields/image) if Keystatic is running in cloud mode, and the Image Library is enabled for the project.
 
 ### Cloud image component block (experimental)
 

--- a/docs/src/content/pages/cloud.mdoc
+++ b/docs/src/content/pages/cloud.mdoc
@@ -26,7 +26,7 @@ You can also join the [\#cloud](https://discord.gg/vCAQaH7dEp) channel on [Disco
 
 Keystatic Cloud lets you connect to GitHub and authenticate for one or multiple Keystatic projects.
 
-It skips the more complicated process of [setting up GitHub mode](/docs/github-mode), while also allowing team mebers to edit content without needing a GitHub account.
+It skips the more complicated process of [setting up GitHub mode](/docs/github-mode), while also allowing team members to edit content without needing a GitHub account.
 
 You'll need to [create a Keystatic Cloud account](https://keystatic.cloud) to start using this service.
 

--- a/docs/src/content/pages/cloud.mdoc
+++ b/docs/src/content/pages/cloud.mdoc
@@ -1,16 +1,100 @@
 ---
 title: Keystatic Cloud
 summary: >-
-  Keystatic Cloud takes care of GitHub authentication for you, and provides an opt-in image storage, optimisation and delivery service.
+  Keystatic Cloud takes care of GitHub authentication for you, and provides an
+  opt-in image storage, optimisation and delivery service.
 ---
-[Keystatic Cloud](https://keystatic.cloud) is a service provided by [Thinkmill](https://thinkmill.com.au). 
+[Keystatic Cloud](https://keystatic.cloud) is a service provided by [Thinkmill](https://thinkmill.com.au).
 
 Cloud simplifies authentication (GitHub) with your projects. No need to deal with environment variables and a custom GitHub app.
 
- Keystatic Cloud also offers opt-in products such as **Cloud Images** — an image storage, optimisation and delivery service.
+Keystatic Cloud also offers opt-in products such as **Cloud Images** — an image storage, optimisation and delivery service.
 
-## Internal preview
+---
 
-Keystatic Cloud — **Cloud Images** in particular — is currently at the "internal preview" stage. If you're interested in using it, please [get in touch with the Thinkmill team](https://thinkmill.com.au/contact).
+{% aside icon="👀" %}
+Keystatic Cloud — [Cloud Images](#cloud-images) in particular — is currently at the "internal preview" stage. 
 
-You can also join the [#cloud](https://discord.gg/vCAQaH7dEp) channel on the [Keystatic Discord server](https://discord.gg/vCAQaH7dEp).
+If you're interested in using it, please [get in touch with the Thinkmill team](https://thinkmill.com.au/contact).
+
+You can also join the [\#cloud](https://discord.gg/vCAQaH7dEp) channel on [Discord](https://discord.gg/vCAQaH7dEp).
+{% /aside %}
+
+---
+
+## Authentication
+
+Keystatic Cloud lets you connect to GitHub and authenticate for one or multiple Keystatic projects.
+
+It skips the more complicated process of [setting up GitHub mode](/docs/github-mode), while also allowing team mebers to edit content without needing a GitHub account.
+
+You'll need to [create a Keystatic Cloud account](https://keystatic.cloud) to start using this service.
+
+You can setup multiple projects in your Keystatic Cloud account — where each project is connected to a specific GitHub repository.
+
+### Configuring your project
+
+In your Keystatic config, you'll need to set the `storage` option to `cloud`. 
+
+You'll also need to add the `cloud.project` property with the name of the team and project from your Keystatic Cloud account:
+
+```ts 
+import { config } from '@keystatic/core'
+
+export default config({
+  storage: {
+    kind: 'cloud',
+  },
+  cloud: {
+    project: '[TEAM_NAME]/[PROJECT_NAME]',
+  },
+  ...
+})
+```
+
+Each project in Keystatic Cloud has a settings page where you'll find a ready-to-paste code snippet in your config file.
+
+---
+
+## Cloud Images
+
+Cloud Images is an opt-in service from Keystatic Cloud. It's an image storage and delivery service that optimises your images for the web.
+
+Each Keystatic Cloud project can have its own Image Library, where you can upload images and copy the URL to use in your content.
+
+### Image optimisation via URL query parameters
+
+When using Keystatic Cloude image URLs, you can pass the following optional query parameters to drastically improve the performance of your images:
+
+- **`fit`** — how the image should be resized to fit the dimensions you specify. Possible values are `scale-down`, `contain`, `cover` and `crop`.
+- **`format`** — the image format to use. Possible values are `png`, `avif`, `webp` and `jpeg`. 
+  If no format is provided, Keystatic Cloud will auto-detect browser capabilities and serve the most optimal format.
+- **`quality`** — the quality of the image. A number between `1` and `100`.
+- **`height`** — the height of the image. A number between `1` and `10240`.
+- **`width`** — the width of the image. A number between `1` and `10240`.
+
+You can provide one or both of height and width, which will have a different effect based on the fit.
+
+Here's an example URL with image transform query parameters: 
+
+```
+https://[IMAGE_URL]?width=240&height=480&fit=crop
+```
+
+### Cloud image field
+
+Keystatic provides a `cloudImage` field, which can be used instead of the [regular image field](/docs/fields/image) if Keystatic is running in cloud mode, and the Image Library is enabled for the project.
+
+{% aside icon="🚧" %}
+Documentation for the `cloudImage` field is coming soon.
+{% /aside %}
+
+### Cloud image component block (experimental)
+
+Keystatic also provides a `CloudImage` component block, which can be used within the flow of a [document field](/docs/fields/document).
+
+Again, you'll need Keystatic running in `cloud` mode, and have the Image Library enabled for the project.
+
+{% aside icon="🚧" %}
+Documentation for the `CloudImage` component block is coming soon.
+{% /aside %}

--- a/docs/src/content/pages/fields/cloud-image.mdoc
+++ b/docs/src/content/pages/fields/cloud-image.mdoc
@@ -1,0 +1,38 @@
+---
+title: Cloud Image field
+summary: The cloud image field is used to work with Keystatic Cloud Images.
+---
+The `cloudImage` field is used to work in conjunction with [Keystatic Cloud](/docs/cloud)'s [Image Library](/docs/cloud#cloud-images).
+
+Instead of storing the image itself, the field stores a reference to the image in the cloud.
+
+{% cloud-image
+   src="https://thinkmill-labs.keystatic.net/keystatic-site/images/lut0do0vglkz/cleanshot-2023-11-21-at-17-08-40-2x"
+   alt="Screenshot of the Cloud Image field modal UI"
+   height=952
+   width=1420 /%}
+
+## Returned value
+
+The returned value for this field is an object with the following properties:
+
+- **`src`**: the URL of the image
+- **`alt`**: the default alt text as set in the Image Library
+- **`height`**: the height of the image
+- **`width`**: the width of the image
+
+## Example usage
+
+```typescript
+avatar: fields.cloudImage({
+  label: 'Avatar',
+  description: 'The avatar for this user',
+  validation: {
+    isRequired: true
+  }
+})
+```
+
+## Type signature
+
+Find the latest version of this field's type signature at: [https://docsmill.dev/npm/@keystatic/core@latest#/.fields.cloudImage](https://docsmill.dev/npm/@keystatic/core@latest#/.fields.cloudImage)


### PR DESCRIPTION
- Sets the new `new` badge to the Cloud page to indicate new content
- Adds documentation about creating a Keystatic Cloud account and setting up authentication
- Adds documentation about the Cloud image transforms via optional URL query parameters
- Adds introduction to the `cloudImage` field and the `CloudImage` componentBlock, which will both have documentation pages dressed up shortly after.