### PR TITLE
Update reader-api.mdoc to fix typo

### DIFF
--- a/docs/src/content/pages/reader-api.mdoc
+++ b/docs/src/content/pages/reader-api.mdoc
@@ -106,7 +106,7 @@ Good places to use the Reader API are:
 - `getStaticProps` in **Next.js (Pages Router)**
 - The frontmatter in **Astro** files
 - The `loader()` function in **Remix**
-- React**Server Components**
+- React **Server Components**
 
 ---
 


### PR DESCRIPTION
This PR fixes a typo in the documentation related to the GitHub reader.