### PR TITLE
Docs: github-mode: Simplify `redirect_uri` instructions

### DIFF
--- a/docs/src/content/pages/github-mode.mdoc
+++ b/docs/src/content/pages/github-mode.mdoc
@@ -124,15 +124,16 @@ When you authorize on a server and get the following error from GitHub, you need
 
 To add a redirect URL:
 
-1. Go to the [list of "Installed Github Apps"](https://docs.github.com/en/apps/using-github-apps/reviewing-and-modifying-installed-github-apps#navigating-to-the-github-app-you-want-to-review-or-modify)
-   - For Users: [`https://github.com/settings/installations`](https://github.com/settings/installations)
-   - For Organisations: `https://github.com/organizations/<org name>/settings/installations`
-2. Select the app > Choose "App settings"
-   - For Users: `https://github.com/settings/apps/<app slug>`
-   - For Organisations: `https://github.com/organizations/<org name>/settings/apps/<app slug>`
+1. Open your app page using values of the `PUBLIC_KEYSTATIC_GITHUB_APP_SLUG` environment variable
+   `https://github.com/apps/<app slug>`
+2. Select "App settings"
 3. Use "Add Callback URL" > Add the additional URL > Save
 
 Now try reloading the authentication page.
+
+If you don't have the app slug, use the [list of "Installed Github Apps"](https://docs.github.com/en/apps/using-github-apps/reviewing-and-modifying-installed-github-apps#navigating-to-the-github-app-you-want-to-review-or-modify) to find your app.
+- For Users: [`https://github.com/settings/installations`](https://github.com/settings/installations)
+- For Organisations: `https://github.com/organizations/<org name>/settings/installations`
 
 ---
 


### PR DESCRIPTION
This is a follow up to https://github.com/Thinkmill/keystatic/pull/1358 which makes the steps to get to the app easier.

I left the hints how to get to the list of all apps as well, but I think the setup process should always add the appSlug, even though [this line is conditional](https://github.com/Thinkmill/keystatic/blob/main/packages/keystatic/src/api/api-node.ts#L73).

Thanks for merging #1358!