### PR TITLE
Fix content components UI not showing in `fields.markdoc`/`fields.mdx` until focused

### DIFF
--- a/.changeset/polite-papayas-taste.md
+++ b/.changeset/polite-papayas-taste.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fix content components UI not showing in `fields.markdoc`/`fields.mdx` until focused

--- a/packages/keystatic/src/form/fields/markdoc/editor/react-node-views.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/react-node-views.tsx
@@ -97,12 +97,14 @@ const NodeViewWrapper = memo(function NodeViewWrapper(props: {
 
 export function NodeViews(props: { state: EditorState }): ReactElement | null {
   const pluginState = reactNodeViewKey.getState(props.state)!;
-  const [nodeViews, setNodeViews] = useState(pluginState.nodeViews);
+  const [nodeViews, setNodeViews] = useState(
+    () => new Map(pluginState.nodeViews)
+  );
   useLayoutEffect(() => {
     return pluginState.register(() => {
-      setNodeViews(pluginState.nodeViews);
+      setNodeViews(new Map(pluginState.nodeViews));
     });
-  });
+  }, [pluginState]);
   const nodeSelectionPos =
     props.state.selection instanceof NodeSelection
       ? props.state.selection.from


### PR DESCRIPTION
Fixes #1236 