### PR TITLE
Fix `fields.datetime({ defaultValue: { kind: 'now' } })`

### DIFF
--- a/.changeset/pretty-balloons-taste.md
+++ b/.changeset/pretty-balloons-taste.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fix `fields.datetime({ defaultValue: { kind: 'now' } })`

--- a/packages/keystatic/src/form/fields/datetime/index.tsx
+++ b/packages/keystatic/src/form/fields/datetime/index.tsx
@@ -43,7 +43,9 @@ export function datetime<IsRequired extends boolean | undefined>({
       }
       if (defaultValue.kind === 'now') {
         const now = new Date();
-        return now.toISOString();
+        return new Date(now.getTime() - now.getTimezoneOffset() * 60 * 1000)
+          .toISOString()
+          .slice(0, -8);
       }
       return null;
     },


### PR DESCRIPTION
Fixes #1084