### PR TITLE
Add Tag icon + Keystar Badge for the tags content component

### DIFF
--- a/docs/keystatic.config.tsx
+++ b/docs/keystatic.config.tsx
@@ -5,15 +5,18 @@ import {
   repeating,
   wrapper,
 } from '@keystatic/core/content-components';
-import { isNonEmptyArray } from 'emery/guards';
-
+import { Badge } from '@keystar/ui/badge';
 import { Flex } from '@keystar/ui/layout';
-import Markdoc, { Config, Node, ValidateError } from '@markdoc/markdoc';
+import { tagIcon } from '@keystar/ui/icon/icons/tagIcon';
+import { isNonEmptyArray } from 'emery/guards';
 import { assert } from 'emery/assertions';
+import Markdoc, { Config, Node, ValidateError } from '@markdoc/markdoc';
 
 export const components = {
   tags: block({
     label: 'Tags',
+    description: 'Insert tags',
+    icon: tagIcon,
     schema: {
       tags: fields.multiselect({
         label: 'Project tags',
@@ -30,20 +33,11 @@ export const components = {
     },
     ContentView({ value }) {
       return (
-        <div style={{ display: 'flex', gap: '1rem' }}>
+        <Flex gap="small">
           {value.tags.map(tag => (
-            <span
-              style={{
-                border: 'solid 1px #ddd',
-                padding: '0.25rem 0.5rem',
-                borderRadius: '20px',
-                fontSize: '11px',
-              }}
-            >
-              {tag}
-            </span>
+            <Badge>{tag}</Badge>
           ))}
-        </div>
+        </Flex>
       );
     },
   }),

--- a/docs/src/content/pages/test.mdoc
+++ b/docs/src/content/pages/test.mdoc
@@ -1,4 +1,0 @@
----
-title: test
----
-{% tags tags=["Local", "github", "Astro", "Next.js"] /%}

--- a/docs/src/content/pages/test.mdoc
+++ b/docs/src/content/pages/test.mdoc
@@ -1,0 +1,4 @@
+---
+title: test
+---
+{% tags tags=["Local", "github", "Astro", "Next.js"] /%}


### PR DESCRIPTION
This mini PR: 

- adds an icon and description for the `tags` content component
- uses the Keystar UI `<Flex>` and `<Badge />` components instead of "arbitrary" styles

![CleanShot 2024-08-01 at 16 46 56@2x](https://github.com/user-attachments/assets/ef335fd0-a201-4b2a-adaa-e45ef1ae0088)