### PR TITLE
Improve `Toast` appearance of "neutral" variant

### DIFF
--- a/.changeset/strong-bikes-cheer.md
+++ b/.changeset/strong-bikes-cheer.md
@@ -1,0 +1,5 @@
+---
+'@keystar/ui': patch
+---
+
+Improve "neutral" `Toast` appearance, esp. for dark mode.

--- a/design-system/pkg/src/toast/Toast.tsx
+++ b/design-system/pkg/src/toast/Toast.tsx
@@ -170,11 +170,12 @@ function Toast(props: ToastProps, ref: ForwardedRef<HTMLDivElement>) {
 function useColorScheme() {
   const prefersDark = useMediaQuery('(prefers-color-scheme: dark)');
   const preferred = useProvider();
-  return preferred.colorScheme === 'auto'
-    ? prefersDark
-      ? 'dark'
-      : 'light'
-    : preferred.colorScheme;
+
+  if (preferred.colorScheme === 'auto') {
+    return prefersDark ? 'dark' : 'light';
+  }
+
+  return preferred.colorScheme;
 }
 
 let _Toast = forwardRef(Toast);

--- a/design-system/pkg/src/toast/Toast.tsx
+++ b/design-system/pkg/src/toast/Toast.tsx
@@ -9,12 +9,19 @@ import { checkCircle2Icon } from '@keystar/ui/icon/icons/checkCircle2Icon';
 import { infoIcon } from '@keystar/ui/icon/icons/infoIcon';
 import { alertTriangleIcon } from '@keystar/ui/icon/icons/alertTriangleIcon';
 import { SlotProvider } from '@keystar/ui/slots';
-import { classNames, css, tokenSchema, useStyleProps } from '@keystar/ui/style';
+import {
+  classNames,
+  css,
+  tokenSchema,
+  useMediaQuery,
+  useStyleProps,
+} from '@keystar/ui/style';
 import { Text } from '@keystar/ui/typography';
 import { isReactText } from '@keystar/ui/utils';
 
 import intlMessages from './l10n';
 import { ToastProps } from './types';
+import { useProvider } from '../core';
 
 const ICONS = {
   info: infoIcon,
@@ -44,6 +51,10 @@ function Toast(props: ToastProps, ref: ForwardedRef<HTMLDivElement>) {
   let iconLabel =
     tone && tone !== 'neutral' ? stringFormatter.format(tone) : null;
   let icon = tone && tone !== 'neutral' ? ICONS[tone] : null;
+
+  const colorScheme = useColorScheme();
+  const staticColor =
+    tone === 'neutral' && colorScheme === 'dark' ? 'dark' : 'light';
 
   const handleAction = () => {
     if (onAction) {
@@ -83,7 +94,8 @@ function Toast(props: ToastProps, ref: ForwardedRef<HTMLDivElement>) {
           // tones
           color: tokenSchema.color.foreground.onEmphasis,
           '&[data-tone=neutral]': {
-            background: tokenSchema.color.scale['slate9'],
+            backgroundColor: tokenSchema.color.background.inverse,
+            color: tokenSchema.color.foreground.inverse,
           },
           '&[data-tone=info]': {
             background: tokenSchema.color.background.accentEmphasis,
@@ -135,13 +147,7 @@ function Toast(props: ToastProps, ref: ForwardedRef<HTMLDivElement>) {
               {isReactText(children) ? <Text>{children}</Text> : children}
             </div>
             {actionLabel && (
-              <Button
-                onPress={handleAction}
-                // prominence="low"
-                static="light"
-                // tone="secondary"
-                // staticColor="white"
-              >
+              <Button onPress={handleAction} static={staticColor}>
                 {actionLabel}
               </Button>
             )}
@@ -149,15 +155,26 @@ function Toast(props: ToastProps, ref: ForwardedRef<HTMLDivElement>) {
         </div>
         <div
           className={css({
-            borderInlineStart: `${tokenSchema.size.border.regular} solid #fff3`,
+            borderInlineStart: `${tokenSchema.size.border.regular} solid var(--divider)`,
             paddingInlineStart: tokenSchema.size.space.regular,
+            '--divider': 'color-mix(in srgb, transparent, currentColor 20%)',
           })}
         >
-          <ClearButton static="light" {...closeButtonProps} />
+          <ClearButton static={staticColor} {...closeButtonProps} />
         </div>
       </SlotProvider>
     </div>
   );
+}
+
+function useColorScheme() {
+  const prefersDark = useMediaQuery('(prefers-color-scheme: dark)');
+  const preferred = useProvider();
+  return preferred.colorScheme === 'auto'
+    ? prefersDark
+      ? 'dark'
+      : 'light'
+    : preferred.colorScheme;
 }
 
 let _Toast = forwardRef(Toast);


### PR DESCRIPTION
Implements better handling of "neutral" toast appearance, especially for dark mode.

| Before | After |
|--------|--------|
| <img width="210" height="72" alt="washed-out toast screenshot" src="https://github.com/user-attachments/assets/7f1a1a9c-ec5f-45a6-b680-71cf5f45bde9" /> | <img width="210" height="72" alt="good contrast screenshot" src="https://github.com/user-attachments/assets/ac16e5ec-3857-4f39-9de5-bc211ca9241d" /> | 