### PR TITLE
Link to github app in `.env` for `slugEnv`

### DIFF
--- a/.changeset/spotty-badgers-punch.md
+++ b/.changeset/spotty-badgers-punch.md
@@ -1,0 +1,5 @@
+---
+"@keystatic/core": patch
+---
+
+Add link to created GitHub App in generated `.env`

--- a/packages/keystatic/src/api/api-node.ts
+++ b/packages/keystatic/src/api/api-node.ts
@@ -70,7 +70,7 @@ export async function handleGitHubAppCreation(
 KEYSTATIC_GITHUB_CLIENT_ID=${ghAppDataResult.client_id}
 KEYSTATIC_GITHUB_CLIENT_SECRET=${ghAppDataResult.client_secret}
 KEYSTATIC_SECRET=${randomBytes(40).toString('hex')}
-${slugEnvVarName ? `${slugEnvVarName}=${ghAppDataResult.slug}\n` : ''}`;
+${slugEnvVarName ? `${slugEnvVarName}=${ghAppDataResult.slug} # https://github.com/apps/${ghAppDataResult.slug}\n` : ''}`;
 
   let prevEnv: string | undefined;
   try {

--- a/packages/keystatic/src/api/api-node.ts
+++ b/packages/keystatic/src/api/api-node.ts
@@ -70,7 +70,11 @@ export async function handleGitHubAppCreation(
 KEYSTATIC_GITHUB_CLIENT_ID=${ghAppDataResult.client_id}
 KEYSTATIC_GITHUB_CLIENT_SECRET=${ghAppDataResult.client_secret}
 KEYSTATIC_SECRET=${randomBytes(40).toString('hex')}
-${slugEnvVarName ? `${slugEnvVarName}=${ghAppDataResult.slug} # https://github.com/apps/${ghAppDataResult.slug}\n` : ''}`;
+${
+  slugEnvVarName
+    ? `${slugEnvVarName}=${ghAppDataResult.slug} # https://github.com/apps/${ghAppDataResult.slug}\n`
+    : ''
+}`;
 
   let prevEnv: string | undefined;
   try {


### PR DESCRIPTION
In the spirit of https://github.com/Thinkmill/keystatic/pull/1359, I wonder if the `.env` file should just have the link to the app on GitHub right there.

This would make the docs more or less obsolete for users who know how to find the app settings once they have their apps page.


--- 

Disclaimer: I did not run this code (due to https://github.com/Thinkmill/keystatic/discussions/1285).