### PR TITLE
Deprecate `fields.document`

### DIFF
--- a/.changeset/silly-jobs-press.md
+++ b/.changeset/silly-jobs-press.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Deprecate `fields.document`

--- a/docs/keystatic.config.tsx
+++ b/docs/keystatic.config.tsx
@@ -540,6 +540,7 @@ export default config({
                     { label: 'Default', value: 'default' },
                     { label: 'New', value: 'new' },
                     { label: 'Experimental', value: 'experimental' },
+                    { label: 'Deprecated', value: 'deprecated' },
                   ],
                   defaultValue: 'default',
                 }),

--- a/docs/src/components/navigation/badges.tsx
+++ b/docs/src/components/navigation/badges.tsx
@@ -29,3 +29,6 @@ export const NewBadge = () => <Badge variant="new" label="New" />;
 export const ComingSoonBadge = () => (
   <Badge variant="experimental" label="Soon" />
 );
+export const DeprecatedBadge = () => (
+  <Badge variant="experimental" label="Deprecated" />
+);

--- a/docs/src/components/navigation/header-nav.tsx
+++ b/docs/src/components/navigation/header-nav.tsx
@@ -19,7 +19,7 @@ export type NavProps = {
       href: string;
       title: string | undefined;
       comingSoon?: boolean;
-      status?: BadgeStatus;
+      status?: BadgeStatus | 'deprecated';
     }[];
   }[];
 };

--- a/docs/src/components/navigation/nav-item.tsx
+++ b/docs/src/components/navigation/nav-item.tsx
@@ -2,7 +2,12 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { ComingSoonBadge, NewBadge, type BadgeStatus } from './badges';
+import {
+  ComingSoonBadge,
+  NewBadge,
+  type BadgeStatus,
+  DeprecatedBadge,
+} from './badges';
 import { cx } from '../../utils';
 
 type NavItemProps = {
@@ -13,7 +18,7 @@ type NavItemProps = {
   title?: string;
   tabIndex?: number;
   comingSoon?: boolean;
-  status?: BadgeStatus;
+  status?: BadgeStatus | 'deprecated';
   currentPage?: boolean;
 };
 
@@ -72,6 +77,7 @@ export function NavItem({
             {label}
             {status === 'new' && <NewBadge />}
             {status === 'experimental' && <ComingSoonBadge />}
+            {status === 'deprecated' && <DeprecatedBadge />}
           </a>
         </Link>
       )}

--- a/docs/src/content/navigation.yaml
+++ b/docs/src/content/navigation.yaml
@@ -5,69 +5,84 @@ navGroups:
         link:
           discriminant: page
           value: introduction
+        status: default
       - label: Quick start
         link:
           discriminant: page
           value: quick-start
+        status: default
       - label: Keystatic Cloud
         link:
           discriminant: page
           value: cloud
+        status: default
   - groupName: Integration guides
     items:
       - label: Astro
         link:
           discriminant: page
           value: installation-astro
+        status: default
       - label: Next.js
         link:
           discriminant: page
           value: installation-next-js
+        status: default
       - label: Remix
         link:
           discriminant: page
           value: installation-remix
+        status: default
   - groupName: Core concepts
     items:
       - label: Content organisation
         link:
           discriminant: page
           value: content-organisation
+        status: default
       - label: Path wildcard
         link:
           discriminant: page
           value: path-wildcard
+        status: default
       - label: Local mode
         link:
           discriminant: page
           value: local-mode
+        status: default
       - label: GitHub mode
         link:
           discriminant: page
           value: github-mode
+        status: default
       - label: Reader API
         link:
           discriminant: page
           value: reader-api
+        status: default
       - label: Format options
         link:
           discriminant: page
           value: format-options
+        status: default
       - label: Entry Layout
         link:
           discriminant: page
           value: entry-layout
+        status: default
       - label: User interface
         link:
           discriminant: page
           value: user-interface
+        status: default
       - label: Content components
         link:
           discriminant: page
           value: content-components
+        status: default
   - groupName: Recipes
     items:
-      - label: "Use Astro's Image component"
+      - label: Use Astro's Image component
         link:
           discriminant: page
           value: recipes/astro-images
@@ -76,137 +91,170 @@ navGroups:
         link:
           discriminant: page
           value: recipes/real-time-previews
+        status: default
       - label: 'Astro: Disable Admin UI Routes in Production'
         link:
           discriminant: page
           value: recipes/astro-disable-admin-ui-in-production
+        status: default
   - groupName: Reference
     items:
       - label: Configuration
         link:
           discriminant: page
           value: configuration
+        status: default
       - label: Collections
         link:
           discriminant: page
           value: collections
+        status: default
       - label: Singletons
         link:
           discriminant: page
           value: singletons
+        status: default
   - groupName: Fields API
     items:
       - label: Array
         link:
           discriminant: page
           value: fields/array
+        status: default
       - label: Blocks
         link:
           discriminant: page
           value: fields/blocks
+        status: default
       - label: Checkbox
         link:
           discriminant: page
           value: fields/checkbox
+        status: default
       - label: Child
         link:
           discriminant: page
           value: fields/child
+        status: default
       - label: Cloud Image
         link:
           discriminant: page
           value: fields/cloud-image
+        status: default
       - label: Conditional
         link:
           discriminant: page
           value: fields/conditional
+        status: default
       - label: Date
         link:
           discriminant: page
           value: fields/date
+        status: default
       - label: Datetime
         link:
           discriminant: page
           value: fields/datetime
+        status: default
       - label: Document
         link:
           discriminant: page
           value: fields/document
+        status: deprecated
       - label: Empty
         link:
           discriminant: page
           value: fields/empty
+        status: default
       - label: Empty Document
         link:
           discriminant: page
           value: fields/empty-document
+        status: default
       - label: File
         link:
           discriminant: page
           value: fields/file
+        status: default
       - label: Image
         link:
           discriminant: page
           value: fields/image
+        status: default
       - label: Integer
         link:
           discriminant: page
           value: fields/integer
+        status: default
       - label: Markdoc
         link:
           discriminant: page
           value: fields/markdoc
+        status: default
       - label: MDX
         link:
           discriminant: page
           value: fields/mdx
+        status: default
       - label: Multiselect
         link:
           discriminant: page
           value: fields/multiselect
+        status: default
       - label: Number
         link:
           discriminant: page
           value: fields/number
+        status: default
       - label: Object
         link:
           discriminant: page
           value: fields/object
+        status: default
       - label: Path Reference
         link:
           discriminant: page
           value: fields/path-reference
+        status: default
       - label: Relationship
         link:
           discriminant: page
           value: fields/relationship
+        status: default
       - label: Select
         link:
           discriminant: page
           value: fields/select
+        status: default
       - label: Slug
         link:
           discriminant: page
           value: fields/slug
+        status: default
       - label: Text
         link:
           discriminant: page
           value: fields/text
+        status: default
       - label: URL
         link:
           discriminant: page
           value: fields/url
+        status: default
   - groupName: Community
     items:
       - label: GitHub Discussions
         link:
           discriminant: url
           value: https://github.com/Thinkmill/keystatic/discussions
+        status: default
       - label: Discord
         link:
           discriminant: url
           value: /chat
+        status: default
       - label: Twitter
         link:
           discriminant: url
           value: https://twitter.com/thekeystatic
+        status: default

--- a/docs/src/content/pages/fields/document.mdoc
+++ b/docs/src/content/pages/fields/document.mdoc
@@ -2,11 +2,16 @@
 title: Document field
 summary: The document field is a highly customisable rich text editor.
 ---
+{% aside icon="⚠️" %}
+[`fields.markdoc`](/docs/fields/markdoc) has superseded this field. [`fields.mdx`](/docs/fields/mdx) is also available if you prefer MDX.
+{% /aside %}
+
 The `document` field is a highly customisable rich text editor.
 
 It lets content creators quickly and easily edit content in your system.
 
 ## Usage example
+
 ```ts
 document: fields.document({
   label: 'Document',
@@ -131,6 +136,7 @@ document: fields.document({
   },
 }),
 ```
+
 ---
 
 ## Other configuration options

--- a/packages/keystatic/src/form/fields/document/index.tsx
+++ b/packages/keystatic/src/form/fields/document/index.tsx
@@ -246,6 +246,9 @@ export function normaliseDocumentFeatures(
   };
 }
 
+/**
+ * @deprecated `fields.markdoc` has superseded this field. `fields.mdx` is also available if you prefer MDX.
+ */
 export function document({
   label,
   componentBlocks = {},


### PR DESCRIPTION
We don't have any plans to remove `fields.document` at the moment but this makes it clear that `fields.markdoc` and `fields.mdx` are the fields we recommend using for rich text.