### PR TITLE
Fix props of mark components not being saved and the name of inline components not being shown in `fields.markdoc` and `fields.mdx`

### DIFF
--- a/.changeset/new-ants-relax.md
+++ b/.changeset/new-ants-relax.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fix props of mark components in `fields.markdoc` and `fields.mdx` not being saved

--- a/.changeset/tough-garlics-cheer.md
+++ b/.changeset/tough-garlics-cheer.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fix inline components in `fields.markdoc` and `fields.mdx` not showing the component name with the default view

--- a/dev-projects/next-app/keystatic.config.tsx
+++ b/dev-projects/next-app/keystatic.config.tsx
@@ -6,7 +6,8 @@ import {
   component,
   NotEditable,
 } from '@keystatic/core';
-import { block } from '@keystatic/core/content-components';
+import { block, inline, mark } from '@keystatic/core/content-components';
+import { highlighterIcon } from '@keystar/ui/icon/icons/highlighterIcon';
 import { NoteToolbar, Note } from './note';
 
 const description = 'Some description';
@@ -303,6 +304,36 @@ export default config({
             Something: block({
               label: 'Something',
               schema: {},
+            }),
+            Highlight: mark({
+              label: 'Highlight',
+              icon: highlighterIcon,
+              schema: {
+                variant: fields.select({
+                  label: 'Variant',
+                  options: [
+                    { label: 'Fluro', value: 'fluro' },
+                    { label: 'Minimal', value: 'minimal' },
+                    { label: 'Brutalist', value: 'brutalist' },
+                  ],
+                  defaultValue: 'fluro',
+                }),
+              },
+            }),
+            StatusBadge: inline({
+              label: 'StatusBadge',
+              schema: {
+                status: fields.select({
+                  label: 'Status',
+                  options: [
+                    { label: 'To do', value: 'todo' },
+                    { label: 'In Progress', value: 'in-progress' },
+                    { label: 'Ready for review', value: 'ready-for-review' },
+                    { label: 'Done', value: 'done' },
+                  ],
+                  defaultValue: 'todo',
+                }),
+              },
             }),
           },
         }),

--- a/packages/keystatic/src/form/fields/markdoc/editor/custom-components.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/custom-components.tsx
@@ -494,6 +494,7 @@ export function getCustomNodeSpecs(
                       ? 'color.alias.borderSelected'
                       : 'color.alias.borderIdle'
                   }
+                  data-component={name}
                   borderRadius="regular"
                   UNSAFE_className={css({
                     '::after': {

--- a/packages/keystatic/src/form/fields/markdoc/editor/popovers/index.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/popovers/index.tsx
@@ -445,6 +445,10 @@ const CustomMarkPopover: MarkPopoverRenderer = props => {
     () => ({ kind: 'object' as const, fields: componentConfig.schema }),
     [componentConfig.schema]
   );
+  const deserialized = useDeserializedValue(
+    props.mark.attrs.props,
+    componentConfig.schema
+  );
   return (
     <>
       <Flex gap="regular" padding="regular">
@@ -488,7 +492,7 @@ const CustomMarkPopover: MarkPopoverRenderer = props => {
             <Heading>Edit {componentConfig.label}</Heading>
             <FormValue
               schema={componentSchema}
-              value={props.mark.attrs.props}
+              value={deserialized}
               onSave={value => {
                 runCommand((state, dispatch) => {
                   if (dispatch) {
@@ -498,7 +502,9 @@ const CustomMarkPopover: MarkPopoverRenderer = props => {
                         .addMark(
                           props.from,
                           props.to,
-                          props.mark.type.create({ props: value })
+                          props.mark.type.create({
+                            props: toSerialized(value, componentConfig.schema),
+                          })
                         )
                     );
                   }

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/mdx.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/mdx.test.tsx
@@ -493,6 +493,36 @@ test('mark', () => {
   `);
 });
 
+test('mark 2', () => {
+  const mdx = `<Highlight variant="warning">something</Highlight>`;
+  const editor = fromMDX(mdx);
+  expect(editor).toMatchInlineSnapshot(`
+    <doc>
+      <paragraph>
+        <text
+          Highlight={
+            {
+              "props": {
+                "extraFiles": [],
+                "value": {
+                  "variant": "warning",
+                },
+              },
+            }
+          }
+        >
+          <cursor />
+          something
+        </text>
+      </paragraph>
+    </doc>
+  `);
+  expect(toMDX(editor)).toMatchInlineSnapshot(`
+    "<Highlight variant="warning">something</Highlight>
+    "
+  `);
+});
+
 test('inline', () => {
   const mdx = `wertgrfdsc<InlineThing something="adkjsakjndnajksdnjk" />asdfasdf`;
   const editor = fromMDX(mdx);


### PR DESCRIPTION
Fixes #1122