### PR TITLE
Fix tag docs typo

### DIFF
--- a/.changeset/proud-buckets-kick.md
+++ b/.changeset/proud-buckets-kick.md
@@ -1,0 +1,5 @@
+---
+'@keystar/ui': patch
+---
+
+Fix tag docs typo.

--- a/design-system/pkg/src/tag/docs/index.mdoc
+++ b/design-system/pkg/src/tag/docs/index.mdoc
@@ -19,7 +19,7 @@ category: Navigation
 
 ### Collections
 
-Picker implements the `react-stately`
+Tag group implements the `react-stately`
 [collection component](https://react-spectrum.adobe.com/react-stately/collections.html) `<Item>` for dynamic and static collections.
 
 Static collections, seen in the example above, can be used when the full list of options is known ahead of time.


### PR DESCRIPTION
Handy, since I need to bump [package versioning](https://github.com/Thinkmill/keystatic/pull/1277). It got stuck on:

> Expected — Waiting for status to be reported