### PR TITLE
Fix breadcrumb collapse

### DIFF
--- a/.changeset/six-dodos-rescue.md
+++ b/.changeset/six-dodos-rescue.md
@@ -1,0 +1,6 @@
+---
+'@keystatic/core': patch
+---
+
+Memo'd breadcrumbs to avoid unexpected behaviour where items collapse into a menu
+prematurely.

--- a/packages/keystatic/src/app/ItemPage.tsx
+++ b/packages/keystatic/src/app/ItemPage.tsx
@@ -1018,27 +1018,32 @@ const ItemPageShell = (
 ) => {
   const router = useRouter();
   const collectionConfig = props.config.collections![props.collection]!;
+  const onBreadcrumbAction = useCallback(
+    (key: Key) => {
+      if (key === 'collection') {
+        router.push(`${props.basePath}/collection/${props.collection}`);
+      }
+    },
+    [props.basePath, props.collection, router]
+  );
+  const breadcrumbs = useMemo(() => {
+    return (
+      <Breadcrumbs
+        flex
+        size="medium"
+        minWidth="alias.singleLineWidth"
+        onAction={onBreadcrumbAction}
+      >
+        <Item key="collection">{collectionConfig.label}</Item>
+        <Item key="item">{props.itemSlug}</Item>
+      </Breadcrumbs>
+    );
+  }, [collectionConfig.label, onBreadcrumbAction, props.itemSlug]);
 
   return (
     <PageRoot containerWidth={containerWidthForEntryLayout(collectionConfig)}>
       <PageHeader>
-        <Breadcrumbs
-          flex
-          size="medium"
-          minWidth={0}
-          onAction={key => {
-            if (key === 'collection') {
-              router.push(
-                `${props.basePath}/collection/${encodeURIComponent(
-                  props.collection
-                )}`
-              );
-            }
-          }}
-        >
-          <Item key="collection">{collectionConfig.label}</Item>
-          <Item key="item">{props.itemSlug}</Item>
-        </Breadcrumbs>
+        {breadcrumbs}
         {props.headerActions}
       </PageHeader>
 

--- a/packages/keystatic/src/app/ItemPage.tsx
+++ b/packages/keystatic/src/app/ItemPage.tsx
@@ -10,15 +10,17 @@ import {
   useMemo,
   useState,
 } from 'react';
+import * as Y from 'yjs';
+import { z } from 'zod';
 
-import { ActionGroup } from '@keystar/ui/action-group';
+import { ActionGroup, Item } from '@keystar/ui/action-group';
 import { Badge } from '@keystar/ui/badge';
-import { Breadcrumbs, Item } from '@keystar/ui/breadcrumbs';
 import { Button, ButtonGroup } from '@keystar/ui/button';
 import { AlertDialog, Dialog, DialogContainer } from '@keystar/ui/dialog';
 import { Icon } from '@keystar/ui/icon';
 import { copyPlusIcon } from '@keystar/ui/icon/icons/copyPlusIcon';
 import { externalLinkIcon } from '@keystar/ui/icon/icons/externalLinkIcon';
+import { githubIcon } from '@keystar/ui/icon/icons/githubIcon';
 import { historyIcon } from '@keystar/ui/icon/icons/historyIcon';
 import { trash2Icon } from '@keystar/ui/icon/icons/trash2Icon';
 import { Box, Flex } from '@keystar/ui/layout';
@@ -35,10 +37,12 @@ import { TextField } from '@keystar/ui/text-field';
 import { Heading, Text } from '@keystar/ui/typography';
 
 import { Config } from '../config';
-import { createGetPreviewProps } from '../form/preview-props';
 import { fields } from '../form/api';
+import { createGetPreviewProps } from '../form/preview-props';
 import { clientSideValidateProp } from '../form/errors';
 import { useEventCallback } from '../form/fields/document/DocumentEditor/ui-utils';
+import { createGetPreviewPropsFromY } from '../form/preview-props-yjs';
+import { getYjsValFromParsedValue } from '../form/props-value';
 
 import {
   prettyErrorForCreateBranchMutation,
@@ -47,17 +51,29 @@ import {
 import { FormForEntry, containerWidthForEntryLayout } from './entry-form';
 import { ForkRepoDialog } from './fork-repo';
 import l10nMessages from './l10n/index.json';
+import { notFound } from './not-found';
 import { getDataFileExtension, getPathPrefix } from './path-utils';
 import { useRouter } from './router';
-import { PageBody, PageHeader, PageRoot } from './shell/page';
+import { HeaderBreadcrumbs } from './shell/Breadcrumbs';
+import { useYjs, useYjsIfAvailable } from './shell/collab';
+import { useConfig } from './shell/context';
 import { useBaseCommit, useRepositoryId, useBranchInfo } from './shell/data';
+import { PageBody, PageHeader, PageRoot } from './shell/page';
+import { useSlugFieldInfo } from './slugs';
+import {
+  delDraft,
+  getDraft,
+  setDraft,
+  showDraftRestoredToast,
+} from './persistence';
+import { PresenceAvatars } from './presence';
 import {
   serializeEntryToFiles,
   useDeleteItem,
   useUpsertItem,
 } from './updating';
-import { parseEntry, useItemData } from './useItemData';
 import { useHasChanged } from './useHasChanged';
+import { parseEntry, useItemData } from './useItemData';
 import {
   getBranchPrefix,
   getCollectionFormat,
@@ -66,24 +82,8 @@ import {
   getSlugFromState,
   isGitHubConfig,
 } from './utils';
-import { notFound } from './not-found';
-import { useConfig } from './shell/context';
-import { useSlugFieldInfo } from './slugs';
-import { z } from 'zod';
 import { LOADING, useData } from './useData';
-import {
-  delDraft,
-  getDraft,
-  setDraft,
-  showDraftRestoredToast,
-} from './persistence';
-import { githubIcon } from '@keystar/ui/icon/icons/githubIcon';
-import { useYjs, useYjsIfAvailable } from './shell/collab';
-import * as Y from 'yjs';
-import { getYjsValFromParsedValue } from '../form/props-value';
 import { useYJsValue } from './useYJsValue';
-import { createGetPreviewPropsFromY } from '../form/preview-props-yjs';
-import { PresenceAvatars } from './presence';
 
 type ItemPageProps = {
   collection: string;
@@ -1026,24 +1026,21 @@ const ItemPageShell = (
     },
     [props.basePath, props.collection, router]
   );
-  const breadcrumbs = useMemo(() => {
-    return (
-      <Breadcrumbs
-        flex
-        size="medium"
-        minWidth="alias.singleLineWidth"
-        onAction={onBreadcrumbAction}
-      >
-        <Item key="collection">{collectionConfig.label}</Item>
-        <Item key="item">{props.itemSlug}</Item>
-      </Breadcrumbs>
-    );
-  }, [collectionConfig.label, onBreadcrumbAction, props.itemSlug]);
+  const breadcrumbItems = useMemo(
+    () => [
+      { key: 'collection', label: collectionConfig.label },
+      { key: 'item', label: props.itemSlug },
+    ],
+    [collectionConfig.label, props.itemSlug]
+  );
 
   return (
     <PageRoot containerWidth={containerWidthForEntryLayout(collectionConfig)}>
       <PageHeader>
-        {breadcrumbs}
+        <HeaderBreadcrumbs
+          items={breadcrumbItems}
+          onAction={onBreadcrumbAction}
+        />
         {props.headerActions}
       </PageHeader>
 

--- a/packages/keystatic/src/app/shell/Breadcrumbs.tsx
+++ b/packages/keystatic/src/app/shell/Breadcrumbs.tsx
@@ -1,0 +1,24 @@
+import { Breadcrumbs, Item } from '@keystar/ui/breadcrumbs';
+import { Key, memo } from 'react';
+
+type HeaderBreadcrumbsProps = {
+  /** The breadcrumb items. */
+  items: { key: Key; label: string }[];
+  /** Called when an item is selected. */
+  onAction: (key: Key) => void;
+};
+
+export const HeaderBreadcrumbs = memo((props: HeaderBreadcrumbsProps) => {
+  return (
+    <Breadcrumbs
+      flex
+      size="medium"
+      minWidth="alias.singleLineWidth"
+      onAction={props.onAction}
+    >
+      {props.items.map(item => (
+        <Item key={item.key}>{item.label}</Item>
+      ))}
+    </Breadcrumbs>
+  );
+});


### PR DESCRIPTION
Abstract `HeaderBreadcrumbs` component that expects memoized `items` and `onAction` props. Memo'd breadcrumbs avoids unexpected behaviour where items collapse into a menu prematurely.