### PR TITLE
Fix lists in `fields.mdx` always being output as loose lists

### DIFF
--- a/.changeset/popular-ladybugs-doubt.md
+++ b/.changeset/popular-ladybugs-doubt.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fix lists in `fields.mdx` always being output as loose lists

--- a/packages/keystatic/src/form/fields/markdoc/editor/mdx/serialize.ts
+++ b/packages/keystatic/src/form/fields/markdoc/editor/mdx/serialize.ts
@@ -239,12 +239,14 @@ function proseMirrorToMDX(
     return {
       type: 'list',
       ordered: true,
+      spread: false,
       children: mapContent(node, node => convertListItem(blocks(node.content))),
     };
   }
   if (node.type === schema.nodes.unordered_list) {
     return {
       type: 'list',
+      spread: false,
       children: mapContent(node, node => convertListItem(blocks(node.content))),
     };
   }

--- a/packages/keystatic/src/form/fields/markdoc/editor/tests/mdx.test.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/tests/mdx.test.tsx
@@ -989,3 +989,47 @@ test('inline in list item', () => {
     "
   `);
 });
+
+test('preserve unordered tight list', () => {
+  const markdoc = `- a
+- b
+- c`;
+  const editor = fromMDX(markdoc);
+  expect(toMDX(editor)).toMatchInlineSnapshot(`
+    "* a
+    * b
+    * c
+    "
+  `);
+});
+
+test('preserve ordered tight list', () => {
+  const markdoc = `1. a
+1. b
+1. c`;
+  const editor = fromMDX(markdoc);
+  expect(toMDX(editor)).toMatchInlineSnapshot(`
+    "1. a
+    2. b
+    3. c
+    "
+  `);
+});
+
+test('loose list', () => {
+  const markdoc = `
+- a
+
+  b
+- c
+- d`;
+  const editor = fromMDX(markdoc);
+  expect(toMDX(editor)).toMatchInlineSnapshot(`
+    "* a
+
+      b
+    * c
+    * d
+    "
+  `);
+});


### PR DESCRIPTION
Fixes #1167