### PR TITLE
Fix: Update to Newsletter Subscription Tag

### DIFF
--- a/docs/src/app/mailing-list/route.ts
+++ b/docs/src/app/mailing-list/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: Request): Promise<Response> {
       email: formData.get('email'),
       tags: [
         ...formData.getAll('tags'),
-        `keystatic website${pathname !== '/' ? `: ${pathname}` : ' homepage'}`,
+        `source:keystatic.com${pathname}`,
       ],
     };
 

--- a/docs/src/app/mailing-list/route.ts
+++ b/docs/src/app/mailing-list/route.ts
@@ -23,10 +23,7 @@ export async function POST(req: Request): Promise<Response> {
     console.log(formData.getAll('tags'));
     const data = {
       email: formData.get('email'),
-      tags: [
-        ...formData.getAll('tags'),
-        `source:keystatic.com${pathname}`,
-      ],
+      tags: [...formData.getAll('tags'), `source:keystatic.com${pathname}`],
     };
 
     const buttondownResponse = await fetch(


### PR DESCRIPTION
Updates the `tag` applied when adding a subscriber to the Thinkmill newsletter. This PR formats the tag consistently with the Keystone and Thinkmill websites.