### PR TITLE
Make Keystatic scale to mobile screen as it should be

### DIFF
--- a/packages/keystatic/src/app/provider.tsx
+++ b/packages/keystatic/src/app/provider.tsx
@@ -194,6 +194,7 @@ export default function Provider({
 
   return (
     <ThemeProvider value={themeContext}>
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
       <KeystarProvider
         locale={config.locale || 'en-US'}
         colorScheme={themeContext.theme}


### PR DESCRIPTION
We should simply add that tag in the `<head>`: `<meta name="viewport" content="width=device-width, initial-scale=1" />`.

Sorry, I don't find how to add it in the head tag, but that solution is way better that nothing and it give the same result and make mobile way more usable.