### PR TITLE
Revert "Editor placeholder cursor visibility"

### DIFF
--- a/.changeset/four-masks-tap.md
+++ b/.changeset/four-masks-tap.md
@@ -1,0 +1,5 @@
+---
+"@keystatic/core": patch
+---
+
+Fix typing when the placeholder is visible in the new editors

--- a/packages/keystatic/src/form/fields/markdoc/editor/placeholder.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/placeholder.ts
@@ -7,42 +7,19 @@ export function placeholderPlugin(text: string) {
   return new Plugin({
     props: {
       decorations(state) {
+        let doc = state.doc;
         if (
-          state.doc.childCount === 1 &&
-          state.doc.firstChild?.isTextblock &&
-          state.doc.firstChild.content.size === 0
+          doc.childCount === 1 &&
+          doc.firstChild?.isTextblock &&
+          doc.firstChild.content.size === 0
         ) {
           let placeholder = document.createElement('span');
           placeholder.className = classes.placeholder;
-          placeholder.contentEditable = 'false'; // 1
           placeholder.textContent = text;
 
-          return DecorationSet.create(state.doc, [
-            Decoration.widget(1, bookendWithZeroWidthSpaces(placeholder), {
-              // undocumented prop on `WidgetViewDesc` that stops the decoration
-              // from being wrapped with a contenteditable=false span.
-              // note:
-              //   1. we must add the contenteditable=false attr ourselves
-              //   2. this is a private API and may break in future versions
-              // see:
-              //   - https://github.com/ProseMirror/prosemirror-view/blob/master/src/viewdesc.ts
-              raw: true,
-            }),
-          ]);
+          return DecorationSet.create(doc, [Decoration.widget(1, placeholder)]);
         }
       },
     },
   });
-}
-
-// firefox bug where the cursor is hidden when beside `contenteditable=false`
-// - https://discuss.prosemirror.net/t/firefox-contenteditable-false-cursor-bug/5016
-// - https://bugzilla.mozilla.org/show_bug.cgi?id=1612076
-function bookendWithZeroWidthSpaces(element: HTMLElement) {
-  let wrapper = document.createElement('span');
-  wrapper.append(zeroWidthSpace(), element, zeroWidthSpace());
-  return wrapper;
-}
-function zeroWidthSpace() {
-  return document.createTextNode('\u200B');
 }


### PR DESCRIPTION
Reverts Thinkmill/keystatic#1063

This seems to have broken typing when the placeholder is visible which is much worse than the cursor sometimes not being visible.

