### PR TITLE
Clear autocomplete content on escape in ProseMirror editor

### DIFF
--- a/packages/keystatic/src/form/fields/markdoc/editor/attributes/new-attribute.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/attributes/new-attribute.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import {
   addAutocompleteDecoration,
   removeAutocompleteDecoration,
+  removeAutocompleteDecorationAndContent,
   wrapCommandAfterRemovingAutocompleteDecoration,
 } from '../autocomplete/decoration';
 import {
@@ -140,7 +141,9 @@ function NewAttributeMenu(props: { query: string; from: number; to: number }) {
       items={options}
       children={childRenderer}
       onEscape={() => {
-        viewRef.current?.dispatch(removeAutocompleteDecoration(editorState.tr));
+        const tr = removeAutocompleteDecorationAndContent(editorState);
+        if (!tr) return;
+        viewRef.current?.dispatch(tr);
       }}
       onAction={key => {
         const option = options.find(option => option.name === key);

--- a/packages/keystatic/src/form/fields/markdoc/editor/autocomplete/insert-menu.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/autocomplete/insert-menu.tsx
@@ -120,7 +120,9 @@ function InsertMenu(props: { query: string; from: number; to: number }) {
       items={options}
       children={childRenderer}
       onEscape={() => {
-        viewRef.current?.dispatch(removeAutocompleteDecoration(editorState.tr));
+        const tr = removeAutocompleteDecorationAndContent(editorState);
+        if (!tr) return;
+        viewRef.current?.dispatch(tr);
       }}
       onAction={key => {
         const option = options.find(option => option.id === key);


### PR DESCRIPTION
Not including a changeset since it's a small thing and there are other changesets mentioning editor improvements