### PR TITLE
Updates dependency cookie from ^0.5.0 to ^0.7.2

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.18.3",
     "@types/react": "^18.2.8",
-    "cookie": "^0.5.0",
+    "cookie": "^0.7.2",
     "set-cookie-parser": "^2.5.1"
   },
   "devDependencies": {

--- a/packages/keystatic/package.json
+++ b/packages/keystatic/package.json
@@ -140,7 +140,7 @@
     "@urql/exchange-auth": "^2.2.0",
     "@urql/exchange-graphcache": "^7.1.2",
     "@urql/exchange-persisted": "^4.3.0",
-    "cookie": "^0.5.0",
+    "cookie": "^0.7.2",
     "emery": "^1.4.1",
     "escape-string-regexp": "^4.0.0",
     "fast-deep-equal": "^3.1.3",


### PR DESCRIPTION
Resolves #1325

See https://github.com/advisories/GHSA-pxg6-pf52-xh8x for more information