### PR TITLE
Fix marks with leading and trailing spaces

### DIFF
--- a/.changeset/loud-onions-smash.md
+++ b/.changeset/loud-onions-smash.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fix marks with leading and trailing spaces

--- a/packages/keystatic/src/form/fields/document/markdoc/markdoc.test.tsx
+++ b/packages/keystatic/src/form/fields/document/markdoc/markdoc.test.tsx
@@ -498,3 +498,34 @@ test('code and bold', () => {
     "
   `);
 });
+
+test('italic in bold', () => {
+  const markdoc = `**a *b* c**`;
+  const editor = fromMarkdoc(markdoc);
+  expect(editor).toMatchInlineSnapshot(`
+    <editor>
+      <paragraph>
+        <text
+          bold={true}
+        >
+          a 
+        </text>
+        <text
+          bold={true}
+          italic={true}
+        >
+          b
+        </text>
+        <text
+          bold={true}
+        >
+           c
+        </text>
+      </paragraph>
+    </editor>
+  `);
+  expect(toMarkdoc(editor)).toMatchInlineSnapshot(`
+    "**a** ***b*** **c**
+    "
+  `);
+});

--- a/packages/keystatic/src/form/fields/document/markdoc/to-markdoc.tsx
+++ b/packages/keystatic/src/form/fields/document/markdoc/to-markdoc.tsx
@@ -46,16 +46,27 @@ function toMarkdocInline(node: Descendant): Node | Node[] {
       mark => mark !== 'text' && mark !== 'code'
     ) as Mark[]
   ).sort();
-  let markdocNode = node.code
-    ? new Ast.Node('code', { content: node.text }, [])
-    : new Ast.Node('text', { content: node.text });
+  const leadingWhitespace = /^\s+/.exec(node.text)?.[0];
+  const trailingWhitespace = /\s+$/.exec(node.text)?.[0];
+
+  let children = node.code
+    ? [new Ast.Node('code', { content: node.text.trim() }, [])]
+    : [new Ast.Node('text', { content: node.text.trim() })];
   for (const mark of marks) {
     const config = markToMarkdoc[mark];
     if (config) {
-      markdocNode = new Ast.Node(config.type, {}, [markdocNode], config.tag);
+      children = [new Ast.Node(config.type, {}, children, config.tag)];
     }
   }
-  return markdocNode;
+
+  if (leadingWhitespace?.length) {
+    children.unshift(new Ast.Node('text', { content: leadingWhitespace }, []));
+  }
+  if (trailingWhitespace?.length) {
+    children.push(new Ast.Node('text', { content: trailingWhitespace }, []));
+  }
+
+  return children;
 }
 
 export function toMarkdocDocument(


### PR DESCRIPTION
Fixes #814

This fix isn't ideal since we could avoid extra wrapping but it fixes the problem of removing spaces