### PR TITLE
Fix ActionGroup always collapsed button label

### DIFF
--- a/.changeset/good-files-teach.md
+++ b/.changeset/good-files-teach.md
@@ -1,0 +1,5 @@
+---
+'@keystar/ui': patch
+---
+
+Fixed `buttonLabelBehavior` for `ActionGroup` not passed by `ActionBar`

--- a/design-system/pkg/src/action-bar/ActionBar.tsx
+++ b/design-system/pkg/src/action-bar/ActionBar.tsx
@@ -62,6 +62,7 @@ function ActionBarInner<T>(
     selectedItemCount,
     isOpen,
     items,
+    buttonLabelBehavior,
   } = props;
 
   let styleProps = useStyleProps(props);
@@ -157,7 +158,7 @@ function ActionBarInner<T>(
             aria-label={stringFormatter.format('actions')}
             prominence="low"
             overflowMode="collapse"
-            buttonLabelBehavior="collapse"
+            buttonLabelBehavior={buttonLabelBehavior}
             onAction={onAction}
             gridArea="actiongroup"
           >


### PR DESCRIPTION
I was working with extending the Keystone custom pages for List view with custom actions.
Seems like `ActionGroup` always collapsed and does not allow me adding visible buttons in the `ActionBar`.

this fixes the behavior which allows me use `Actionbar` with multiple items in the `ActionGroup` shown with the same key `buttonLabelBehavior`

default value is `collapse` for `ActionBar` anyways

before:
![image](https://github.com/user-attachments/assets/72428ebf-6ca2-4b85-86f6-a3090ab457e6)

after:
![image](https://github.com/user-attachments/assets/62b6f378-a8d5-40d1-b6cc-fbe97b7ef073)
