### PR TITLE
Update installation-astro.mdoc

### DIFF
--- a/docs/src/content/pages/installation-astro.mdoc
+++ b/docs/src/content/pages/installation-astro.mdoc
@@ -166,7 +166,7 @@ const posts = await getCollection('posts')
 To display content from an individual post, you can import and use Astro's `<Content />` component to [render your content to HTML](https://docs.astro.build/en/guides/content-collections/#rendering-content-to-html):
 
 ```tsx
-// src/pages/posts/my-post.astro
+// src/pages/posts/my-first-post.astro
 ---
 import { getEntry } from 'astro:content'
 


### PR DESCRIPTION
There is an error in documentation, i went step by step from https://keystatic.com/docs/installation-astro#rendering-keystatic-content and in the section "Displaying a single collection entry" there should be file name 
// src/pages/posts/my-first-post.astro not // src/pages/posts/my-post.astro