### PR TITLE
Store search query state in URL

### DIFF
--- a/packages/keystatic/src/app/CollectionPage.tsx
+++ b/packages/keystatic/src/app/CollectionPage.tsx
@@ -77,7 +77,25 @@ export function CollectionPage(props: CollectionPageProps) {
   const containerWidth = 'none'; // TODO: use a "large" when we have more columns
   const collectionConfig = config.collections?.[collection];
   if (!collectionConfig) notFound();
-  const [searchTerm, setSearchTerm] = useState('');
+
+  const router = useRouter();
+  const [searchTerm, setSearchTerm] = useState(
+    new URLSearchParams(router.search).get('search') ?? ''
+  );
+
+  const setSearchTermFromForm = useCallback(
+    (value: string) => {
+      setSearchTerm(value);
+      const params = new URLSearchParams(router.search);
+      if (value) {
+        params.set('search', value);
+      } else {
+        params.delete('search');
+      }
+      router.replace(router.pathname + '?' + params.toString());
+    },
+    [router]
+  );
 
   let debouncedSearchTerm = useDebouncedValue(searchTerm, 300);
 
@@ -89,7 +107,7 @@ export function CollectionPage(props: CollectionPageProps) {
           props.collection
         )}/create`}
         searchTerm={searchTerm}
-        onSearchTermChange={setSearchTerm}
+        onSearchTermChange={setSearchTermFromForm}
       />
       <CollectionPageContent searchTerm={debouncedSearchTerm} {...props} />
     </PageRoot>

--- a/packages/keystatic/src/app/router.tsx
+++ b/packages/keystatic/src/app/router.tsx
@@ -13,6 +13,8 @@ export type Router = {
   replace: (path: string) => void;
   href: string;
   params: string[];
+  pathname: string;
+  search: string;
 };
 
 const RouterContext = createContext<Router | null>(null);
@@ -41,6 +43,8 @@ export function RouterProvider(props: { children: ReactNode }) {
     const parsedUrl = new URL(url);
     return {
       href: parsedUrl.pathname + parsedUrl.search,
+      pathname: parsedUrl.pathname,
+      search: parsedUrl.search,
       replace(path) {
         navigate(path, true);
       },

--- a/packages/keystatic/src/app/shell/sidebar/index.tsx
+++ b/packages/keystatic/src/app/shell/sidebar/index.tsx
@@ -268,13 +268,14 @@ function useIsCurrent() {
   return useCallback(
     (href: string, { exact = false } = {}) => {
       if (exact) {
-        return href === router.href ? 'page' : undefined;
+        return href === router.pathname ? 'page' : undefined;
       }
-      return href === router.href || router.href.startsWith(`${href}/`)
+      return href === router.pathname ||
+        router.pathname.startsWith(`${router.pathname}/`)
         ? 'page'
         : undefined;
     },
-    [router.href]
+    [router.pathname]
   );
 }
 


### PR DESCRIPTION
This PR stores the search query in the URL as a `search` query string, and it pre-populates the initial value of the collection page with the current search query.

First contribution here, so please forgive any formatting or code pattern violations 😄 