### PR TITLE
fields/slug: Make `pattern` optional for fields slug

### DIFF
--- a/.changeset/healthy-pets-act.md
+++ b/.changeset/healthy-pets-act.md
@@ -1,0 +1,5 @@
+---
+"@keystatic/core": patch
+---
+
+Fix `validation.pattern` being required for `fields.slug`

--- a/packages/keystatic/src/form/fields/slug/index.tsx
+++ b/packages/keystatic/src/form/fields/slug/index.tsx
@@ -59,7 +59,7 @@ export function slug(_args: {
         min?: number;
         max?: number;
       };
-      pattern: { regex: RegExp; message?: string };
+      pattern?: { regex: RegExp; message?: string };
     };
   };
 }): SlugFormField<


### PR DESCRIPTION
The `pattern` was introduce in https://github.com/Thinkmill/keystatic/pull/1228.

However it is a required field for `slug`s. See also https://github.com/Thinkmill/keystatic/commit/36ea216c4a473eeab60aff41cb9dfabfb45127b8#r144629665

The way I read the code is, that the code actually expect the pattern to be optional by using `?.` and setting a default of `undefined`. The pattern on the `text` field is optional.

I am assuming the optionality was missing for the slug field. This PR adds it.