### PR TITLE
Fix whitespace on the ends of italics/bold/strikethrough breaking `fields.markdoc`

### DIFF
--- a/.changeset/fuzzy-bulldogs-add.md
+++ b/.changeset/fuzzy-bulldogs-add.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fix whitespace on the ends of italics/bold/strikethrough breaking `fields.markdoc`

--- a/packages/keystatic/src/form/fields/markdoc/editor/markdoc/serialize.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/markdoc/serialize.ts
@@ -34,7 +34,7 @@ function _inline(
       {},
       textblockChildren(
         fragment,
-        (text): MarkdocNode => new Ast.Node('text', { value: text }),
+        (content): MarkdocNode => new Ast.Node('text', { content }),
         node => getLeafContent(node, state),
         mark => getWrapperForMark(mark, state)
       )

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/markdoc.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/markdoc.test.tsx
@@ -567,20 +567,23 @@ test('more', () => {
   `);
 });
 
-test('whitespace is ejected from em, strong, etc.', () => {
-  const editor = (
-    <doc>
-      <paragraph>
-        <text>something</text>
-        <text italic>
-          <cursor /> a{' '}
-        </text>
-        <text>something</text>
-      </paragraph>
-    </doc>
-  );
-  expect(toMarkdoc(editor)).toMatchInlineSnapshot(`
-    "something *a* something
-    "
-  `);
-});
+for (const [mark, symbol] of [
+  ['bold', '**'],
+  ['italic', '*'],
+  ['strikethrough', '~~'],
+] as const) {
+  test(`whitespace is ejected from ${mark}`, () => {
+    const editor = (
+      <doc>
+        <paragraph>
+          <text>something</text>
+          <text {...{ [mark]: true }}>
+            <cursor /> a{' '}
+          </text>
+          <text>something</text>
+        </paragraph>
+      </doc>
+    );
+    expect(toMarkdoc(editor)).toBe(`something ${symbol}a${symbol} something\n`);
+  });
+}

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/markdoc.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/markdoc.test.tsx
@@ -566,3 +566,21 @@ test('more', () => {
     "
   `);
 });
+
+test('whitespace is ejected from em, strong, etc.', () => {
+  const editor = (
+    <doc>
+      <paragraph>
+        <text>something</text>
+        <text italic>
+          <cursor /> a{' '}
+        </text>
+        <text>something</text>
+      </paragraph>
+    </doc>
+  );
+  expect(toMarkdoc(editor)).toMatchInlineSnapshot(`
+    "something *a* something
+    "
+  `);
+});

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/mdx.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/mdx.test.tsx
@@ -932,3 +932,21 @@ test('more', () => {
     "
   `);
 });
+
+test('whitespace is ejected from em, strong, etc.', () => {
+  const editor = (
+    <doc>
+      <paragraph>
+        <text>something</text>
+        <text italic>
+          <cursor /> a{' '}
+        </text>
+        <text>something</text>
+      </paragraph>
+    </doc>
+  );
+  expect(toMDX(editor)).toMatchInlineSnapshot(`
+    "something *a* something
+    "
+  `);
+});

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/mdx.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/mdx.test.tsx
@@ -933,20 +933,23 @@ test('more', () => {
   `);
 });
 
-test('whitespace is ejected from em, strong, etc.', () => {
-  const editor = (
-    <doc>
-      <paragraph>
-        <text>something</text>
-        <text italic>
-          <cursor /> a{' '}
-        </text>
-        <text>something</text>
-      </paragraph>
-    </doc>
-  );
-  expect(toMDX(editor)).toMatchInlineSnapshot(`
-    "something *a* something
-    "
-  `);
-});
+for (const [mark, symbol] of [
+  ['bold', '**'],
+  ['italic', '*'],
+  ['strikethrough', '~~'],
+] as const) {
+  test(`whitespace is ejected from ${mark}`, () => {
+    const editor = (
+      <doc>
+        <paragraph>
+          <text>something</text>
+          <text {...{ [mark]: true }}>
+            <cursor /> a{' '}
+          </text>
+          <text>something</text>
+        </paragraph>
+      </doc>
+    );
+    expect(toMDX(editor)).toBe(`something ${symbol}a${symbol} something\n`);
+  });
+}


### PR DESCRIPTION
Fixes #1177