### PR TITLE
Add pathPrefix support for local storage mode

### DIFF
--- a/packages/keystatic/src/app/path-utils.ts
+++ b/packages/keystatic/src/app/path-utils.ts
@@ -207,7 +207,7 @@ export type FormatInfo = {
 };
 
 export function getPathPrefix(storage: Config['storage']) {
-  if (storage.kind === 'local' || !storage.pathPrefix) {
+  if (!storage.pathPrefix) {
     return undefined;
   }
   return fixPath(storage.pathPrefix) + '/';

--- a/packages/keystatic/src/config.tsx
+++ b/packages/keystatic/src/config.tsx
@@ -99,7 +99,10 @@ export type GitHubConfig<
   singletons?: Singletons;
 } & CommonConfig<Collections, Singletons>;
 
-type LocalStorageConfig = { kind: 'local' };
+type LocalStorageConfig = {
+  kind: 'local';
+  pathPrefix?: string;
+};
 
 export type LocalConfig<
   Collections extends {


### PR DESCRIPTION
This PR aims to solve Thinkmill/keystatic#1431.

It allows using a `pathPrefix` in local mode, which is useful for editing content files outside of the project root for example but is not limited to this use case.

It is designed to have minimal footprint on the rest of the codebase.