### PR TITLE
Editor popover improvements

### DIFF
--- a/.changeset/chilled-plums-warn.md
+++ b/.changeset/chilled-plums-warn.md
@@ -1,0 +1,8 @@
+---
+'@keystatic/core': patch
+---
+
+Markdoc editor popover improvements:
+
+- boundary respected by popovers
+- popovers tethered to reference regardless of type (node/range/virtual) + better perf

--- a/.changeset/eleven-dragons-whisper.md
+++ b/.changeset/eleven-dragons-whisper.md
@@ -1,0 +1,6 @@
+---
+'@keystar/ui': patch
+---
+
+Support "boundary" + "portal" props on `EditorPopover` component. Simulate
+clipping for portal'd popovers.

--- a/design-system/pkg/src/editor/stories/EditorListbox.stories.tsx
+++ b/design-system/pkg/src/editor/stories/EditorListbox.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@keystar/ui-storybook';
-import { Key, ReactElement, useEffect, useRef, useState } from 'react';
+import { Key, ReactElement, useEffect, useRef } from 'react';
 
 import { Icon } from '@keystar/ui/icon';
 import { fileCodeIcon } from '@keystar/ui/icon/icons/fileCodeIcon';
@@ -15,10 +15,9 @@ import { listOrderedIcon } from '@keystar/ui/icon/icons/listOrderedIcon';
 import { quoteIcon } from '@keystar/ui/icon/icons/quoteIcon';
 import { tableIcon } from '@keystar/ui/icon/icons/tableIcon';
 import { separatorHorizontalIcon } from '@keystar/ui/icon/icons/separatorHorizontalIcon';
-import { Box } from '@keystar/ui/layout';
 import { Kbd, KbdProps, Text } from '@keystar/ui/typography';
 
-import { EditorListbox, EditorPopover, Item, Section } from '..';
+import { EditorListbox, Item, Section } from '..';
 
 type KbdOption = 'alt' | 'meta' | 'shift';
 type KbdOptions = KbdOption[];
@@ -107,49 +106,6 @@ export const ComplexItems = () => {
 
 ComplexItems.story = {
   name: 'complex items',
-};
-
-export const WithinPopover = () => {
-  let listenerRef = useListenerRef();
-  let [triggerRef, setTriggerRef] = useState<HTMLElement | null>(null);
-
-  return (
-    <>
-      <Box
-        paddingX="medium"
-        ref={setTriggerRef}
-        UNSAFE_style={{
-          marginBottom: 600,
-          marginTop: 600,
-          marginInlineStart: 300,
-        }}
-      >
-        <Text color="accent" weight="medium">
-          /insert-menu
-        </Text>
-      </Box>
-      {triggerRef && (
-        <EditorPopover
-          reference={triggerRef}
-          placement="bottom-start"
-          adaptToViewport="stretch"
-          minHeight="alias.singleLineWidth"
-        >
-          <EditorListbox
-            aria-label="popover example"
-            items={complexItems[0].children}
-            children={childRenderer}
-            listenerRef={listenerRef}
-            UNSAFE_style={{ width: 320 }}
-          />
-        </EditorPopover>
-      )}
-    </>
-  );
-};
-
-WithinPopover.story = {
-  name: 'within popover',
 };
 
 // Utils

--- a/design-system/pkg/src/editor/stories/EditorPopover.stories.tsx
+++ b/design-system/pkg/src/editor/stories/EditorPopover.stories.tsx
@@ -11,7 +11,7 @@ import { listIcon } from '@keystar/ui/icon/icons/listIcon';
 import { listOrderedIcon } from '@keystar/ui/icon/icons/listOrderedIcon';
 import { Box, Divider, Flex } from '@keystar/ui/layout';
 import { Heading, Text } from '@keystar/ui/typography';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { EditorPopover, EditorPopoverRef } from '..';
 
@@ -39,45 +39,48 @@ export const Default = () => {
   );
 };
 
-Default.story = {
-  name: 'default',
-};
-
-export const Refs = () => {
-  let floating = useRef<EditorPopoverRef | null>(null);
+export const ScrollBoundary = () => {
   let [isOpen, setOpen] = useState(false);
+  let [scrollRef, setScrollRef] = useState<HTMLElement | null>(null);
   let [triggerRef, setTriggerRef] = useState<HTMLElement | null>(null);
 
+  useLayoutEffect(() => {
+    if (triggerRef) {
+      triggerRef.scrollIntoView({ block: 'center' });
+    }
+  }, [triggerRef]);
+
   return (
-    <Flex gap="large">
+    <Box
+      ref={setScrollRef}
+      backgroundColor="surface"
+      height="scale.2400"
+      width="scale.2400"
+      overflow="hidden scroll"
+      position="relative"
+    >
+      <div style={{ height: 300 }} />
       <ActionButton onPress={() => setOpen(bool => !bool)} ref={setTriggerRef}>
         Press me
       </ActionButton>
-      {isOpen && (
-        <ActionButton
-          onPress={() => {
-            console.log(floating.current);
-          }}
+      <div style={{ height: 300 }} />
+      {isOpen && triggerRef && scrollRef && (
+        <EditorPopover
+          reference={triggerRef}
+          boundary={scrollRef}
+          placement="top"
+          // portal={false}
         >
-          Log ref data
-        </ActionButton>
-      )}
-      {isOpen && triggerRef && (
-        <EditorPopover ref={floating} reference={triggerRef}>
           <Box padding="regular">
             <Text>Popover content</Text>
           </Box>
         </EditorPopover>
       )}
-    </Flex>
+    </Box>
   );
 };
 
-Refs.story = {
-  name: 'refs',
-};
-
-export const Sticky = () => {
+export const AdaptToBoundaryStick = () => {
   let [isOpen, setOpen] = useState(false);
   let [triggerRef, setTriggerRef] = useState<HTMLImageElement | null>(null);
 
@@ -139,7 +142,7 @@ export const Sticky = () => {
         pudding.
       </Text>
       {triggerRef && isOpen && (
-        <EditorPopover adaptToViewport="stick" reference={triggerRef}>
+        <EditorPopover adaptToBoundary="stick" reference={triggerRef}>
           <Box padding="regular" maxWidth="container.xsmall">
             <Text>
               This popover will overlap the target, staying in view when the
@@ -152,8 +155,59 @@ export const Sticky = () => {
   );
 };
 
-Sticky.story = {
-  name: 'sticky',
+export const AdaptToBoundaryStretch = () => {
+  let [isOpen, setOpen] = useState(false);
+  let [triggerRef, setTriggerRef] = useState<HTMLElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (triggerRef) {
+      triggerRef.scrollIntoView({ block: 'center' });
+    }
+  }, [triggerRef]);
+
+  return (
+    <>
+      <div style={{ height: 500 }} />
+      <ActionButton onPress={() => setOpen(bool => !bool)} ref={setTriggerRef}>
+        Press me
+      </ActionButton>
+      <div style={{ height: 500 }} />
+      {isOpen && triggerRef && (
+        <EditorPopover
+          reference={triggerRef}
+          placement="bottom-start"
+          adaptToBoundary="stretch"
+          minHeight="alias.singleLineWidth"
+          maxWidth="alias.singleLineWidth"
+        >
+          <Flex
+            direction="column"
+            gap="large"
+            padding="medium"
+            overflow="hidden auto"
+            maxHeight="inherit"
+          >
+            <Text>Sesame snaps</Text>
+            <Text>Soufflé cupcake</Text>
+            <Text>Cupcake tiramisu</Text>
+            <Text>Danish bear claw powder</Text>
+            <Text>Dessert gummi bears</Text>
+            <Text>Cookie shortbread</Text>
+            <Text>Lemon drops muffin</Text>
+            <Text>Tiramisu apple pie</Text>
+            <Text>Gummi bears</Text>
+            <Text>Cupcake tart oat cake</Text>
+            <Text>Macaroon apple pie</Text>
+            <Text>Biscuit dragée</Text>
+            <Text>Sesame snaps</Text>
+            <Text>Carrot cake powder</Text>
+            <Text>Cookie cotton candy</Text>
+            <Text>Sweet gummi bears</Text>
+          </Flex>
+        </EditorPopover>
+      )}
+    </>
+  );
 };
 
 export const Range = () => {
@@ -231,9 +285,38 @@ export const Range = () => {
   );
 };
 
-Range.story = {
-  name: 'range',
+export const Refs = () => {
+  let floating = useRef<EditorPopoverRef | null>(null);
+  let [isOpen, setOpen] = useState(false);
+  let [triggerRef, setTriggerRef] = useState<HTMLElement | null>(null);
+
+  return (
+    <Flex gap="large">
+      <ActionButton onPress={() => setOpen(bool => !bool)} ref={setTriggerRef}>
+        Press me
+      </ActionButton>
+      {isOpen && (
+        <ActionButton
+          onPress={() => {
+            console.log(floating.current);
+          }}
+        >
+          Log ref data
+        </ActionButton>
+      )}
+      {isOpen && triggerRef && (
+        <EditorPopover ref={floating} reference={triggerRef}>
+          <Box padding="regular">
+            <Text>Popover content</Text>
+          </Box>
+        </EditorPopover>
+      )}
+    </Flex>
+  );
 };
+
+// Utils
+// ----------------------------------------------------------------------------
 
 function useRangeFromDocumentSelection() {
   const [range, setRange] = useState<Range | null>(null);

--- a/packages/keystatic/src/form/fields/markdoc/editor/Toolbar.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/Toolbar.tsx
@@ -1,7 +1,8 @@
 import { setBlockType, toggleMark, wrapIn } from 'prosemirror-commands';
 import { MarkType, NodeType } from 'prosemirror-model';
 import { Command, EditorState, TextSelection } from 'prosemirror-state';
-import { ReactElement, ReactNode, useMemo } from 'react';
+import { HTMLAttributes, ReactElement, ReactNode, useMemo } from 'react';
+import { filterDOMProps } from '@react-aria/utils';
 
 import { ActionGroup, Item } from '@keystar/ui/action-group';
 import { ActionButton } from '@keystar/ui/button';
@@ -17,6 +18,7 @@ import { plusIcon } from '@keystar/ui/icon/icons/plusIcon';
 import { quoteIcon } from '@keystar/ui/icon/icons/quoteIcon';
 import { removeFormattingIcon } from '@keystar/ui/icon/icons/removeFormattingIcon';
 import { strikethroughIcon } from '@keystar/ui/icon/icons/strikethroughIcon';
+import { tableIcon } from '@keystar/ui/icon/icons/tableIcon';
 import { typeIcon } from '@keystar/ui/icon/icons/typeIcon';
 import { Flex } from '@keystar/ui/layout';
 import { MenuTrigger, Menu } from '@keystar/ui/menu';
@@ -32,7 +34,6 @@ import {
 } from './editor-view';
 import { toggleList } from './lists';
 import { insertNode, insertTable, toggleCodeBlock } from './commands/misc';
-import { tableIcon } from '@keystar/ui/icon/icons/tableIcon';
 import { EditorSchema } from './schema';
 
 function EditorToolbarButton(props: {
@@ -77,11 +78,11 @@ function EditorToolbarButton(props: {
 //   </TooltipTrigger>
 // );
 
-export function Toolbar() {
+export function Toolbar(props: HTMLAttributes<HTMLDivElement>) {
   const schema = useEditorSchema();
   const { nodes } = schema;
   return (
-    <ToolbarContainer>
+    <ToolbarContainer {...props}>
       <ToolbarScrollArea>
         <HeadingMenu headingType={nodes.heading} />
         <InlineMarks />
@@ -162,16 +163,21 @@ const ToolbarGroup = ({ children }: { children: ReactNode }) => {
   return <Flex gap="regular">{children}</Flex>;
 };
 
-const ToolbarContainer = ({ children }: { children: ReactNode }) => {
+const ToolbarContainer = ({
+  children,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) => {
   return (
     <Flex
-      minWidth={0}
+      {...filterDOMProps(props, { labelable: true })}
+      // styles
       backgroundColor="canvas"
-      borderTopStartRadius="medium"
       borderTopEndRadius="medium"
+      borderTopStartRadius="medium"
+      insetTop={0}
+      minWidth={0}
       position="sticky"
       zIndex={2}
-      insetTop={0}
     >
       {children}
       <Flex

--- a/packages/keystatic/src/form/fields/markdoc/editor/autocomplete/autocomplete.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/autocomplete/autocomplete.tsx
@@ -1,12 +1,12 @@
-import {
-  EditorListboxProps,
-  EditorPopover,
-  useEditorListbox,
-} from '../new-primitives';
 import { useMemo } from 'react';
+
+import { EditorPopover } from '@keystar/ui/editor';
+
 import { useEditorViewRef } from '../editor-view';
 import { useEditorKeydownListener } from '../keydown';
 import { useEditorReferenceElement } from '../popovers/reference';
+import { EditorListboxProps, useEditorListbox } from '../new-primitives';
+import { useBoundaryRect } from '../popovers';
 
 export function EditorAutocomplete<Item extends object>(
   props: Omit<EditorListboxProps<Item>, 'listenerRef'> & {
@@ -14,6 +14,7 @@ export function EditorAutocomplete<Item extends object>(
     to: number;
   }
 ) {
+  const boundary = useBoundaryRect();
   const viewRef = useEditorViewRef();
   const referenceElement = useEditorReferenceElement(props.from, props.to);
   const listenerRef = useMemo(() => {
@@ -32,13 +33,15 @@ export function EditorAutocomplete<Item extends object>(
     keydownListener(event);
     return event.defaultPrevented;
   });
+
   return (
     referenceElement && (
       <EditorPopover
-        reference={referenceElement}
-        placement="bottom-start"
-        adaptToViewport="stretch"
+        adaptToBoundary="stretch"
+        boundary={boundary}
         minWidth="element.medium"
+        placement="bottom-start"
+        reference={referenceElement}
       >
         {listbox}
       </EditorPopover>

--- a/packages/keystatic/src/form/fields/markdoc/editor/context.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/context.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext } from 'react';
+
+type ContextType = { id: string };
+const EditorContext = createContext<ContextType>({ id: '' });
+
+export const EditorContextProvider = EditorContext.Provider;
+export function useEditorContext() {
+  return useContext(EditorContext);
+}
+
+export function getRootId(id: string) {
+  return `keystatic-editor-root-${id}`;
+}
+export function getToolbarId(id: string) {
+  return `keystatic-editor-toolbar-${id}`;
+}
+export function getContentId(id: string) {
+  return `keystatic-editor-content-${id}`;
+}
+export function getRoot(id: string) {
+  return document.getElementById(getRootId(id));
+}
+export function getToolbar(id: string) {
+  return document.getElementById(getToolbarId(id));
+}
+export function getContent(id: string) {
+  return document.getElementById(getContentId(id));
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/index.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/index.tsx
@@ -1,6 +1,6 @@
 import { EditorView } from 'prosemirror-view';
 import { EditorState } from 'prosemirror-state';
-import { Ref, forwardRef } from 'react';
+import { Ref, forwardRef, useId, useMemo } from 'react';
 import { Box } from '@keystar/ui/layout';
 import { css } from '@emotion/css';
 import { tokenSchema } from '@keystar/ui/style';
@@ -11,6 +11,12 @@ import { ProseMirrorEditable, ProseMirrorEditor } from './editor-view';
 import { AutocompleteDecoration } from './autocomplete/decoration';
 import { NodeViews } from './react-node-views';
 import { CellMenuPortal } from './popovers/table';
+import {
+  EditorContextProvider,
+  getContentId,
+  getRootId,
+  getToolbarId,
+} from './context';
 
 const orderedListStyles = ['lower-roman', 'decimal', 'lower-alpha'];
 const unorderedListStyles = ['square', 'disc', 'circle'];
@@ -55,22 +61,36 @@ export const Editor = forwardRef(function Editor(
   },
   ref: Ref<{ view: EditorView | null }>
 ) {
+  const id = useId();
+  const editorContext = useMemo(() => ({ id }), [id]);
   return (
-    <ProseMirrorEditor value={props.value} onChange={props.onChange} ref={ref}>
-      <Box
-        backgroundColor="canvas"
-        border="neutral"
-        borderRadius="medium"
-        minWidth={0}
-        UNSAFE_className={prosemirrorStyles}
+    <EditorContextProvider value={editorContext}>
+      <ProseMirrorEditor
+        value={props.value}
+        onChange={props.onChange}
+        ref={ref}
       >
-        <Toolbar />
-        <ProseMirrorEditable className={editableStyles} />
-      </Box>
-      <NodeViews state={props.value} />
-      <CellMenuPortal />
-      <EditorPopoverDecoration state={props.value} />
-      <AutocompleteDecoration />
-    </ProseMirrorEditor>
+        <Box
+          id={getRootId(id)}
+          data-keystatic-editor="root"
+          backgroundColor="canvas"
+          border="neutral"
+          borderRadius="medium"
+          minWidth={0}
+          UNSAFE_className={prosemirrorStyles}
+        >
+          <Toolbar id={getToolbarId(id)} data-keystatic-editor="toolbar" />
+          <ProseMirrorEditable
+            id={getContentId(id)}
+            data-keystatic-editor="content"
+            className={editableStyles}
+          />
+        </Box>
+        <NodeViews state={props.value} />
+        <CellMenuPortal />
+        <EditorPopoverDecoration state={props.value} />
+        <AutocompleteDecoration />
+      </ProseMirrorEditor>
+    </EditorContextProvider>
   );
 });

--- a/packages/keystatic/src/form/fields/markdoc/editor/popovers/index.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/popovers/index.tsx
@@ -1,19 +1,23 @@
 import { Mark, MarkType, Node, ResolvedPos } from 'prosemirror-model';
 import { EditorState, TextSelection } from 'prosemirror-state';
+import { toggleHeader } from 'prosemirror-tables';
 import { ReactElement, useMemo } from 'react';
-import { EditorSchema, getEditorSchema } from '../schema';
+import { Rect } from '@floating-ui/react';
+
 import { ActionButton } from '@keystar/ui/button';
+import { EditorPopover, EditorPopoverProps } from '@keystar/ui/editor';
 import { Icon } from '@keystar/ui/icon';
 import { trash2Icon } from '@keystar/ui/icon/icons/trash2Icon';
-import { Flex } from '@keystar/ui/layout';
+import { Divider, Flex } from '@keystar/ui/layout';
 import { TooltipTrigger, Tooltip } from '@keystar/ui/tooltip';
-import { useEditorDispatchCommand, useEditorSchema } from '../editor-view';
-import { LinkToolbar } from './link-toolbar';
-import { CodeBlockLanguageCombobox } from './code-block-language';
-import { useEditorReferenceElement } from './reference';
-import { EditorPopover, EditorToolbarSeparator } from '../new-primitives';
 import { sheetIcon } from '@keystar/ui/icon/icons/sheetIcon';
-import { toggleHeader } from 'prosemirror-tables';
+
+import { useEditorDispatchCommand, useEditorSchema } from '../editor-view';
+import { EditorSchema, getEditorSchema } from '../schema';
+import { CodeBlockLanguageCombobox } from './code-block-language';
+import { LinkToolbar } from './link-toolbar';
+import { useEditorReferenceElement } from './reference';
+import { getContent, getToolbar, useEditorContext } from '../context';
 
 type NodePopoverRenderer = (props: {
   node: Node;
@@ -37,7 +41,7 @@ const popoverComponents: Record<string, NodePopoverRenderer> = {
             });
           }}
         />
-        <EditorToolbarSeparator />
+        <Divider orientation="vertical" />
         <TooltipTrigger>
           <ActionButton
             prominence="low"
@@ -80,7 +84,7 @@ const popoverComponents: Record<string, NodePopoverRenderer> = {
           </ActionButton>
           <Tooltip>Header row</Tooltip>
         </TooltipTrigger>
-        <EditorToolbarSeparator />
+        <Divider orientation="vertical" />
         <TooltipTrigger>
           <ActionButton
             prominence="low"
@@ -178,12 +182,14 @@ const LinkPopover: MarkPopoverRenderer = props => {
 
 type PopoverDecoration =
   | {
+      adaptToBoundary?: EditorPopoverProps['adaptToBoundary'];
       kind: 'node';
       component: NodePopoverRenderer;
       node: Node;
       pos: number;
     }
   | {
+      adaptToBoundary?: EditorPopoverProps['adaptToBoundary'];
       kind: 'mark';
       component: MarkPopoverRenderer;
       mark: Mark;
@@ -201,6 +207,7 @@ function getPopoverDecoration(state: EditorState): PopoverDecoration | null {
       linkAroundFrom.to === linkAroundTo.to
     ) {
       return {
+        adaptToBoundary: 'flip',
         kind: 'mark',
         component: LinkPopover,
         mark: linkAroundFrom.mark,
@@ -219,6 +226,7 @@ function getPopoverDecoration(state: EditorState): PopoverDecoration | null {
     const renderer = popoverComponents[node.type.name];
     if (renderer !== undefined) {
       return {
+        adaptToBoundary: 'stick',
         kind: 'node',
         node,
         component: renderer,
@@ -242,14 +250,18 @@ function PopoverInner(props: {
     props.decoration.kind === 'node'
       ? props.decoration.pos + props.decoration.node.nodeSize
       : props.decoration.to;
+
   const reference = useEditorReferenceElement(from, to);
+  const boundary = useBoundaryRect();
+
   return (
     reference && (
       <EditorPopover
-        reference={reference}
-        placement="bottom"
-        adaptToViewport="stick"
+        adaptToBoundary={props.decoration.adaptToBoundary}
+        boundary={boundary}
         minWidth="element.medium"
+        placement="bottom"
+        reference={reference}
       >
         {props.decoration.kind === 'node' ? (
           <props.decoration.component
@@ -274,4 +286,38 @@ export function EditorPopoverDecoration(props: { state: EditorState }) {
   );
   if (!popoverDecoration) return null;
   return <PopoverInner decoration={popoverDecoration} state={props.state} />;
+}
+
+export function useBoundaryRect(): Rect | undefined {
+  let { id } = useEditorContext();
+
+  let element = getContent(id);
+  if (!element) {
+    return undefined;
+  }
+
+  let scrollParent = getNearestScrollParent(element);
+  if (!scrollParent) {
+    return undefined;
+  }
+
+  let toolbar = getToolbar(id);
+  let offset = toolbar?.offsetHeight ?? 0;
+  let rect = scrollParent.getBoundingClientRect();
+  return {
+    x: rect.x,
+    y: rect.y + offset,
+    width: rect.width,
+    height: rect.height - offset,
+  };
+}
+
+function getNearestScrollParent(element: Element | null): Element | null {
+  if (!element) {
+    return null;
+  }
+  if (element.scrollHeight > element.clientHeight) {
+    return element;
+  }
+  return getNearestScrollParent(element.parentElement);
 }

--- a/packages/keystatic/src/form/fields/markdoc/editor/popovers/reference.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/popovers/reference.tsx
@@ -1,4 +1,4 @@
-import { ReferenceElement } from '@floating-ui/react';
+import { ReferenceElement, VirtualElement } from '@floating-ui/react';
 import { useLayoutEffect, useState } from 'react';
 import { useEditorViewInEffect } from '../editor-view';
 import { EditorView } from 'prosemirror-view';
@@ -12,7 +12,7 @@ function getReferenceElementForRange(
   if (nodeAtFrom !== null && to === from + nodeAtFrom.nodeSize) {
     const node = view.nodeDOM(from);
     if (node instanceof Element) {
-      return node;
+      return virtualElement(node, view);
     }
   }
   const fromDom = view.domAtPos(from);
@@ -20,7 +20,7 @@ function getReferenceElementForRange(
   const range = document.createRange();
   range.setStart(fromDom.node, fromDom.offset);
   range.setEnd(toDom.node, toDom.offset);
-  return range;
+  return virtualElement(range, view);
 }
 
 export function useEditorReferenceElement(
@@ -39,4 +39,15 @@ export function useEditorReferenceElement(
     setReferenceElement(getReferenceElementForRange(view, from, to));
   }, [getEditorView, from, to]);
   return referenceElement;
+}
+
+/**
+ * Normalize API for node, range, etc. and include `contextElement` to ensure
+ * clipping and position update detection works as expected.
+ * @see https://floating-ui.com/docs/virtual-elements
+ */
+function virtualElement(el: VirtualElement, view: EditorView) {
+  const contextElement = view.dom;
+  const getBoundingClientRect = () => el.getBoundingClientRect();
+  return { contextElement, getBoundingClientRect };
 }


### PR DESCRIPTION
**@keystar/ui**

- Support "boundary" + "portal" props on `EditorPopover` component.
- Simulate clipping for portal'd popovers.

**@keystatic/core**

- Markdoc editor boundary respected by popovers.
- Markdoc editor popovers tethered to reference regardless of type (node/range/virtual) + better perf.