### PR TITLE
ProseMirror insert menu decoration

### DIFF
--- a/.changeset/silent-gifts-beam.md
+++ b/.changeset/silent-gifts-beam.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+ProseMirror editor: support and populate "description" + "icon" on insert menu items.

--- a/packages/keystatic/src/form/fields/markdoc/editor/autocomplete/insert-menu.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/autocomplete/insert-menu.tsx
@@ -1,7 +1,10 @@
+import { Icon } from '@keystar/ui/icon';
+import { Text } from '@keystar/ui/typography';
 import { matchSorter } from 'match-sorter';
 import { NodeType } from 'prosemirror-model';
 import { Command, EditorState } from 'prosemirror-state';
 import { useMemo } from 'react';
+
 import { weakMemoize } from '../utils';
 import {
   addAutocompleteDecoration,
@@ -23,6 +26,7 @@ import { EditorSchema } from '../schema';
 export type InsertMenuItemSpec = {
   label: string;
   description?: string;
+  icon?: React.ReactElement;
   command: (type: NodeType, schema: EditorSchema) => Command;
 };
 
@@ -34,6 +38,7 @@ export type InsertMenuItem = {
   id: string;
   label: string;
   description?: string;
+  icon?: React.ReactElement;
   forToolbar?: true;
   command: Command;
 };
@@ -75,7 +80,9 @@ function wrapInsertMenuCommand(command: Command): Command {
 function childRenderer(item: InsertMenuItem) {
   return (
     <Item key={item.id} textValue={item.label}>
-      {item.label}
+      <Text>{item.label}</Text>
+      {item.description && <Text slot="description">{item.description}</Text>}
+      {item.icon && <Icon src={item.icon} />}
     </Item>
   );
 }

--- a/packages/keystatic/src/form/fields/markdoc/editor/popovers/index.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/popovers/index.tsx
@@ -248,7 +248,7 @@ function PopoverInner(props: {
       <EditorPopover
         reference={reference}
         placement="bottom"
-        adaptToViewport="stretch"
+        adaptToViewport="stick"
         minWidth="element.medium"
       >
         {props.decoration.kind === 'node' ? (

--- a/packages/keystatic/src/form/fields/markdoc/editor/schema.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/schema.tsx
@@ -1,4 +1,17 @@
 import { css, tokenSchema } from '@keystar/ui/style';
+import { fileCodeIcon } from '@keystar/ui/icon/icons/fileCodeIcon';
+import { heading1Icon } from '@keystar/ui/icon/icons/heading1Icon';
+import { heading2Icon } from '@keystar/ui/icon/icons/heading2Icon';
+import { heading3Icon } from '@keystar/ui/icon/icons/heading3Icon';
+import { heading4Icon } from '@keystar/ui/icon/icons/heading4Icon';
+import { heading5Icon } from '@keystar/ui/icon/icons/heading5Icon';
+import { heading6Icon } from '@keystar/ui/icon/icons/heading6Icon';
+// import { imageIcon } from '@keystar/ui/icon/icons/imageIcon';
+import { listIcon } from '@keystar/ui/icon/icons/listIcon';
+import { listOrderedIcon } from '@keystar/ui/icon/icons/listOrderedIcon';
+import { quoteIcon } from '@keystar/ui/icon/icons/quoteIcon';
+import { tableIcon } from '@keystar/ui/icon/icons/tableIcon';
+import { separatorHorizontalIcon } from '@keystar/ui/icon/icons/separatorHorizontalIcon';
 import {
   DOMOutputSpec,
   NodeSpec,
@@ -111,6 +124,14 @@ export type EditorNodeSpec = NodeSpec &
 const inlineContent = `(text | (text hard_break) | attribute)*`;
 
 const levels = [1, 2, 3, 4, 5, 6];
+const levelsMeta = [
+  { description: 'Use this for a top level heading', icon: heading1Icon },
+  { description: 'Use this for key sections', icon: heading2Icon },
+  { description: 'Use this for sub-sections', icon: heading3Icon },
+  { description: 'Use this for deep headings', icon: heading4Icon },
+  { description: 'Use this for grouping list items', icon: heading5Icon },
+  { description: 'Use this for low-level headings', icon: heading6Icon },
+];
 
 const cellAttrs: Record<string, AttributeSpec> = {
   colspan: { default: 1 },
@@ -317,6 +338,8 @@ const nodeSpecs = {
     },
     insertMenu: {
       label: 'Blockquote',
+      description: 'Insert a quote or citation',
+      icon: quoteIcon,
       command: wrapIn,
     },
   },
@@ -328,6 +351,8 @@ const nodeSpecs = {
     },
     insertMenu: {
       label: 'Divider',
+      description: 'A horizontal line to separate content',
+      icon: separatorHorizontalIcon,
       command: insertNode,
     },
   },
@@ -341,6 +366,8 @@ const nodeSpecs = {
     },
     insertMenu: {
       label: 'Code block',
+      description: 'Display code with syntax highlighting',
+      icon: fileCodeIcon,
       command: setBlockType,
     },
     marks: '',
@@ -367,6 +394,8 @@ const nodeSpecs = {
     },
     insertMenu: {
       label: 'Bullet list',
+      description: 'Insert an unordered list',
+      icon: listIcon,
       command: toggleList,
     },
   },
@@ -379,6 +408,8 @@ const nodeSpecs = {
     },
     insertMenu: {
       label: 'Ordered list',
+      description: 'Insert an ordered list',
+      icon: listOrderedIcon,
       command: toggleList,
     },
   },
@@ -405,7 +436,8 @@ const nodeSpecs = {
     toDOM(node) {
       return ['h' + node.attrs.level, 0];
     },
-    insertMenu: levels.map(level => ({
+    insertMenu: levels.map((level, index) => ({
+      ...levelsMeta[index],
       label: 'Heading ' + level,
       command: type => setBlockType(type, { level }),
     })),
@@ -414,6 +446,8 @@ const nodeSpecs = {
     content: 'table_row+',
     insertMenu: {
       label: 'Table',
+      description: 'Insert a table',
+      icon: tableIcon,
       command(_, schema) {
         return insertTable(schema);
       },
@@ -602,12 +636,16 @@ export function createEditorSchema(markdocConfig: Config) {
         for (const item of insertMenuSpec) {
           insertMenuItems.push({
             label: item.label,
+            description: item.description,
+            icon: item.icon,
             command: item.command(node, editorSchema),
           });
         }
       } else {
         insertMenuItems.push({
           label: insertMenuSpec.label,
+          description: insertMenuSpec.description,
+          icon: insertMenuSpec.icon,
           command: insertMenuSpec.command(node, editorSchema),
         });
       }
@@ -685,6 +723,7 @@ export function createEditorSchema(markdocConfig: Config) {
       },
     });
   }
+  // TODO: keep "bullet list" and "ordered list" together
   editorSchema.insertMenuItems = insertMenuItems
     .sort((a, b) => a.label.localeCompare(b.label))
     .map((item, i) => ({ ...item, id: i.toString() }));


### PR DESCRIPTION
Support and populate "description" + "icon" on insert menu items. Default `adaptToViewport` to "stick" on editor popovers; should yield better results in most cases.

| Before | After |
|--------|--------|
| <img width="344" alt="insert menu before changes" src="https://github.com/Thinkmill/keystatic/assets/2730833/e5b83606-f87b-451d-b053-6920e1c61ded"> | <img width="336" alt="insert menu items with icon and description" src="https://github.com/Thinkmill/keystatic/assets/2730833/09481ee4-830e-4ea9-97c8-1e905b5c71dd"> |