### PR TITLE
Output dates in YAML

### DIFF
--- a/.changeset/six-spies-shout.md
+++ b/.changeset/six-spies-shout.md
@@ -1,0 +1,6 @@
+---
+'@keystatic/core': minor
+---
+
+`fields.date` and `fields.datetime` are now output as dates instead of strings
+in YAML

--- a/docs/src/content/blog/the-fresh-keystatic-cli.mdoc
+++ b/docs/src/content/blog/the-fresh-keystatic-cli.mdoc
@@ -1,7 +1,7 @@
 ---
 title: The fresh Keystatic CLI
 draft: false
-publishedOn: '2023-06-28'
+publishedOn: 2023-06-28
 summary: >-
   Kick-start a Keystatic-integrated project with our new "create" CLI, available
   via npm.

--- a/packages/keystatic/src/app/required-files.ts
+++ b/packages/keystatic/src/app/required-files.ts
@@ -1,6 +1,6 @@
 import { assert } from 'emery';
 import { load } from 'js-yaml';
-import { AssetFormField, ContentFormField, JsonValue } from '../form/api';
+import { AssetFormField, ContentFormField, JsonYamlValue } from '../form/api';
 import { ReadonlyPropPath } from '../form/fields/document/DocumentEditor/component-blocks/utils';
 import { FormatInfo } from './path-utils';
 
@@ -30,7 +30,7 @@ export function loadDataFile(
   data: Uint8Array,
   formatInfo: FormatInfo
 ): {
-  loaded: JsonValue;
+  loaded: JsonYamlValue;
   extraFakeFile?: {
     path: string;
     contents: Uint8Array;

--- a/packages/keystatic/src/form/api.tsx
+++ b/packages/keystatic/src/form/api.tsx
@@ -15,17 +15,18 @@ export type FormFieldInputProps<Value> = {
   forceValidation: boolean;
 };
 
-export type JsonValue =
+export type JsonYamlValue =
   | string
   | number
   | boolean
   | null
-  | readonly JsonValue[]
-  | { [key: string]: JsonValue };
+  | Date
+  | readonly JsonYamlValue[]
+  | { [key: string]: JsonYamlValue };
 
-type JsonValueWithoutNull = JsonValue & {};
+type JsonYamlValueWithoutNull = JsonYamlValue & {};
 
-export type FormFieldStoredValue = JsonValueWithoutNull | undefined;
+export type FormFieldStoredValue = JsonYamlValueWithoutNull | undefined;
 
 export type BasicFormField<
   ParsedValue extends {} | null,

--- a/packages/keystatic/src/form/fields/date/index.tsx
+++ b/packages/keystatic/src/form/fields/date/index.tsx
@@ -51,13 +51,23 @@ export function date<IsRequired extends boolean | undefined>({
       if (value === undefined) {
         return null;
       }
+      if (value instanceof Date) {
+        const year = value.getUTCFullYear();
+        const month = String(value.getUTCMonth() + 1).padStart(2, '0');
+        const day = String(value.getUTCDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
+      }
       if (typeof value !== 'string') {
         throw new FieldDataError('Must be a string');
       }
       return value;
     },
     serialize(value) {
-      return { value: value === null ? undefined : value };
+      if (value === null) return { value: undefined };
+      const date = new Date(value);
+      date.toISOString = () => value;
+      date.toString = () => value;
+      return { value: date };
     },
     validate(value) {
       const message = validateDate(validation, value, label);

--- a/packages/keystatic/src/form/fields/datetime/index.tsx
+++ b/packages/keystatic/src/form/fields/datetime/index.tsx
@@ -51,13 +51,20 @@ export function datetime<IsRequired extends boolean | undefined>({
       if (value === undefined) {
         return null;
       }
+      if (value instanceof Date) {
+        return value.toISOString().slice(0, -8);
+      }
       if (typeof value !== 'string') {
-        throw new FieldDataError('Must be a string');
+        throw new FieldDataError('Must be a string or date');
       }
       return value;
     },
     serialize(value) {
-      return { value: value === null ? undefined : value };
+      if (value === null) return { value: undefined };
+      const date = new Date(value + 'Z');
+      date.toJSON = () => date.toISOString().slice(0, -8);
+      date.toString = () => date.toISOString().slice(0, -8);
+      return { value: date };
     },
     validate(value) {
       const message = validateDatetime(validation, value, label);

--- a/packages/keystatic/src/form/parse-props.ts
+++ b/packages/keystatic/src/form/parse-props.ts
@@ -1,7 +1,7 @@
 import { assertNever } from 'emery';
 import { ComponentSchema } from './api';
 import { ReadonlyPropPath } from './fields/document/DocumentEditor/component-blocks/utils';
-import { FormField, FormFieldStoredValue, JsonValue } from '..';
+import { FormField, FormFieldStoredValue, JsonYamlValue } from '..';
 import { FieldDataError } from './fields/error';
 import { validateArrayLength } from './validate-array-length';
 import { getInitialPropsValue } from './initial-values';
@@ -19,7 +19,7 @@ export class PropValidationError extends Error {
 }
 
 function toFormFieldStoredValue(
-  val: JsonValue | undefined
+  val: JsonYamlValue | undefined
 ): FormFieldStoredValue {
   if (val === null) {
     return undefined;
@@ -31,7 +31,7 @@ const isArray: (val: unknown) => val is readonly unknown[] = Array.isArray;
 
 export function parseProps(
   schema: ComponentSchema,
-  _value: JsonValue | undefined,
+  _value: JsonYamlValue | undefined,
   path: ReadonlyPropPath,
   pathWithArrayFieldSlugs: readonly string[],
   parseFormField: (
@@ -59,7 +59,12 @@ export function parseProps(
       return getInitialPropsValue(schema);
     }
     try {
-      if (typeof value !== 'object' || value === null || isArray(value)) {
+      if (
+        typeof value !== 'object' ||
+        value === null ||
+        isArray(value) ||
+        value instanceof Date
+      ) {
         throw new FieldDataError('Must be an object');
       }
       for (const key of Object.keys(value)) {
@@ -100,7 +105,12 @@ export function parseProps(
       value = {};
     }
     try {
-      if (typeof value !== 'object' || value === null || isArray(value)) {
+      if (
+        typeof value !== 'object' ||
+        value === null ||
+        isArray(value) ||
+        value instanceof Date
+      ) {
         throw new FieldDataError('Must be an object');
       }
       const allowedKeysSet = new Set(Object.keys(schema.fields));
@@ -163,7 +173,8 @@ export function parseProps(
             schema.slugField &&
             typeof innerVal === 'object' &&
             innerVal !== null &&
-            !isArray(innerVal)
+            !isArray(innerVal) &&
+            !(innerVal instanceof Date)
           ) {
             if (schema.element.kind !== 'object') {
               throw new Error(


### PR DESCRIPTION
Closes #821

Note this doesn't change the type in the reader API, that is still a string.