### PR TITLE
Docs: Hint that `mdx.inline` is not transformed by Astro

### DIFF
--- a/docs/src/content/pages/fields/mdx.mdoc
+++ b/docs/src/content/pages/fields/mdx.mdoc
@@ -114,7 +114,7 @@ someContent: fields.mdx.inline({
 })
 ```
 
-this will write content next to other fields like this instead of in a different file:
+This will write content next to other fields like this instead of in a different file:
 
 ```yaml
 someContent: |
@@ -122,6 +122,8 @@ someContent: |
 
   Some content
 ```
+
+Depending on your Integration, you may have to transform those sections manually. Astro, for example, will return them as plain text. You can [use mikromark](https://github.com/micromark/micromark) – which Keystatic uses internally – to generate the HTML.
 
 ---
 


### PR DESCRIPTION
This is a help out a bit with https://github.com/Thinkmill/keystatic/discussions/1318.

Ideally this section would go into more details how different frameworks (NextJS, Astro, …) treat the `mdx.inline`.

But this hint should still help out those that where looking for some tighter integration …