### PR TITLE
Support parsing link/image references in the mdx field

### DIFF
--- a/.changeset/clever-wolves-taste.md
+++ b/.changeset/clever-wolves-taste.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Support parsing link/image references in the mdx field

--- a/packages/keystatic/package.json
+++ b/packages/keystatic/package.json
@@ -178,6 +178,7 @@
     "slate": "^0.91.4",
     "slate-history": "^0.86.0",
     "slate-react": "^0.91.9",
+    "unist-util-visit": "^5.0.0",
     "urql": "^4.0.0",
     "zod": "^3.20.2"
   },

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/mdx.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/mdx.test.tsx
@@ -531,3 +531,32 @@ something else`;
     "
   `);
 });
+
+test('link reference', () => {
+  const mdx = `[a][b]
+  
+[b]: https://keystatic.com
+`;
+  const editor = fromMDX(mdx);
+  expect(editor).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text
+          link={
+            {
+              "href": "https://keystatic.com",
+              "title": "",
+            }
+          }
+        >
+          <cursor />
+          a
+        </text>
+      </paragraph>
+    </doc>
+  `);
+  expect(toMDX(editor)).toMatchInlineSnapshot(`
+    "[a](https://keystatic.com)
+    "
+  `);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -848,6 +848,7 @@ importers:
       slate-react: ^0.91.9
       tsx: ^3.8.0
       typescript: ^5.2.2
+      unist-util-visit: ^5.0.0
       urql: ^4.0.0
       zod: ^3.20.2
     dependencies:
@@ -918,6 +919,7 @@ importers:
       slate: 0.91.4
       slate-history: 0.86.0_slate@0.91.4
       slate-react: 0.91.11_6tgy34rvmll7duwkm4ydcekf3u
+      unist-util-visit: 5.0.0
       urql: 4.0.5_7ydmg4ky5cpt4mzloff6pvn2pa
       zod: 3.22.2
     devDependencies:


### PR DESCRIPTION
Fixes #923

Note this doesn't preserve the references & definitions because that would be impractical, this just supports parsing them and serialising them inline