### PR TITLE
Docs mdx: Add sections on custom `options`

### DIFF
--- a/docs/src/content/pages/fields/markdoc.mdoc
+++ b/docs/src/content/pages/fields/markdoc.mdoc
@@ -76,6 +76,24 @@ someContent: |
 
 ---
 
+## Formatting options
+
+The editor can be customised to allow a range of formatting options. This is done via `options`.
+
+See the type signature for `MarkdocEditorOptions` for the full set of options:
+[https://docsmill.dev/npm/@keystatic/core@latest#/.fields.markdoc.MarkdocEditorOptions](https://docsmill.dev/npm/@keystatic/core@latest#/.fields.markdoc.MarkdocEditorOptions)
+
+---
+
+## Image options
+
+The directory where images are stored can be customised in the same way as [`fields.image`](/docs/fields/image) with `directory` and `publicPath`. Though unlike [`fields.image`](/docs/fields/image) outside the editor where image filenames are determined by the key in the schema where the field is, filenames for images in the editor can be customised directly in the editor.
+
+See the type signature for `MarkdocEditorOptions.image` for the full set of options:
+[https://docsmill.dev/npm/@keystatic/core@latest#/.fields.markdoc.MarkdocEditorOptions](https://docsmill.dev/npm/@keystatic/core@latest#/.fields.markdoc.MarkdocEditorOptions)
+
+---
+
 ## Type signature
 
 Find the latest version of this field's type signature at: [https://docsmill.dev/npm/@keystatic/core#/.fields.markdoc](https://docsmill.dev/npm/@keystatic/core#/.fields.markdoc)

--- a/docs/src/content/pages/fields/mdx.mdoc
+++ b/docs/src/content/pages/fields/mdx.mdoc
@@ -125,6 +125,24 @@ someContent: |
 
 ---
 
+## Formatting options
+
+The WYSIWYG toolbar can be customised to allow a range of formatting options. This is done via `options`.
+
+Please consult the type signature for `MDXEditorOptions` for a full set of customization options:
+[https://docsmill.dev/npm/@keystatic/core@latest#/.fields.mdx.MDXEditorOptions](https://docsmill.dev/npm/@keystatic/core@latest#/.fields.mdx.MDXEditorOptions)
+
+---
+
+## Image options
+
+The WYSIWYG toolbar has a build in image option. Just like with [the Image field](/docs/fields/image#directory), you can customize the `directory` and `publicPath`.
+
+Please consult the type signature for `MDXEditorOptions.image` for a full set of customization options:
+[https://docsmill.dev/npm/@keystatic/core@latest#/.fields.mdx.MDXEditorOptions](https://docsmill.dev/npm/@keystatic/core@latest#/.fields.mdx.MDXEditorOptions)
+
+---
+
 ## Type signature
 
 Find the latest version of this field's type signature at: [https://docsmill.dev/npm/@keystatic/core#/.fields.mdx](https://docsmill.dev/npm/@keystatic/core#/.fields.mdx)

--- a/docs/src/content/pages/fields/mdx.mdoc
+++ b/docs/src/content/pages/fields/mdx.mdoc
@@ -127,18 +127,18 @@ someContent: |
 
 ## Formatting options
 
-The WYSIWYG toolbar can be customised to allow a range of formatting options. This is done via `options`.
+The editor can be customised to allow a range of formatting options. This is done via `options`.
 
-Please consult the type signature for `MDXEditorOptions` for a full set of customization options:
+See the type signature for `MDXEditorOptions` for the full set of options:
 [https://docsmill.dev/npm/@keystatic/core@latest#/.fields.mdx.MDXEditorOptions](https://docsmill.dev/npm/@keystatic/core@latest#/.fields.mdx.MDXEditorOptions)
 
 ---
 
 ## Image options
 
-The WYSIWYG toolbar has a build in image option. Just like with [the Image field](/docs/fields/image#directory), you can customize the `directory` and `publicPath`.
+The directory where images are stored can be customised in the same way as [`fields.image`](/docs/fields/image) with `directory` and `publicPath`. Though unlike [`fields.image`](/docs/fields/image) outside the editor where image filenames are determined by the key in the schema where the field is, filenames for images in the editor can be customised directly in the editor.
 
-Please consult the type signature for `MDXEditorOptions.image` for a full set of customization options:
+See the type signature for `MDXEditorOptions.image` for the full set of options:
 [https://docsmill.dev/npm/@keystatic/core@latest#/.fields.mdx.MDXEditorOptions](https://docsmill.dev/npm/@keystatic/core@latest#/.fields.mdx.MDXEditorOptions)
 
 ---


### PR DESCRIPTION
I consider this a quick fix to at least hint at the options by linking to the respective type signature files. The old [document docs](https://keystatic.com/docs/fields/document) had longer sections on those customization topics. It might be worth expanding on this in the future, similar to what the Document field docs had. But for now those sections would have helped me find what I was looking for…