### PR TITLE
Fix `inline` component serialisation in `fields.mdx`

### DIFF
--- a/.changeset/serious-tables-run.md
+++ b/.changeset/serious-tables-run.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fix `inline` component serialisation in `fields.mdx`

--- a/packages/keystatic/src/form/fields/markdoc/editor/mdx/serialize.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/mdx/serialize.ts
@@ -97,7 +97,9 @@ function textblockChildren(
       children.push({
         type: 'mdxJsxTextElement',
         name: child.type.name,
-        attributes: propsToAttributes(child.attrs.props),
+        attributes: propsToAttributes(
+          internalToSerialized(componentConfig.schema, child.attrs.props, state)
+        ),
         children: [],
       });
       return;

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/markdoc.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/markdoc.test.tsx
@@ -8,7 +8,7 @@ import { proseMirrorToMarkdoc } from '../markdoc/serialize';
 import Markdoc from '@markdoc/markdoc';
 import { createEditorSchema } from '../schema';
 import { editorOptionsToConfig } from '../../config';
-import { block, mark } from '../../../../../content-components';
+import { block, inline, mark } from '../../../../../content-components';
 import { fields } from '../../../../..';
 
 const schema = createEditorSchema(
@@ -35,6 +35,12 @@ const schema = createEditorSchema(
       label: 'With array',
       schema: {
         array: fields.array(fields.text({ label: 'Text' })),
+      },
+    }),
+    'inline-thing': inline({
+      label: 'Inline Thing',
+      schema: {
+        something: fields.text({ label: 'Something' }),
       },
     }),
   },
@@ -451,6 +457,38 @@ test('two hard breaks', () => {
     "something\\
     \\
     The
+    "
+  `);
+});
+
+test('inline', () => {
+  const markdoc = `wertgrfdsc{% inline-thing something="adkjsakjndnajksdnjk" /%}sfasdf`;
+  const editor = fromMarkdoc(markdoc);
+  expect(editor).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text>
+          <cursor />
+          wertgrfdsc
+        </text>
+        <inline-thing
+          props={
+            {
+              "extraFiles": [],
+              "value": {
+                "something": "adkjsakjndnajksdnjk",
+              },
+            }
+          }
+        />
+        <text>
+          sfasdf
+        </text>
+      </paragraph>
+    </doc>
+  `);
+  expect(toMarkdoc(editor)).toMatchInlineSnapshot(`
+    "wertgrfdsc{% inline-thing something="adkjsakjndnajksdnjk" /%}sfasdf
     "
   `);
 });

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/mdx.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/mdx.test.tsx
@@ -12,7 +12,7 @@ import { fromMarkdown } from 'mdast-util-from-markdown';
 import { mdxjs } from 'micromark-extension-mdxjs';
 import { mdxToProseMirror } from '../mdx/parse';
 import { expect, test } from '@jest/globals';
-import { block, mark } from '../../../../../content-components';
+import { block, inline, mark } from '../../../../../content-components';
 import { fields } from '../../../../..';
 import { gfm } from 'micromark-extension-gfm';
 
@@ -50,6 +50,12 @@ const schema = createEditorSchema(
           ],
           defaultValue: 'default',
         }),
+      },
+    }),
+    InlineThing: inline({
+      label: 'Inline Thing',
+      schema: {
+        something: fields.text({ label: 'Something' }),
       },
     }),
   },
@@ -483,6 +489,38 @@ test('mark', () => {
   `);
   expect(toMDX(editor)).toMatchInlineSnapshot(`
     "<Highlight variant="success">something</Highlight>
+    "
+  `);
+});
+
+test('inline', () => {
+  const mdx = `wertgrfdsc<InlineThing something="adkjsakjndnajksdnjk" />asdfasdf`;
+  const editor = fromMDX(mdx);
+  expect(editor).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text>
+          <cursor />
+          wertgrfdsc
+        </text>
+        <InlineThing
+          props={
+            {
+              "extraFiles": [],
+              "value": {
+                "something": "adkjsakjndnajksdnjk",
+              },
+            }
+          }
+        />
+        <text>
+          asdfasdf
+        </text>
+      </paragraph>
+    </doc>
+  `);
+  expect(toMDX(editor)).toMatchInlineSnapshot(`
+    "wertgrfdsc<InlineThing something="adkjsakjndnajksdnjk" />asdfasdf
     "
   `);
 });


### PR DESCRIPTION
#1016 