### PR TITLE
Add basic support for custom CSS in the app

### DIFF
--- a/.changeset/selfish-items-double.md
+++ b/.changeset/selfish-items-double.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': minor
+---
+
+Add option to include custom CSS in admin UI

--- a/packages/keystatic/src/app/provider.tsx
+++ b/packages/keystatic/src/app/provider.tsx
@@ -205,6 +205,7 @@ export default function Provider({
           href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet"
         />
+        <style>{config.customCSS}</style>
         <UrqlProvider value={useMemo(() => createUrqlClient(config), [config])}>
           {children}
         </UrqlProvider>

--- a/packages/keystatic/src/app/provider.tsx
+++ b/packages/keystatic/src/app/provider.tsx
@@ -205,7 +205,7 @@ export default function Provider({
           href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet"
         />
-        <style>{config.customCSS}</style>
+        {config.customCSS && <style>{config.customCSS}</style>}
         <UrqlProvider value={useMemo(() => createUrqlClient(config), [config])}>
           {children}
         </UrqlProvider>

--- a/packages/keystatic/src/config.tsx
+++ b/packages/keystatic/src/config.tsx
@@ -41,6 +41,7 @@ type CommonConfig<Collections, Singletons> = {
   locale?: Locale;
   cloud?: { project: string };
   ui?: UserInterface<Collections, Singletons>;
+  customCSS?: string;
 };
 
 type CommonRemoteStorageConfig = {


### PR DESCRIPTION
Hey! This adds basic support for custom CSS in the app, to allow some quirky behaviour (that I can exemplify if needed).

For example, this allows adding something like a utility-based CSS library (by precompiling the CSS, of course).

Of course this can be improved in the future, but for now it already covers a lot of cases even with the simplest implementation of all!

The next steps would be probably to allow to introduce things like TailwindCSS in the build step of the Admin UI specifically, or maybe something else I can't think of right now, I'm tired ahah

Hope you enjoy this simple solution :) Let me know if you want me to change anything.