### PR TITLE
Onboarding: Guard deployedURL

### DIFF
--- a/.changeset/nice-parrots-sort.md
+++ b/.changeset/nice-parrots-sort.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+During onboarding, make sure the Deployed App URL does not have double slashes.

--- a/packages/keystatic/src/app/onboarding/setup.tsx
+++ b/packages/keystatic/src/app/onboarding/setup.tsx
@@ -77,7 +77,7 @@ export function KeystaticSetup(props: { config: GitHubConfig }) {
               parseRepoConfig(props.config.storage.repo).owner
             } Keystatic`,
             url: deployedURL
-              ? `${deployedURL}/keystatic`
+              ? new URL('/keystatic', deployedURL).toString()
               : `${window.location.origin}/keystatic`,
             public: true,
             redirect_url: `${window.location.origin}/api/keystatic/github/created-app`,
@@ -85,7 +85,12 @@ export function KeystaticSetup(props: { config: GitHubConfig }) {
               `${window.location.origin}/api/keystatic/github/oauth/callback`,
               `http://127.0.0.1/api/keystatic/github/oauth/callback`,
               ...(deployedURL
-                ? [`${deployedURL}/api/keystatic/github/oauth/callback`]
+                ? [
+                    new URL(
+                      '/api/keystatic/github/oauth/callback',
+                      deployedURL
+                    ).toString(),
+                  ]
                 : []),
             ],
             request_oauth_on_install: true,


### PR DESCRIPTION
Before, it was possible to provide `https://foo.com/` as input and generate a redirect_uri like `https://foo.com//api/keystatic/github/oauth/callback` which triggers the "The `redirect_uri` is not associated with this application." error by Github. Now the path is merged with the URL correctly for any valid URL input.

---

Disclaimer: This is untested, because of https://github.com/Thinkmill/keystatic/discussions/1285 but I think it should be fine.