### PR TITLE
Editor a11y fixes

### DIFF
--- a/.changeset/bright-pumas-act.md
+++ b/.changeset/bright-pumas-act.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Minor a11y fixes/improvements for document + markdoc editors.

--- a/.changeset/fuzzy-spoons-attend.md
+++ b/.changeset/fuzzy-spoons-attend.md
@@ -1,0 +1,5 @@
+---
+'@keystar/ui': patch
+---
+
+Support "labelElementType" on `Field` component.

--- a/design-system/pkg/src/field/types.tsx
+++ b/design-system/pkg/src/field/types.tsx
@@ -15,24 +15,16 @@ export type FieldRenderProp = (
   inputProps: FieldRenderInputProps
 ) => ReactElement;
 
-export type FieldProps = {
-  /** A `ContextualHelp` element to place next to the label. */
-  contextualHelp?: ReactElement;
-  /**
-   * Description text provides information to assist the user in completing a
-   * field.
-   */
-  description?: ReactNode;
-  /**
-   * Error messages inform the user when the input does not meet validation
-   * criteria.
-   */
-  errorMessage?: ReactNode;
-  /** Whether user input is required on the input before form submission. */
-  isRequired?: boolean;
-  /** Concisely label the field. */
-  label?: ReactNode;
-} & InputBase &
+export type FieldProps = Pick<
+  FieldPrimitiveProps,
+  | 'contextualHelp'
+  | 'description'
+  | 'errorMessage'
+  | 'isRequired'
+  | 'label'
+  | 'labelElementType'
+> &
+  InputBase &
   AriaLabelingProps &
   BaseStyleProps &
   DOMProps;
@@ -41,14 +33,28 @@ export type FieldPrimitiveProps = {
   children: ReactElement;
   /** A `ContextualHelp` element to place next to the label. */
   contextualHelp?: ReactElement;
-  isRequired?: boolean;
-  label?: ReactNode;
-  labelElementType?: HTMLTag;
-  labelProps?: HTMLAttributes<HTMLElement>;
+  /**
+   * Description text provides information to assist the user in completing a
+   * field.
+   */
   description?: ReactNode;
   descriptionProps?: HTMLAttributes<HTMLElement>;
+  /**
+   * Error messages inform the user when the input does not meet validation
+   * criteria.
+   */
   errorMessage?: ReactNode;
   errorMessageProps?: HTMLAttributes<HTMLElement>;
+  /** Whether user input is required on the input before form submission. */
+  isRequired?: boolean;
+  /** Concisely label the field. */
+  label?: ReactNode;
+  /**
+   * The HTML element used to render the label, e.g. 'label', or 'span'.
+   * @default 'label'
+   */
+  labelElementType?: HTMLTag;
+  labelProps?: HTMLAttributes<HTMLElement>;
   /**
    * For controls that DO NOT use a semantic element for user input. In these
    * cases the "required" state would not otherwise be announced to users of

--- a/packages/keystatic/src/form/fields/document/ui.tsx
+++ b/packages/keystatic/src/form/fields/document/ui.tsx
@@ -39,11 +39,13 @@ export function DocumentFieldInput(
 
   let fieldProps: FieldProps = {
     label: props.label,
+    labelElementType: 'span', // the editor element isn't an input, so we need to use a span for the label
     description: props.description,
   };
   if (entryLayoutPane === 'main') {
     fieldProps = {
       'aria-label': props.label,
+      // `aria-description` is still in W3C Editor's Draft for ARIA 1.3.
     };
   }
 

--- a/packages/keystatic/src/form/fields/markdoc/editor/index.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/index.tsx
@@ -120,6 +120,9 @@ export const Editor = forwardRef(function Editor(
         >
           <Toolbar id={getToolbarId(id)} data-keystatic-editor="toolbar" />
           <ProseMirrorEditable
+            {...props}
+            role="textbox"
+            aria-multiline="true"
             id={getContentId(id)}
             data-keystatic-editor="content"
             className={editableStyles}
@@ -127,7 +130,6 @@ export const Editor = forwardRef(function Editor(
               layout: entryLayoutPane,
               container: containerSize,
             })}
-            {...props}
           />
         </Box>
         <NodeViews state={value} />

--- a/packages/keystatic/src/form/fields/markdoc/ui.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/ui.tsx
@@ -47,11 +47,13 @@ export function DocumentFieldInput(
 
   let fieldProps: FieldProps = {
     label: props.label,
+    labelElementType: 'span', // the editor element isn't an input, so we need to use a span for the label
     description: props.description,
   };
   if (entryLayoutPane === 'main') {
     fieldProps = {
       'aria-label': props.label,
+      // `aria-description` is still in W3C Editor's Draft for ARIA 1.3.
     };
   }
 


### PR DESCRIPTION
**@keystar/ui**

- Support "labelElementType" on `Field` component.

**@keystatic/core**

- Minor a11y fixes/improvements for document + markdoc editors.