### PR TITLE
Update the french Singletons translation

### DIFF
--- a/.changeset/lovely-vans-breathe.md
+++ b/.changeset/lovely-vans-breathe.md
@@ -1,0 +1,5 @@
+---
+"@keystatic/core": patch
+---
+
+Update the french Singletons translation

--- a/packages/keystatic/src/app/l10n/fr-FR/singletons/index.json
+++ b/packages/keystatic/src/app/l10n/fr-FR/singletons/index.json
@@ -1,6 +1,6 @@
 {
   "key": "singletons",
-  "value": "Célibataires",
+  "value": "Singletons",
   "notes": "",
   "type": "global"
 }


### PR DESCRIPTION
Hello !

How funny it was to discover the french translation for Singletons : **[Célibataires](https://www.larousse.fr/dictionnaires/francais/c%C3%A9libataire/14011#:~:text=mari%C3%A9-,c%C3%A9libataire%20n.,qui%20vit%20dans%20le%20c%C3%A9libat.)** 
It means "being single".

So I fixed it by updating the translation back to Singletons, which is valid in french [see in the dic](https://www.larousse.fr/dictionnaires/francais/singleton/72859#:~:text=Ensemble%20ne%20comprenant%20qu'un%20seul%20%C3%A9l%C3%A9ment.)