### PR TITLE
Fix inline components in list items being parsed into their own paragraphs in `fields.markdoc`

### DIFF
--- a/.changeset/odd-queens-smoke.md
+++ b/.changeset/odd-queens-smoke.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fix inline components in list items being parsed into their own paragraphs in `fields.markdoc`

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/markdoc.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/markdoc.test.tsx
@@ -587,3 +587,39 @@ for (const [mark, symbol] of [
     expect(toMarkdoc(editor)).toBe(`something ${symbol}a${symbol} something\n`);
   });
 }
+
+test('inline in list item', () => {
+  const markdoc = `- wertgrfdsc{% inline-thing something="adkjsakjndnajksdnjk" /%}sfasdf`;
+  const editor = fromMarkdoc(markdoc);
+  expect(editor).toMatchInlineSnapshot(`
+    <doc>
+      <unordered_list>
+        <list_item>
+          <paragraph>
+            <text>
+              <cursor />
+              wertgrfdsc
+            </text>
+            <inline-thing
+              props={
+                {
+                  "extraFiles": [],
+                  "value": {
+                    "something": "adkjsakjndnajksdnjk",
+                  },
+                }
+              }
+            />
+            <text>
+              sfasdf
+            </text>
+          </paragraph>
+        </list_item>
+      </unordered_list>
+    </doc>
+  `);
+  expect(toMarkdoc(editor)).toMatchInlineSnapshot(`
+    "- wertgrfdsc{% inline-thing something="adkjsakjndnajksdnjk" /%}sfasdf
+    "
+  `);
+});

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/mdx.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/mdx.test.tsx
@@ -953,3 +953,39 @@ for (const [mark, symbol] of [
     expect(toMDX(editor)).toBe(`something ${symbol}a${symbol} something\n`);
   });
 }
+
+test('inline in list item', () => {
+  const markdoc = `- wertgrfdsc<InlineThing something="adkjsakjndnajksdnjk" />sfasdf`;
+  const editor = fromMDX(markdoc);
+  expect(editor).toMatchInlineSnapshot(`
+    <doc>
+      <unordered_list>
+        <list_item>
+          <paragraph>
+            <text>
+              <cursor />
+              wertgrfdsc
+            </text>
+            <InlineThing
+              props={
+                {
+                  "extraFiles": [],
+                  "value": {
+                    "something": "adkjsakjndnajksdnjk",
+                  },
+                }
+              }
+            />
+            <text>
+              sfasdf
+            </text>
+          </paragraph>
+        </list_item>
+      </unordered_list>
+    </doc>
+  `);
+  expect(toMDX(editor)).toMatchInlineSnapshot(`
+    "* wertgrfdsc<InlineThing something="adkjsakjndnajksdnjk" />sfasdf
+    "
+  `);
+});


### PR DESCRIPTION
Fixes #1196