### PR TITLE
Filter out DOM props TableVirtualizer

### DIFF
--- a/.changeset/kind-snakes-invent.md
+++ b/.changeset/kind-snakes-invent.md
@@ -1,0 +1,5 @@
+---
+'@keystar/ui': patch
+---
+
+Filter out DOM props TableVirtualizer

--- a/design-system/pkg/src/table/TableView.tsx
+++ b/design-system/pkg/src/table/TableView.tsx
@@ -26,7 +26,7 @@ import {
   useTableSelectAllCheckbox,
   useTableSelectionCheckbox,
 } from '@react-aria/table';
-import { mergeProps } from '@react-aria/utils';
+import { filterDOMProps, mergeProps } from '@react-aria/utils';
 import {
   layoutInfoToStyle,
   ScrollView,
@@ -453,7 +453,7 @@ function TableVirtualizer<T extends object>(props: TableVirtualizerProps<T>) {
     virtualizerState,
     domRef
   );
-  let mergedProps = mergeProps(otherProps, virtualizerProps);
+  let mergedProps = mergeProps(filterDOMProps(otherProps), virtualizerProps);
 
   const [headerView, bodyView] = virtualizerState.visibleViews;
   let headerHeight = layout.getLayoutInfo('header')?.rect.height || 0;


### PR DESCRIPTION
Hi there! First of all, thank you so much for the amazing work you've been doing with Keystatic!

Recently I've noticed some browser console errors whenever landing on a collection page inside of Keystatic's Admin UI:

![Screenshot 2023-12-10 at 13 23 08](https://github.com/Thinkmill/keystatic/assets/4006802/7c2e593b-1633-4b90-8452-50ec2a791445)

Turns out, DOM props were being passed to an element inside of the `TableVirtualizer` component, when they should've been filtered out. This pull request fixes that.