### PR TITLE
Suggest checking that the GitHub App is installed in the repository when committing returns a `Resource not accessible by integration` error

### DIFF
--- a/.changeset/sweet-ducks-refuse.md
+++ b/.changeset/sweet-ducks-refuse.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Suggest checking that the GitHub App is installed in the repository when committing returns a `Resource not accessible by integration` error

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check:packages": "preconstruct validate",
     "check:types": "tsc",
     "clean": "git clean -fXd",
+    "docs": "pnpm --filter=keystatic-docs dev",
     "dev:create": "pnpm --filter=create dev",
     "dev:localization": "pnpm --filter=localization dev",
     "dev:docs": "pnpm --filter=keystatic-docs dev",

--- a/packages/keystatic/src/app/updating.tsx
+++ b/packages/keystatic/src/app/updating.tsx
@@ -281,6 +281,21 @@ export function useUpsertItem(args: {
             }
           }
 
+          if (
+            result.error?.graphQLErrors.some(
+              err =>
+                'type' in err &&
+                err.type === 'FORBIDDEN' &&
+                err.message === 'Resource not accessible by integration'
+            )
+          ) {
+            throw new Error(
+              `The GitHub App is unable to commit to the repository. Please ensure that the Keystatic GitHub App is installed in the GitHub repository ${
+                repoWithWriteAccess!.owner
+              }/${repoWithWriteAccess!.name}`
+            );
+          }
+
           if (result.error) {
             throw result.error;
           }
@@ -410,6 +425,20 @@ export function useDeleteItem(args: {
               },
             },
           });
+          if (
+            error?.graphQLErrors.some(
+              err =>
+                'type' in err &&
+                err.type === 'FORBIDDEN' &&
+                err.message === 'Resource not accessible by integration'
+            )
+          ) {
+            throw new Error(
+              `The GitHub App is unable to commit to the repository. Please ensure that the Keystatic GitHub App is installed in the GitHub repository ${
+                repoWithWriteAccess!.owner
+              }/${repoWithWriteAccess!.name}`
+            );
+          }
           if (error) {
             throw error;
           }


### PR DESCRIPTION
Fixes #503 
Fixes #939

This error means that the GitHub App doesn't have write permissions to the configured repo. For public repos, people won't hit the "Repo not found" prompt to install the GitHub App since the repo can still be accessed without the GitHub App being installed in it. Note when using the flow to create a GitHub App, it will redirect them to install the GitHub App in the repo, this is for cases when someone is using a GitHub App created earlier or etc.