### PR TITLE
Editor placeholder cursor visibility

### DIFF
--- a/.changeset/chilled-adults-arrive.md
+++ b/.changeset/chilled-adults-arrive.md
@@ -1,0 +1,6 @@
+---
+'@keystatic/core': patch
+---
+
+Fix for a Firefox bug where the text cursor is hidden when beside a
+`contenteditable=false` element.

--- a/packages/keystatic/src/form/fields/markdoc/editor/placeholder.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/placeholder.ts
@@ -7,19 +7,41 @@ export function placeholderPlugin(text: string) {
   return new Plugin({
     props: {
       decorations(state) {
-        let doc = state.doc;
         if (
-          doc.childCount === 1 &&
-          doc.firstChild?.isTextblock &&
-          doc.firstChild.content.size === 0
+          state.doc.childCount === 1 &&
+          state.doc.firstChild?.isTextblock &&
+          state.doc.firstChild.content.size === 0
         ) {
           let placeholder = document.createElement('span');
           placeholder.className = classes.placeholder;
+          placeholder.contentEditable = 'false'; // 1
           placeholder.textContent = text;
 
-          return DecorationSet.create(doc, [Decoration.widget(1, placeholder)]);
+          return DecorationSet.create(state.doc, [
+            Decoration.widget(1, bookendWithZeroWidthSpace(placeholder), {
+              // undocumented prop on `WidgetViewDesc` that stops the decoration
+              // from being wrapped with a contenteditable=false span.
+              // note:
+              //   1. we must add the contenteditable=false attr ourselves
+              //   2. this is a private API and may break in future versions
+              // see:
+              //   - https://github.com/ProseMirror/prosemirror-view/blob/master/src/viewdesc.ts
+              raw: true,
+            }),
+          ]);
         }
       },
     },
   });
+}
+
+// firefox bug where the cursor is hidden when beside `contenteditable=false`
+// - https://discuss.prosemirror.net/t/firefox-contenteditable-false-cursor-bug/5016
+// - https://bugzilla.mozilla.org/show_bug.cgi?id=1612076
+function bookendWithZeroWidthSpace(element: HTMLElement) {
+  let wrapper = document.createElement('span');
+  wrapper.appendChild(document.createTextNode('\u200b'));
+  wrapper.appendChild(element);
+  wrapper.appendChild(document.createTextNode('\u200b'));
+  return wrapper;
 }

--- a/packages/keystatic/src/form/fields/markdoc/editor/placeholder.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/placeholder.ts
@@ -18,7 +18,7 @@ export function placeholderPlugin(text: string) {
           placeholder.textContent = text;
 
           return DecorationSet.create(state.doc, [
-            Decoration.widget(1, bookendWithZeroWidthSpace(placeholder), {
+            Decoration.widget(1, bookendWithZeroWidthSpaces(placeholder), {
               // undocumented prop on `WidgetViewDesc` that stops the decoration
               // from being wrapped with a contenteditable=false span.
               // note:
@@ -38,10 +38,11 @@ export function placeholderPlugin(text: string) {
 // firefox bug where the cursor is hidden when beside `contenteditable=false`
 // - https://discuss.prosemirror.net/t/firefox-contenteditable-false-cursor-bug/5016
 // - https://bugzilla.mozilla.org/show_bug.cgi?id=1612076
-function bookendWithZeroWidthSpace(element: HTMLElement) {
+function bookendWithZeroWidthSpaces(element: HTMLElement) {
   let wrapper = document.createElement('span');
-  wrapper.appendChild(document.createTextNode('\u200b'));
-  wrapper.appendChild(element);
-  wrapper.appendChild(document.createTextNode('\u200b'));
+  wrapper.append(zeroWidthSpace(), element, zeroWidthSpace());
   return wrapper;
+}
+function zeroWidthSpace() {
+  return document.createTextNode('\u200B');
 }


### PR DESCRIPTION
Fixes #993 — Firefox bug where the cursor is hidden when beside a `contenteditable=false` element.