### PR TITLE
Return more useful error when reaching `/api/keystatic/github/created-app` route when the GitHub App is already setup

### DIFF
--- a/.changeset/sour-ravens-know.md
+++ b/.changeset/sour-ravens-know.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Return more useful error when reaching `/api/keystatic/github/created-app` route when the GitHub App is already setup

--- a/packages/keystatic/src/api/generic.ts
+++ b/packages/keystatic/src/api/generic.ts
@@ -177,6 +177,12 @@ export function makeGenericAPIRouteHandler(
         ['Set-Cookie', immediatelyExpiringCookie('keystatic-gh-refresh-token')],
       ]);
     }
+    if (joined === 'github/created-app') {
+      return {
+        status: 404,
+        body: 'It looks like you just tried to create a GitHub App for Keystatic but there is already a GitHub App configured for Keystatic.\n\nYou may be here because you started creating a GitHub App but then started the process again elsewhere and completed it there. You should likely go back to Keystatic and sign in with GitHub to continue.',
+      };
+    }
     return { status: 404, body: 'Not Found' };
   };
 }


### PR DESCRIPTION
Fixes #1357

Note this only fixes the issue described in the title of #1357, the other problem described in the issue where there's a blank page in GitHub App creation flow seems to be something with Astro refreshing after Keystatic writes the env variables which I'm hoping to look into more