### PR TITLE
feat: add option to output document as raw string

### DIFF
--- a/packages/keystatic/src/reader/generic.ts
+++ b/packages/keystatic/src/reader/generic.ts
@@ -196,6 +196,8 @@ export type MinimalFs = {
   fileExists(path: string): Promise<boolean>;
 };
 
+const decoder = new TextDecoder();
+
 async function getAllEntries(
   parent: string,
   fsReader: MinimalFs
@@ -350,7 +352,7 @@ const readItem = cache(async function readItem(
         }
         if (schema.formKind === 'content') {
           contentFieldPathsToEagerlyResolve?.push(path);
-          return async () => {
+          return async (options?: { raw: boolean }) => {
             let content: undefined | Uint8Array;
             const filename =
               pathWithArrayFieldSlugs.join('/') + schema.contentExtension;
@@ -360,6 +362,10 @@ const readItem = cache(async function readItem(
               content =
                 (await fsReader.readFile(`${itemDir}/${filename}`)) ??
                 undefined;
+            }
+
+            if (options?.raw) {
+              return decoder.decode(content);
             }
 
             return schema.reader.parse(value, { content });


### PR DESCRIPTION
Add a  `raw` option to content resolve function so it will output raw string instead parsed AST.

This could be useful when user need to fetch the collection entry in the client side since markdoc AST is not serializable. 

But I need help about adjusting the type declaration, the generic here is pure MAGIC. 