### PR TITLE
Markdoc editor toolbar

### DIFF
--- a/.changeset/green-stingrays-rescue.md
+++ b/.changeset/green-stingrays-rescue.md
@@ -1,0 +1,6 @@
+---
+'@keystatic/core': patch
+---
+
+Refactor the markdoc editor toolbar; move all formatting options under a single
+tab-stop.

--- a/.changeset/lazy-maps-lick.md
+++ b/.changeset/lazy-maps-lick.md
@@ -1,0 +1,5 @@
+---
+'@keystar/ui': patch
+---
+
+Remove support for "uncontrolled state" in `EditorToolbar*` components.

--- a/design-system/pkg/src/editor/stories/EditorToolbar.stories.tsx
+++ b/design-system/pkg/src/editor/stories/EditorToolbar.stories.tsx
@@ -44,10 +44,38 @@ export const Default = () => {
 };
 Default.storyName = 'default';
 
+function multiSelect<T>(key: T) {
+  return (previous: T[]) => {
+    if (previous.includes(key)) {
+      return previous.filter(existingKey => existingKey !== key);
+    } else {
+      return previous.concat(key);
+    }
+  };
+}
+function singleSelect<T>(key: T) {
+  return (previous: T | null) => {
+    if (previous === key) {
+      return null;
+    } else {
+      return key;
+    }
+  };
+}
+
 export const Groups = () => {
+  let [inlineMarks, setInlineMarks] = useState<Key[]>([]);
+  let [list, setList] = useState<Key | null>(null);
+  let [code, setCode] = useState<Key | null>(null);
+
   return (
     <EditorToolbar aria-label="Formatting options">
-      <EditorToolbarGroup selectionMode="multiple" aria-label="Text formatting">
+      <EditorToolbarGroup
+        selectionMode="multiple"
+        aria-label="Text formatting"
+        value={inlineMarks}
+        onChange={key => setInlineMarks(multiSelect(key))}
+      >
         <EditorToolbarItem value="bold" aria-label="bold">
           <Icon src={boldIcon} />
         </EditorToolbarItem>
@@ -67,7 +95,12 @@ export const Groups = () => {
 
       <EditorToolbarSeparator />
 
-      <EditorToolbarGroup selectionMode="single" aria-label="Lists">
+      <EditorToolbarGroup
+        selectionMode="single"
+        aria-label="Lists"
+        value={list}
+        onChange={key => setList(singleSelect(key))}
+      >
         <EditorToolbarItem value="bulleted" aria-label="bulleted list">
           <Icon src={listIcon} />
         </EditorToolbarItem>
@@ -84,7 +117,12 @@ export const Groups = () => {
 
       <EditorToolbarSeparator />
 
-      <EditorToolbarGroup selectionMode="single" aria-label="Code formatting">
+      <EditorToolbarGroup
+        selectionMode="single"
+        aria-label="Code formatting"
+        value={code}
+        onChange={key => setCode(singleSelect(key))}
+      >
         <EditorToolbarItem value="code" aria-label="Code">
           <Icon src={code2Icon} />
         </EditorToolbarItem>
@@ -98,31 +136,24 @@ export const Groups = () => {
 Groups.storyName = 'groups';
 
 export const FocusStops = () => {
-  let [disabledKeys, setDisabledKeys] = useState<Iterable<Key>>();
+  let [disabledButton, setDisabledButton] = useState(false);
   return (
     <Flex direction="column" gap="large" alignItems="start">
-      <button
-        onClick={() =>
-          setDisabledKeys(v => (v ? undefined : ['strikethrough']))
-        }
-      >
-        before
-      </button>
+      <button onClick={() => setDisabledButton(bool => !!bool)}>before</button>
       <EditorToolbar aria-label="Formatting options">
-        <EditorToolbarGroup
-          disabledKeys={disabledKeys}
-          selectionMode="multiple"
-          aria-label="Text formatting"
-        >
-          <EditorToolbarItem value="bold" aria-label="bold">
+        <EditorToolbarGroup aria-label="Text formatting">
+          <EditorToolbarButton aria-label="bold">
             <Icon src={boldIcon} />
-          </EditorToolbarItem>
-          <EditorToolbarItem value="italic" aria-label="italic">
+          </EditorToolbarButton>
+          <EditorToolbarButton aria-label="italic">
             <Icon src={italicIcon} />
-          </EditorToolbarItem>
-          <EditorToolbarItem value="strikethrough" aria-label="strikethrough">
+          </EditorToolbarButton>
+          <EditorToolbarButton
+            aria-label="strikethrough"
+            isDisabled={disabledButton}
+          >
             <Icon src={strikethroughIcon} />
-          </EditorToolbarItem>
+          </EditorToolbarButton>
         </EditorToolbarGroup>
 
         <EditorToolbarSeparator />
@@ -140,29 +171,29 @@ FocusStops.storyName = 'focus stops';
 export const Tooltips = () => {
   return (
     <EditorToolbar aria-label="Formatting options">
-      <EditorToolbarGroup selectionMode="multiple" aria-label="Text formatting">
+      <EditorToolbarGroup aria-label="Text formatting">
         <TooltipTrigger>
-          <EditorToolbarItem value="bold" aria-label="bold">
+          <EditorToolbarButton aria-label="bold">
             <Icon src={boldIcon} />
-          </EditorToolbarItem>
+          </EditorToolbarButton>
           <Tooltip>
             <Text>Bold</Text>
             <Kbd meta>B</Kbd>
           </Tooltip>
         </TooltipTrigger>
         <TooltipTrigger>
-          <EditorToolbarItem value="italic" aria-label="italic">
+          <EditorToolbarButton aria-label="italic">
             <Icon src={italicIcon} />
-          </EditorToolbarItem>
+          </EditorToolbarButton>
           <Tooltip>
             <Text>Italic</Text>
             <Kbd meta>I</Kbd>
           </Tooltip>
         </TooltipTrigger>
         <TooltipTrigger>
-          <EditorToolbarItem value="strikethrough" aria-label="strikethrough">
+          <EditorToolbarButton aria-label="strikethrough">
             <Icon src={strikethroughIcon} />
-          </EditorToolbarItem>
+          </EditorToolbarButton>
           <Tooltip>Strikethrough</Tooltip>
         </TooltipTrigger>
       </EditorToolbarGroup>
@@ -181,11 +212,11 @@ export const Tooltips = () => {
 
       <EditorToolbarSeparator />
 
-      <EditorToolbarGroup selectionMode="single" aria-label="Lists">
+      <EditorToolbarGroup aria-label="Lists">
         <TooltipTrigger>
-          <EditorToolbarItem value="bulleted" aria-label="bulleted list">
+          <EditorToolbarButton aria-label="bulleted list">
             <Icon src={listIcon} />
-          </EditorToolbarItem>
+          </EditorToolbarButton>
           <Tooltip>
             <Text>Bulleted list</Text>
             <Kbd meta shift>
@@ -194,9 +225,9 @@ export const Tooltips = () => {
           </Tooltip>
         </TooltipTrigger>
         <TooltipTrigger>
-          <EditorToolbarItem value="numbered" aria-label="numbered list">
+          <EditorToolbarButton aria-label="numbered list">
             <Icon src={listOrderedIcon} />
-          </EditorToolbarItem>
+          </EditorToolbarButton>
           <Tooltip>
             <Text>Numbered list</Text>
             <Kbd meta shift>

--- a/design-system/pkg/src/editor/stories/EditorToolbar.stories.tsx
+++ b/design-system/pkg/src/editor/stories/EditorToolbar.stories.tsx
@@ -11,7 +11,7 @@ import { listOrderedIcon } from '@keystar/ui/icon/icons/listOrderedIcon';
 import { Flex } from '@keystar/ui/layout';
 import { TooltipTrigger, Tooltip } from '@keystar/ui/tooltip';
 import { Kbd, Text } from '@keystar/ui/typography';
-import { useState } from 'react';
+import { Key, useState } from 'react';
 
 import {
   EditorToolbar,
@@ -26,12 +26,91 @@ export default {
 };
 
 export const Default = () => {
-  let [visible, setVisible] = useState(true);
+  return (
+    <EditorToolbar aria-label="Formatting options">
+      <EditorToolbarGroup aria-label="Text formatting">
+        <EditorToolbarButton aria-label="bold">
+          <Icon src={boldIcon} />
+        </EditorToolbarButton>
+        <EditorToolbarButton aria-label="italic">
+          <Icon src={italicIcon} />
+        </EditorToolbarButton>
+        <EditorToolbarButton aria-label="strikethrough">
+          <Icon src={strikethroughIcon} />
+        </EditorToolbarButton>
+      </EditorToolbarGroup>
+    </EditorToolbar>
+  );
+};
+Default.storyName = 'default';
+
+export const Groups = () => {
+  return (
+    <EditorToolbar aria-label="Formatting options">
+      <EditorToolbarGroup selectionMode="multiple" aria-label="Text formatting">
+        <EditorToolbarItem value="bold" aria-label="bold">
+          <Icon src={boldIcon} />
+        </EditorToolbarItem>
+        <EditorToolbarItem value="italic" aria-label="italic">
+          <Icon src={italicIcon} />
+        </EditorToolbarItem>
+        <EditorToolbarItem value="strikethrough" aria-label="strikethrough">
+          <Icon src={strikethroughIcon} />
+        </EditorToolbarItem>
+      </EditorToolbarGroup>
+
+      <EditorToolbarSeparator />
+
+      <EditorToolbarButton aria-label="link">
+        <Icon src={linkIcon} />
+      </EditorToolbarButton>
+
+      <EditorToolbarSeparator />
+
+      <EditorToolbarGroup selectionMode="single" aria-label="Lists">
+        <EditorToolbarItem value="bulleted" aria-label="bulleted list">
+          <Icon src={listIcon} />
+        </EditorToolbarItem>
+        <EditorToolbarItem value="numbered" aria-label="numbered list">
+          <Icon src={listOrderedIcon} />
+        </EditorToolbarItem>
+      </EditorToolbarGroup>
+
+      <EditorToolbarSeparator />
+
+      <EditorToolbarButton aria-label="Blockquote">
+        <Icon src={indentIcon} />
+      </EditorToolbarButton>
+
+      <EditorToolbarSeparator />
+
+      <EditorToolbarGroup selectionMode="single" aria-label="Code formatting">
+        <EditorToolbarItem value="code" aria-label="Code">
+          <Icon src={code2Icon} />
+        </EditorToolbarItem>
+        <EditorToolbarItem value="code-block" aria-label="Code block">
+          <Icon src={fileCodeIcon} />
+        </EditorToolbarItem>
+      </EditorToolbarGroup>
+    </EditorToolbar>
+  );
+};
+Groups.storyName = 'groups';
+
+export const FocusStops = () => {
+  let [disabledKeys, setDisabledKeys] = useState<Iterable<Key>>();
   return (
     <Flex direction="column" gap="large" alignItems="start">
-      <button onClick={() => setVisible(b => !b)}>before</button>
+      <button
+        onClick={() =>
+          setDisabledKeys(v => (v ? undefined : ['strikethrough']))
+        }
+      >
+        before
+      </button>
       <EditorToolbar aria-label="Formatting options">
         <EditorToolbarGroup
+          disabledKeys={disabledKeys}
           selectionMode="multiple"
           aria-label="Text formatting"
         >
@@ -41,11 +120,7 @@ export const Default = () => {
           <EditorToolbarItem value="italic" aria-label="italic">
             <Icon src={italicIcon} />
           </EditorToolbarItem>
-          <EditorToolbarItem
-            value="strikethrough"
-            aria-label="strikethrough"
-            isDisabled={visible}
-          >
+          <EditorToolbarItem value="strikethrough" aria-label="strikethrough">
             <Icon src={strikethroughIcon} />
           </EditorToolbarItem>
         </EditorToolbarGroup>
@@ -55,154 +130,108 @@ export const Default = () => {
         <EditorToolbarButton aria-label="link">
           <Icon src={linkIcon} />
         </EditorToolbarButton>
+      </EditorToolbar>
+      <button>after</button>
+    </Flex>
+  );
+};
+FocusStops.storyName = 'focus stops';
 
-        <EditorToolbarSeparator />
+export const Tooltips = () => {
+  return (
+    <EditorToolbar aria-label="Formatting options">
+      <EditorToolbarGroup selectionMode="multiple" aria-label="Text formatting">
+        <TooltipTrigger>
+          <EditorToolbarItem value="bold" aria-label="bold">
+            <Icon src={boldIcon} />
+          </EditorToolbarItem>
+          <Tooltip>
+            <Text>Bold</Text>
+            <Kbd meta>B</Kbd>
+          </Tooltip>
+        </TooltipTrigger>
+        <TooltipTrigger>
+          <EditorToolbarItem value="italic" aria-label="italic">
+            <Icon src={italicIcon} />
+          </EditorToolbarItem>
+          <Tooltip>
+            <Text>Italic</Text>
+            <Kbd meta>I</Kbd>
+          </Tooltip>
+        </TooltipTrigger>
+        <TooltipTrigger>
+          <EditorToolbarItem value="strikethrough" aria-label="strikethrough">
+            <Icon src={strikethroughIcon} />
+          </EditorToolbarItem>
+          <Tooltip>Strikethrough</Tooltip>
+        </TooltipTrigger>
+      </EditorToolbarGroup>
 
-        <EditorToolbarGroup selectionMode="single" aria-label="Lists">
+      <EditorToolbarSeparator />
+
+      <TooltipTrigger>
+        <EditorToolbarButton aria-label="link">
+          <Icon src={linkIcon} />
+        </EditorToolbarButton>
+        <Tooltip>
+          <Text>Link</Text>
+          <Kbd meta>K</Kbd>
+        </Tooltip>
+      </TooltipTrigger>
+
+      <EditorToolbarSeparator />
+
+      <EditorToolbarGroup selectionMode="single" aria-label="Lists">
+        <TooltipTrigger>
           <EditorToolbarItem value="bulleted" aria-label="bulleted list">
             <Icon src={listIcon} />
           </EditorToolbarItem>
+          <Tooltip>
+            <Text>Bulleted list</Text>
+            <Kbd meta shift>
+              8
+            </Kbd>
+          </Tooltip>
+        </TooltipTrigger>
+        <TooltipTrigger>
           <EditorToolbarItem value="numbered" aria-label="numbered list">
             <Icon src={listOrderedIcon} />
           </EditorToolbarItem>
-        </EditorToolbarGroup>
-
-        <EditorToolbarSeparator />
-
-        <EditorToolbarButton aria-label="Blockquote">
-          <Icon src={indentIcon} />
-        </EditorToolbarButton>
-
-        <EditorToolbarSeparator />
-
-        <EditorToolbarGroup selectionMode="single" aria-label="Code formatting">
-          <EditorToolbarItem value="code" aria-label="Code">
-            <Icon src={code2Icon} />
-          </EditorToolbarItem>
-          <EditorToolbarItem value="code-block" aria-label="Code block">
-            <Icon src={fileCodeIcon} />
-          </EditorToolbarItem>
-        </EditorToolbarGroup>
-      </EditorToolbar>
-      <button>after</button>
-    </Flex>
-  );
-};
-
-Default.story = {
-  name: 'default',
-};
-
-export const Tooltips = () => {
-  let [visible, setVisible] = useState(true);
-  return (
-    <Flex direction="column" gap="large" alignItems="start">
-      <button onClick={() => setVisible(b => !b)}>before</button>
-      <EditorToolbar aria-label="Formatting options">
-        <EditorToolbarGroup
-          selectionMode="multiple"
-          aria-label="Text formatting"
-        >
-          <TooltipTrigger>
-            <EditorToolbarItem value="bold" aria-label="bold">
-              <Icon src={boldIcon} />
-            </EditorToolbarItem>
-            <Tooltip>
-              <Text>Bold</Text>
-              <Kbd meta>B</Kbd>
-            </Tooltip>
-          </TooltipTrigger>
-          <TooltipTrigger>
-            <EditorToolbarItem value="italic" aria-label="italic">
-              <Icon src={italicIcon} />
-            </EditorToolbarItem>
-            <Tooltip>
-              <Text>Italic</Text>
-              <Kbd meta>I</Kbd>
-            </Tooltip>
-          </TooltipTrigger>
-          <TooltipTrigger>
-            <EditorToolbarItem
-              value="strikethrough"
-              aria-label="strikethrough"
-              isDisabled={visible}
-            >
-              <Icon src={strikethroughIcon} />
-            </EditorToolbarItem>
-            <Tooltip>Strikethrough</Tooltip>
-          </TooltipTrigger>
-        </EditorToolbarGroup>
-
-        <EditorToolbarSeparator />
-
-        <TooltipTrigger>
-          <EditorToolbarButton aria-label="link">
-            <Icon src={linkIcon} />
-          </EditorToolbarButton>
           <Tooltip>
-            <Text>Link</Text>
-            <Kbd meta>K</Kbd>
+            <Text>Numbered list</Text>
+            <Kbd meta shift>
+              7
+            </Kbd>
           </Tooltip>
         </TooltipTrigger>
+      </EditorToolbarGroup>
 
-        <EditorToolbarSeparator />
+      <EditorToolbarSeparator />
 
-        <EditorToolbarGroup selectionMode="single" aria-label="Lists">
-          <TooltipTrigger>
-            <EditorToolbarItem value="bulleted" aria-label="bulleted list">
-              <Icon src={listIcon} />
-            </EditorToolbarItem>
-            <Tooltip>
-              <Text>Bulleted list</Text>
-              <Kbd meta shift>
-                8
-              </Kbd>
-            </Tooltip>
-          </TooltipTrigger>
-          <TooltipTrigger>
-            <EditorToolbarItem value="numbered" aria-label="numbered list">
-              <Icon src={listOrderedIcon} />
-            </EditorToolbarItem>
-            <Tooltip>
-              <Text>Numbered list</Text>
-              <Kbd meta shift>
-                7
-              </Kbd>
-            </Tooltip>
-          </TooltipTrigger>
-        </EditorToolbarGroup>
+      <TooltipTrigger>
+        <EditorToolbarButton aria-label="Blockquote" isDisabled>
+          <Icon src={indentIcon} />
+        </EditorToolbarButton>
+        <Tooltip>Blockquote</Tooltip>
+      </TooltipTrigger>
 
-        <EditorToolbarSeparator />
+      <EditorToolbarSeparator />
 
+      <EditorToolbarGroup aria-label="Code formatting">
         <TooltipTrigger>
-          <EditorToolbarButton aria-label="Blockquote">
-            <Icon src={indentIcon} />
+          <EditorToolbarButton aria-label="Code" isSelected={false}>
+            <Icon src={code2Icon} />
           </EditorToolbarButton>
-          <Tooltip>Blockquote</Tooltip>
+          <Tooltip>Code</Tooltip>
         </TooltipTrigger>
-
-        <EditorToolbarSeparator />
-
-        <EditorToolbarGroup selectionMode="single" aria-label="Code formatting">
-          <TooltipTrigger>
-            <EditorToolbarItem value="code" aria-label="Code">
-              <Icon src={code2Icon} />
-            </EditorToolbarItem>
-            <Tooltip>Code</Tooltip>
-          </TooltipTrigger>
-          <TooltipTrigger>
-            <EditorToolbarItem value="code-block" aria-label="Code block">
-              <Icon src={fileCodeIcon} />
-            </EditorToolbarItem>
-            <Tooltip>Code block</Tooltip>
-          </TooltipTrigger>
-        </EditorToolbarGroup>
-      </EditorToolbar>
-      <button>after</button>
-    </Flex>
+        <TooltipTrigger>
+          <EditorToolbarButton aria-label="Code block">
+            <Icon src={fileCodeIcon} />
+          </EditorToolbarButton>
+          <Tooltip>Code block</Tooltip>
+        </TooltipTrigger>
+      </EditorToolbarGroup>
+    </EditorToolbar>
   );
 };
-
-Tooltips.story = {
-  name: 'tooltips',
-};
+Tooltips.storyName = 'tooltips';

--- a/dev-projects/next-app/keystatic.config.tsx
+++ b/dev-projects/next-app/keystatic.config.tsx
@@ -299,6 +299,12 @@ export default config({
         logo: fields.image({ label: 'Logo' }),
       },
     }),
+    markdoc: singleton({
+      label: 'Markdoc',
+      schema: {
+        markdoc: __experimental_markdoc_field({ label: 'Markdoc', config: {} }),
+      },
+    }),
     fields: singleton({
       label: 'All Fields',
       schema: {

--- a/packages/keystatic/src/form/fields/markdoc/editor/Toolbar.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/Toolbar.tsx
@@ -3,8 +3,13 @@ import { MarkType, NodeType } from 'prosemirror-model';
 import { Command, EditorState, TextSelection } from 'prosemirror-state';
 import { HTMLAttributes, ReactElement, ReactNode, useMemo } from 'react';
 
-import { ActionGroup, Item } from '@keystar/ui/action-group';
 import { ActionButton } from '@keystar/ui/button';
+import {
+  EditorToolbarButton,
+  EditorToolbarGroup,
+  EditorToolbarItem,
+  EditorToolbar,
+} from '@keystar/ui/editor';
 import { Icon } from '@keystar/ui/icon';
 import { boldIcon } from '@keystar/ui/icon/icons/boldIcon';
 import { chevronDownIcon } from '@keystar/ui/icon/icons/chevronDownIcon';
@@ -18,10 +23,8 @@ import { quoteIcon } from '@keystar/ui/icon/icons/quoteIcon';
 import { removeFormattingIcon } from '@keystar/ui/icon/icons/removeFormattingIcon';
 import { strikethroughIcon } from '@keystar/ui/icon/icons/strikethroughIcon';
 import { tableIcon } from '@keystar/ui/icon/icons/tableIcon';
-import { typeIcon } from '@keystar/ui/icon/icons/typeIcon';
-import { Flex } from '@keystar/ui/layout';
 import { MenuTrigger, Menu } from '@keystar/ui/menu';
-import { Picker } from '@keystar/ui/picker';
+import { Picker, Item } from '@keystar/ui/picker';
 import { breakpointQueries, css, tokenSchema } from '@keystar/ui/style';
 import { Tooltip, TooltipTrigger } from '@keystar/ui/tooltip';
 import { Text, Kbd } from '@keystar/ui/typography';
@@ -37,7 +40,7 @@ import { EditorSchema } from './schema';
 import { ImageToolbarButton } from './images';
 import { useEntryLayoutSplitPaneContext } from '../../../../app/entry-form';
 
-export function EditorToolbarButton(props: {
+export function ToolbarButton(props: {
   children: ReactNode;
   'aria-label': string;
   isSelected?: (editorState: EditorState) => boolean;
@@ -50,34 +53,21 @@ export function EditorToolbarButton(props: {
   const isDisabled = !props.command(state) || props.isDisabled?.(state);
   return useMemo(
     () => (
-      <ActionButton
-        prominence="low"
+      <EditorToolbarButton
         isSelected={isSelected}
         isDisabled={isDisabled}
         onPress={() => {
           runCommand(props.command);
         }}
         aria-label={props['aria-label']}
-        aria-pressed={isSelected}
+        // aria-pressed={isSelected}
       >
         {props.children}
-      </ActionButton>
+      </EditorToolbarButton>
     ),
     [isDisabled, isSelected, props, runCommand]
   );
 }
-
-// export const tableButton = (
-//   <TooltipTrigger>
-//     <EditorToolbarButton command={() => {}}>
-//       <Icon src={tableIcon} />
-//     </EditorToolbarButton>
-//     <TableButton />
-//     <Tooltip>
-//       <Text>Table</Text>
-//     </Tooltip>
-//   </TooltipTrigger>
-// );
 
 export function Toolbar(props: HTMLAttributes<HTMLDivElement>) {
   const schema = useEditorSchema();
@@ -88,33 +78,33 @@ export function Toolbar(props: HTMLAttributes<HTMLDivElement>) {
         <HeadingMenu headingType={nodes.heading} />
         <InlineMarks />
         <ListButtons />
-        <ToolbarGroup>
+        <EditorToolbarGroup aria-label="Blocks">
           <TooltipTrigger>
-            <EditorToolbarButton
+            <ToolbarButton
               command={insertNode(nodes.divider)}
               aria-label="Divider"
             >
               <Icon src={minusIcon} />
-            </EditorToolbarButton>
+            </ToolbarButton>
             <Tooltip>
               <Text>Divider</Text>
               <Kbd>---</Kbd>
             </Tooltip>
           </TooltipTrigger>
           <TooltipTrigger>
-            <EditorToolbarButton
+            <ToolbarButton
               aria-label="Quote"
               command={wrapIn(nodes.blockquote)}
             >
               <Icon src={quoteIcon} />
-            </EditorToolbarButton>
+            </ToolbarButton>
             <Tooltip>
               <Text>Quote</Text>
               <Kbd>{'>⎵'}</Kbd>
             </Tooltip>
           </TooltipTrigger>
           <TooltipTrigger>
-            <EditorToolbarButton
+            <ToolbarButton
               aria-label="Code block"
               command={toggleCodeBlock(nodes.code_block, nodes.paragraph)}
               isSelected={(state: EditorState) => {
@@ -135,35 +125,27 @@ export function Toolbar(props: HTMLAttributes<HTMLDivElement>) {
               }}
             >
               <Icon src={codeIcon} />
-            </EditorToolbarButton>
+            </ToolbarButton>
             <Tooltip>
               <Text>Code block</Text>
               <Kbd>```</Kbd>
             </Tooltip>
           </TooltipTrigger>
           <TooltipTrigger>
-            <EditorToolbarButton
-              aria-label="Table"
-              command={insertTable(schema)}
-            >
+            <ToolbarButton aria-label="Table" command={insertTable(schema)}>
               <Icon src={tableIcon} />
-            </EditorToolbarButton>
+            </ToolbarButton>
             <Tooltip>
               <Text>Table</Text>
             </Tooltip>
           </TooltipTrigger>
           <ImageToolbarButton />
-        </ToolbarGroup>
+        </EditorToolbarGroup>
       </ToolbarScrollArea>
       <InsertBlockMenu />
     </ToolbarWrapper>
   );
 }
-
-/** Group buttons together that don't fit into an `ActionGroup` semantically. */
-const ToolbarGroup = ({ children }: { children: ReactNode }) => {
-  return <Flex gap="regular">{children}</Flex>;
-};
 
 const ToolbarContainer = ({ children }: { children: ReactNode }) => {
   let entryLayoutPane = useEntryLayoutSplitPaneContext();
@@ -222,17 +204,16 @@ const ToolbarWrapper = (props: HTMLAttributes<HTMLDivElement>) => {
 const ToolbarScrollArea = (props: { children: ReactNode }) => {
   let entryLayoutPane = useEntryLayoutSplitPaneContext();
   return (
-    <Flex
+    <EditorToolbar
+      aria-label="Formatting options"
       data-layout={entryLayoutPane}
-      paddingY="regular"
-      paddingX="medium"
-      gap="large"
       flex
       minWidth={0}
       UNSAFE_className={css({
         msOverflowStyle: 'none' /* for Internet Explorer, Edge */,
         scrollbarWidth: 'none' /* for Firefox */,
         overflowX: 'auto',
+        paddingInline: tokenSchema.size.space.medium,
 
         /* for Chrome, Safari, and Opera */
         '&::-webkit-scrollbar': {
@@ -404,6 +385,7 @@ const isMarkActive = (markType: MarkType) => (state: EditorState) => {
 function InlineMarks() {
   const state = useEditorState();
   const schema = useEditorSchema();
+  const runCommand = useEditorDispatchCommand();
   const inlineMarks = useMemo(() => {
     const marks: {
       key: string;
@@ -457,54 +439,57 @@ function InlineMarks() {
       key: 'clearFormatting',
       label: 'Clear formatting',
       icon: removeFormattingIcon,
-      command: () => false,
+      command: removeAllMarks(),
       isSelected: () => false,
     });
     return marks;
-  }, [schema]);
+  }, [schema.marks]);
   const selectedKeys = useMemoStringified(
     inlineMarks.filter(val => val.isSelected(state)).map(val => val.key)
   );
   const disabledKeys = useMemoStringified(
     inlineMarks.filter(val => !val.command(state)).map(val => val.key)
   );
-  const runCommand = useEditorDispatchCommand();
+
   return useMemo(() => {
     return (
-      <ActionGroup
-        UNSAFE_className={css({
-          minWidth: `calc(${tokenSchema.size.element.medium} * 4)`,
-        })}
-        prominence="low"
-        density="compact"
-        buttonLabelBehavior="hide"
-        overflowMode="collapse"
-        summaryIcon={<Icon src={typeIcon} />}
-        items={inlineMarks}
-        selectionMode="multiple"
-        selectedKeys={selectedKeys}
-        disabledKeys={disabledKeys}
-        onAction={key => {
-          const command = inlineMarks.find(mark => mark.key === key)?.command;
-          if (command) {
-            runCommand(command);
+      <EditorToolbarGroup
+        aria-label="Text formatting"
+        value={selectedKeys}
+        onChange={keys => {
+          const key = getKeyByDifference(keys, selectedKeys);
+          const mark = inlineMarks.find(mark => mark.key === key);
+          if (mark) {
+            runCommand(mark.command);
           }
         }}
+        disabledKeys={disabledKeys}
+        selectionMode="multiple"
       >
-        {item => {
-          return (
-            <Item key={item.key} textValue={item.label}>
-              <Text>{item.label}</Text>
-              {'shortcut' in item && <Kbd meta>{item.shortcut}</Kbd>}
-              <Icon src={item.icon} />
-            </Item>
-          );
-        }}
-      </ActionGroup>
+        {inlineMarks.map(mark => (
+          <TooltipTrigger key={mark.key}>
+            <EditorToolbarItem value={mark.key} aria-label={mark.label}>
+              <Icon src={mark.icon} />
+            </EditorToolbarItem>
+            <Tooltip>
+              <Text>{mark.label}</Text>
+              {'shortcut' in mark && <Kbd meta>{mark.shortcut}</Kbd>}
+            </Tooltip>
+          </TooltipTrigger>
+        ))}
+      </EditorToolbarGroup>
     );
   }, [disabledKeys, inlineMarks, runCommand, selectedKeys]);
 }
 
+// TODO: this seems costly. maybe refactor `ToolbarGroup` to pass just the
+// changed key, not the whole array
+function getKeyByDifference<T>(a: T[], b: T[]) {
+  return difference(a, b)[0] ?? difference(b, a)[0];
+}
+function difference<T>(a: T[], b: T[]) {
+  return a.filter(x => !b.includes(x));
+}
 function useMemoStringified<T>(value: T): T {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   return useMemo(() => value, [JSON.stringify(value)]);
@@ -515,9 +500,9 @@ function getActiveListType(state: EditorState, schema: EditorSchema) {
   for (let i = sharedDepth; i > 0; i--) {
     const node = state.selection.$from.node(i);
     if (node.type === schema.nodes.ordered_list) {
-      return 'ordered' as const;
+      return 'ordered_list' as const;
     } else if (node.type === schema.nodes.unordered_list) {
-      return 'unordered' as const;
+      return 'unordered_list' as const;
     }
   }
 }
@@ -534,61 +519,82 @@ function ListButtons() {
     toggleList(schema.nodes.unordered_list)(state);
   const activeListType = getActiveListType(state, schema);
 
+  const items = useMemo(() => {
+    return [
+      !!schema.nodes.unordered_list && {
+        label: 'Bullet list',
+        key: 'unordered_list',
+        shortcut: '-',
+        icon: listIcon,
+      },
+      !!schema.nodes.ordered_list && {
+        label: 'Numbered list',
+        key: 'ordered_list',
+        shortcut: '1.',
+        icon: listOrderedIcon,
+      },
+    ].filter(removeFalse);
+  }, [schema.nodes.unordered_list, schema.nodes.ordered_list]);
+
+  const disabledKeys = useMemo(() => {
+    return [
+      !canWrapInOrderedList && 'ordered_list',
+      !canWrapInUnorderedList && 'unordered_list',
+    ].filter(removeFalse);
+  }, [canWrapInOrderedList, canWrapInUnorderedList]);
+
   return useMemo(() => {
+    if (items.length === 0) {
+      return null;
+    }
+
     return (
-      <ActionGroup
-        flexShrink={0}
+      <EditorToolbarGroup
         aria-label="Lists"
-        selectionMode="single"
-        buttonLabelBehavior="hide"
-        density="compact"
-        prominence="low"
-        disabledKeys={[
-          !canWrapInOrderedList && 'ordered',
-          !canWrapInUnorderedList && 'unordered',
-        ].filter(removeFalse)}
-        summaryIcon={<Icon src={listIcon} />}
-        selectedKeys={activeListType ? [activeListType] : []}
-        onAction={key => {
-          const format = key as 'ordered' | 'unordered';
-          const type = schema.nodes[`${format}_list`];
+        value={activeListType}
+        onChange={key => {
+          const format = (key ? key : activeListType) as
+            | 'ordered_list'
+            | 'unordered_list';
+          console.log('format', format);
+          const type = schema.nodes[format];
           if (type) {
             dispatchCommand(toggleList(type));
           }
         }}
-        items={[
-          !!schema.nodes.unordered_list && {
-            label: 'Bullet List',
-            key: 'unordered',
-            shortcut: '-',
-            icon: listIcon,
-          },
-          !!schema.nodes.unordered_list && {
-            label: 'Numbered List',
-            key: 'ordered',
-            shortcut: '1.',
-            icon: listOrderedIcon,
-          },
-        ].filter(removeFalse)}
+        disabledKeys={disabledKeys}
+        selectionMode="single"
       >
-        {item => (
-          <Item textValue={`${item.label} (${item.shortcut})`}>
-            <Icon src={item.icon} />
-            <Text>{item.label}</Text>
-            <Kbd>{item.shortcut}</Kbd>
-          </Item>
-        )}
-      </ActionGroup>
+        {items.map(item => (
+          <TooltipTrigger key={item.key}>
+            <EditorToolbarItem value={item.key} aria-label={item.label}>
+              <Icon src={item.icon} />
+            </EditorToolbarItem>
+            <Tooltip>
+              <Text>{item.label}</Text>
+              <Kbd meta>{item.shortcut}</Kbd>
+            </Tooltip>
+          </TooltipTrigger>
+        ))}
+      </EditorToolbarGroup>
     );
-  }, [
-    activeListType,
-    canWrapInOrderedList,
-    canWrapInUnorderedList,
-    dispatchCommand,
-    schema.nodes,
-  ]);
+  }, [activeListType, disabledKeys, dispatchCommand, items, schema.nodes]);
 }
 
 function removeFalse<T>(val: T): val is Exclude<T, false> {
   return val !== false;
+}
+
+function removeAllMarks(): Command {
+  return (state, dispatch) => {
+    if (state.selection.empty) {
+      return false;
+    }
+
+    if (dispatch) {
+      // TODO: extend the range to include the whole mark on either side of the selection
+      dispatch(state.tr.removeMark(state.selection.from, state.selection.to));
+    }
+    return true;
+  };
 }

--- a/packages/keystatic/src/form/fields/markdoc/editor/Toolbar.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/Toolbar.tsx
@@ -41,6 +41,7 @@ import { insertNode, insertTable, toggleCodeBlock } from './commands/misc';
 import { EditorSchema } from './schema';
 import { ImageToolbarButton } from './images';
 import { useEntryLayoutSplitPaneContext } from '../../../../app/entry-form';
+import { itemRenderer } from './autocomplete/insert-menu';
 
 export function ToolbarButton(props: {
   children: ReactNode;
@@ -148,6 +149,7 @@ export function Toolbar(props: HTMLAttributes<HTMLDivElement>) {
           </EditorToolbarGroup>
         </EditorToolbar>
       </ToolbarScrollArea>
+
       <InsertBlockMenu />
     </ToolbarWrapper>
   );
@@ -332,8 +334,12 @@ function InsertBlockMenu() {
   const commandDispatch = useEditorDispatchCommand();
   const schema = useEditorSchema();
 
+  // const items = useMemo(
+  //   () => schema.insertMenuItems.filter(x => x.forToolbar),
+  //   [schema.insertMenuItems]
+  // );
   const items = useMemo(
-    () => schema.insertMenuItems.filter(x => x.forToolbar),
+    () => schema.insertMenuItems.filter(x => !!x.command),
     [schema.insertMenuItems]
   );
   const idToItem = useMemo(
@@ -364,11 +370,7 @@ function InsertBlockMenu() {
         }}
         items={items}
       >
-        {item => (
-          <Item key={item.id} textValue={item.label}>
-            {item.label}
-          </Item>
-        )}
+        {itemRenderer}
       </Menu>
     </MenuTrigger>
   );

--- a/packages/keystatic/src/form/fields/markdoc/editor/autocomplete/insert-menu.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/autocomplete/insert-menu.tsx
@@ -77,7 +77,7 @@ function wrapInsertMenuCommand(command: Command): Command {
   };
 }
 
-function childRenderer(item: InsertMenuItem) {
+export function itemRenderer(item: InsertMenuItem) {
   return (
     <Item key={item.id} textValue={item.label}>
       <Text>{item.label}</Text>
@@ -118,7 +118,7 @@ function InsertMenu(props: { query: string; from: number; to: number }) {
       to={props.to}
       aria-label="Insert menu"
       items={options}
-      children={childRenderer}
+      children={itemRenderer}
       onEscape={() => {
         const tr = removeAutocompleteDecorationAndContent(editorState);
         if (!tr) return;

--- a/packages/keystatic/src/form/fields/markdoc/editor/images.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/images.tsx
@@ -1,13 +1,15 @@
+import { Fragment, Slice } from 'prosemirror-model';
+import { Plugin } from 'prosemirror-state';
+import { dropPoint } from 'prosemirror-transform';
+
 import { Icon } from '@keystar/ui/icon';
+import { imageIcon } from '@keystar/ui/icon/icons/imageIcon';
 import { Tooltip, TooltipTrigger } from '@keystar/ui/tooltip';
 import { Text } from '@keystar/ui/typography';
-import { EditorToolbarButton } from './Toolbar';
+
 import { getUploadedFileObject } from '../../image/ui';
-import { imageIcon } from '@keystar/ui/icon/icons/imageIcon';
-import { Plugin } from 'prosemirror-state';
 import { EditorSchema } from './schema';
-import { dropPoint } from 'prosemirror-transform';
-import { Fragment, Slice } from 'prosemirror-model';
+import { ToolbarButton } from './Toolbar';
 
 export function readFileAsDataUrl(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -79,7 +81,7 @@ export function imageDropPlugin(schema: EditorSchema) {
 export function ImageToolbarButton() {
   return (
     <TooltipTrigger>
-      <EditorToolbarButton
+      <ToolbarButton
         aria-label="Image"
         command={(_, dispatch, view) => {
           if (dispatch && view) {
@@ -101,7 +103,7 @@ export function ImageToolbarButton() {
         }}
       >
         <Icon src={imageIcon} />
-      </EditorToolbarButton>
+      </ToolbarButton>
       <Tooltip>
         <Text>Image</Text>
       </Tooltip>


### PR DESCRIPTION
**@keystar/ui**

- Remove support for "uncontrolled state" in `EditorToolbar*` components.

**@keystatic/core**

- Refactor the markdoc editor toolbar; move all formatting options under a single tab-stop.
- Implement "clear formatting" functionality.
- Don't render the insert menu when no items.