### PR TITLE
Fix previewing SVGs in `fields.image` and the editors

### DIFF
--- a/.changeset/tidy-ravens-taste.md
+++ b/.changeset/tidy-ravens-taste.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fix previewing SVGs in `fields.image` and the editors

--- a/packages/keystatic/src/form/fields/document/DocumentEditor/image.tsx
+++ b/packages/keystatic/src/form/fields/document/DocumentEditor/image.tsx
@@ -54,7 +54,10 @@ export const ImageElement = ({
     editor,
     __elementForGettingPath
   );
-  const objectUrl = useObjectURL(currentElement.src.content)!;
+  const objectUrl = useObjectURL(
+    currentElement.src.content,
+    currentElement.src.filename.endsWith('.svg') ? 'image/svg+xml' : undefined
+  )!;
   const activePopoverElement = useActiveBlockPopover();
   const selected = activePopoverElement === __elementForGettingPath;
 

--- a/packages/keystatic/src/form/fields/file/ui.tsx
+++ b/packages/keystatic/src/form/fields/file/ui.tsx
@@ -24,7 +24,7 @@ export function FileFieldInput(
   const { value } = props;
   const [blurred, onBlur] = useReducer(() => true, false);
   const isInEditor = useIsInDocumentEditor();
-  const objectUrl = useObjectURL(value === null ? null : value.data);
+  const objectUrl = useObjectURL(value === null ? null : value.data, undefined);
   const labelId = useId();
   const descriptionId = useId();
   return (

--- a/packages/keystatic/src/form/fields/image/ui.tsx
+++ b/packages/keystatic/src/form/fields/image/ui.tsx
@@ -45,17 +45,20 @@ export function getUploadedImage(): Promise<
   return getUploadedFile('image/*');
 }
 
-export function useObjectURL(data: Uint8Array | null) {
+export function useObjectURL(
+  data: Uint8Array | null,
+  contentType: string | undefined
+) {
   const [url, setUrl] = useState<string | null>(null);
   useEffect(() => {
     if (data) {
-      const url = URL.createObjectURL(new Blob([data]));
+      const url = URL.createObjectURL(new Blob([data], { type: contentType }));
       setUrl(url);
       return () => URL.revokeObjectURL(url);
     } else {
       setUrl(null);
     }
-  }, [data]);
+  }, [contentType, data]);
   return url;
 }
 
@@ -74,7 +77,10 @@ export function ImageFieldInput(
   const { value } = props;
   const [blurred, onBlur] = useReducer(() => true, false);
   const isInEditor = useIsInDocumentEditor();
-  const objectUrl = useObjectURL(value === null ? null : value.data);
+  const objectUrl = useObjectURL(
+    value === null ? null : value.data,
+    value?.extension === 'svg' ? 'image/svg+xml' : undefined
+  );
   const labelId = useId();
   const descriptionId = useId();
   return (

--- a/packages/keystatic/src/form/fields/markdoc/editor/schema.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/schema.tsx
@@ -343,7 +343,11 @@ const nodeSpecs = {
       },
     },
     nodeView(node) {
-      const blob = new Blob([node.attrs.src]);
+      const blob = new Blob([node.attrs.src], {
+        type: node.attrs.filename.endsWith('.svg')
+          ? 'image/svg+xml'
+          : undefined,
+      });
       const dom = document.createElement('img');
       dom.src = URL.createObjectURL(blob);
       dom.alt = node.attrs.alt;
@@ -373,9 +377,11 @@ const nodeSpecs = {
       return [
         'img',
         {
-          src: `data:application/octet-stream;base64,${fromUint8Array(
-            node.attrs.src
-          )}`,
+          src: `data:${
+            node.attrs.filename.endsWith('.svg')
+              ? 'image/svg+xml'
+              : 'application/octet-stream'
+          };base64,${fromUint8Array(node.attrs.src)}`,
           alt: node.attrs.alt,
           title: node.attrs.title,
           'data-filename': node.attrs.filename,


### PR DESCRIPTION
Fixes #974 

This was broken because we weren't passing a content type when creating the blob used as the image src (it worked for other images types since they have magic bytes that browsers will detect unlike SVGs that are just text)