### PR TITLE
Fix polish translations

### DIFF
--- a/.changeset/modern-ghosts-fly.md
+++ b/.changeset/modern-ghosts-fly.md
@@ -1,0 +1,5 @@
+---
+"@keystatic/core": patch
+---
+
+Fix polish translations

--- a/packages/keystatic/src/app/l10n/pl-PL/add/index.json
+++ b/packages/keystatic/src/app/l10n/pl-PL/add/index.json
@@ -1,6 +1,6 @@
 {
   "key": "add",
-  "value": "Dodać",
+  "value": "Dodaj",
   "notes": "",
   "type": "global"
 }

--- a/packages/keystatic/src/app/l10n/pl-PL/cancel/index.json
+++ b/packages/keystatic/src/app/l10n/pl-PL/cancel/index.json
@@ -1,6 +1,6 @@
 {
   "key": "cancel",
-  "value": "Anulować",
+  "value": "Anuluj",
   "notes": "",
   "type": "global"
 }

--- a/packages/keystatic/src/app/l10n/pl-PL/create/index.json
+++ b/packages/keystatic/src/app/l10n/pl-PL/create/index.json
@@ -1,6 +1,6 @@
 {
   "key": "create",
-  "value": "Tworzyć",
+  "value": "Utwórz",
   "notes": "",
   "type": "global"
 }

--- a/packages/keystatic/src/app/l10n/pl-PL/currentBranch/index.json
+++ b/packages/keystatic/src/app/l10n/pl-PL/currentBranch/index.json
@@ -1,6 +1,6 @@
 {
   "key": "currentBranch",
-  "value": "Obecny oddział",
+  "value": "Obecna gałąź",
   "notes": "",
   "type": "git-related"
 }

--- a/packages/keystatic/src/app/l10n/pl-PL/defaultBranch/index.json
+++ b/packages/keystatic/src/app/l10n/pl-PL/defaultBranch/index.json
@@ -1,6 +1,6 @@
 {
   "key": "defaultBranch",
-  "value": "Oddział domyślny",
+  "value": "Domyślna gałąź",
   "notes": "",
   "type": "git-related"
 }

--- a/packages/keystatic/src/app/l10n/pl-PL/delete/index.json
+++ b/packages/keystatic/src/app/l10n/pl-PL/delete/index.json
@@ -1,6 +1,6 @@
 {
   "key": "delete",
-  "value": "Usuwać",
+  "value": "Usuń",
   "notes": "",
   "type": "global"
 }

--- a/packages/keystatic/src/app/l10n/pl-PL/deleteBranch/index.json
+++ b/packages/keystatic/src/app/l10n/pl-PL/deleteBranch/index.json
@@ -1,6 +1,6 @@
 {
   "key": "deleteBranch",
-  "value": "Usuń oddział",
+  "value": "Usuń gałąź",
   "notes": "",
   "type": "git-related"
 }

--- a/packages/keystatic/src/app/l10n/pl-PL/edit/index.json
+++ b/packages/keystatic/src/app/l10n/pl-PL/edit/index.json
@@ -1,6 +1,6 @@
 {
   "key": "edit",
-  "value": "Edytować",
+  "value": "Edytuj",
   "notes": "",
   "type": "global"
 }

--- a/packages/keystatic/src/app/l10n/pl-PL/save/index.json
+++ b/packages/keystatic/src/app/l10n/pl-PL/save/index.json
@@ -1,6 +1,6 @@
 {
   "key": "save",
-  "value": "Ratować",
+  "value": "Zapisz",
   "notes": "",
   "type": "global"
 }

--- a/packages/keystatic/src/app/l10n/pl-PL/singleton/index.json
+++ b/packages/keystatic/src/app/l10n/pl-PL/singleton/index.json
@@ -1,6 +1,6 @@
 {
   "key": "singleton",
-  "value": "singel",
+  "value": "Singleton",
   "notes": "",
   "type": "global"
 }


### PR DESCRIPTION
I fixed errors in Polish translations, including changing ‘Dodać’ to ‘Dodaj’, and corrected several other inaccuracies.