### PR TITLE
Docs: astro-images: Add help notice on case sensitivity of glob

### DIFF
--- a/docs/src/content/pages/recipes/astro-images.mdoc
+++ b/docs/src/content/pages/recipes/astro-images.mdoc
@@ -113,4 +113,8 @@ captionImage: block({
 })
 ```
 
-Read the  [Astro guide on dynamic image imports](https://docs.astro.build/en/recipes/dynamically-importing-images/) for details on the implementation.
+Read the [Astro guide on dynamic image imports](https://docs.astro.build/en/recipes/dynamically-importing-images/) for details on the implementation.
+
+{% aside icon="☝️" %}
+Reminder: The `glob` string is case-sensitive, so you need to include patterns like `import.meta.glob('/src/assets/*.{jpeg,jpg,JPEG,JPG}')` because Keystatic does not change the capitalization of file extensions during upload.
+{% /aside %}


### PR DESCRIPTION
I hope this will help with debugging something that is tedious to debug when you don't expect this to be a possible error.

I tried improving the Astro docs at the source first in https://github.com/withastro/docs/pull/10169/files but it looks like the case-sensitivity is something that Astro devs are supposed to know about (I did not…), so that was rejected.
