### PR TITLE
Fix incorrectly passing base64url encoded content to GitHub's API instead of standard base64

### DIFF
--- a/.changeset/mighty-plants-matter.md
+++ b/.changeset/mighty-plants-matter.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fix incorrectly passing base64url encoded content to GitHub's API instead of standard base64

--- a/packages/keystatic/src/app/updating.tsx
+++ b/packages/keystatic/src/app/updating.tsx
@@ -28,7 +28,7 @@ import { AppSlugContext } from './onboarding/install-app';
 import { createUrqlClient } from './provider';
 import { serializeProps } from '../form/serialize-props';
 import { scopeEntriesWithPathPrefix } from './shell/path-prefix';
-import { base64UrlEncode } from '#base64';
+import { base64Encode } from '#base64';
 
 const textEncoder = new TextEncoder();
 
@@ -217,7 +217,7 @@ export function useUpsertItem(args: {
                 fileChanges: {
                   additions: additions.map(addition => ({
                     ...addition,
-                    contents: base64UrlEncode(addition.contents),
+                    contents: base64Encode(addition.contents),
                   })),
                   deletions,
                 },
@@ -298,7 +298,7 @@ export function useUpsertItem(args: {
             body: JSON.stringify({
               additions: additions.map(addition => ({
                 ...addition,
-                contents: base64UrlEncode(addition.contents),
+                contents: base64Encode(addition.contents),
               })),
               deletions,
             }),

--- a/packages/keystatic/src/base64.ts
+++ b/packages/keystatic/src/base64.ts
@@ -7,11 +7,15 @@ export function base64UrlDecode(base64: string) {
 }
 
 export function base64UrlEncode(bytes: Uint8Array) {
-  const binString = Array.from(bytes, byte => String.fromCodePoint(byte)).join(
-    ''
-  );
-  return btoa(binString)
+  return base64Encode(bytes)
     .replace(/\+/g, '-')
     .replace(/\//g, '_')
     .replace(/=/g, '');
+}
+
+export function base64Encode(bytes: Uint8Array) {
+  const binString = Array.from(bytes, byte => String.fromCodePoint(byte)).join(
+    ''
+  );
+  return btoa(binString);
 }


### PR DESCRIPTION
Fixes #1147