### PR TITLE
Remove `getSetCookie` workaround from `@keystatic/astro`

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -31,12 +31,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.3",
-    "@types/react": "^19.0.8",
-    "set-cookie-parser": "^2.5.1"
+    "@types/react": "^19.0.8"
   },
   "devDependencies": {
     "@keystatic/core": "workspace:^",
-    "@types/set-cookie-parser": "^2.4.2",
     "astro": "^5.2.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/astro/src/api.tsx
+++ b/packages/astro/src/api.tsx
@@ -3,7 +3,6 @@ import {
   makeGenericAPIRouteHandler,
 } from '@keystatic/core/api/generic';
 import type { APIContext } from 'astro';
-import { parseString } from 'set-cookie-parser';
 
 export function makeHandler(_config: APIRouteConfig) {
   return async function keystaticAPIRoute(context: APIContext) {
@@ -35,62 +34,7 @@ export function makeHandler(_config: APIRouteConfig) {
       }
     );
     const { body, headers, status } = await handler(context.request);
-    // all this stuff should be able to go away when astro is using a version of undici with getSetCookie
-    let headersInADifferentStructure = new Map<string, string[]>();
-    if (headers) {
-      if (Array.isArray(headers)) {
-        for (const [key, value] of headers) {
-          if (!headersInADifferentStructure.has(key.toLowerCase())) {
-            headersInADifferentStructure.set(key.toLowerCase(), []);
-          }
-          headersInADifferentStructure.get(key.toLowerCase())!.push(value);
-        }
-      } else if (typeof headers.entries === 'function') {
-        for (const [key, value] of headers.entries()) {
-          headersInADifferentStructure.set(key.toLowerCase(), [value]);
-        }
-        if (
-          'getSetCookie' in headers &&
-          typeof headers.getSetCookie === 'function'
-        ) {
-          const setCookieHeaders = (headers as any).getSetCookie();
-          if (setCookieHeaders?.length) {
-            headersInADifferentStructure.set('set-cookie', setCookieHeaders);
-          }
-        }
-      } else {
-        for (const [key, value] of Object.entries(headers)) {
-          headersInADifferentStructure.set(key.toLowerCase(), [value]);
-        }
-      }
-    }
-
-    const setCookieHeaders = headersInADifferentStructure.get('set-cookie');
-    headersInADifferentStructure.delete('set-cookie');
-    if (setCookieHeaders) {
-      for (const setCookieValue of setCookieHeaders) {
-        const { name, value, ...options } = parseString(setCookieValue);
-        const sameSite = options.sameSite?.toLowerCase();
-        context.cookies.set(name, value, {
-          domain: options.domain,
-          expires: options.expires,
-          httpOnly: options.httpOnly,
-          maxAge: options.maxAge,
-          path: options.path,
-          sameSite:
-            sameSite === 'lax' || sameSite === 'strict' || sameSite === 'none'
-              ? sameSite
-              : undefined,
-        });
-      }
-    }
-
-    return new Response(body, {
-      status,
-      headers: [...headersInADifferentStructure.entries()].flatMap(
-        ([key, val]) => val.map((x): [string, string] => [key, x])
-      ),
-    });
+    return new Response(body, { status, headers });
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1062,16 +1062,10 @@ importers:
       '@types/react':
         specifier: ^19.0.8
         version: 19.0.8
-      set-cookie-parser:
-        specifier: ^2.5.1
-        version: 2.6.0
     devDependencies:
       '@keystatic/core':
         specifier: workspace:^
         version: link:../keystatic
-      '@types/set-cookie-parser':
-        specifier: ^2.4.2
-        version: 2.4.3
       astro:
         specifier: ^5.2.5
         version: 5.2.5(@types/node@22.13.1)(idb-keyval@6.2.1)(rollup@4.34.6)(terser@5.19.4)(tsx@4.8.2)(typescript@5.5.3)
@@ -6363,9 +6357,6 @@ packages:
 
   '@types/serve-static@1.15.2':
     resolution: {integrity: sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==}
-
-  '@types/set-cookie-parser@2.4.3':
-    resolution: {integrity: sha512-7QhnH7bi+6KAhBB+Auejz1uV9DHiopZqu7LfR/5gZZTkejJV5nYeZZpgfFoE0N8aDsXuiYpfKyfyMatCwQhyTQ==}
 
   '@types/signal-exit@3.0.1':
     resolution: {integrity: sha512-OSitN9PP9E/c4tlt1Qdj3CAz5uHD9Da5rhUqlaKyQRCX1T7Zdpbk6YdeZbR2eiE2ce+NMBgVnMxGqpaPSNQDUQ==}
@@ -21417,10 +21408,6 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
-      '@types/node': 22.13.1
-
-  '@types/set-cookie-parser@2.4.3':
-    dependencies:
       '@types/node': 22.13.1
 
   '@types/signal-exit@3.0.1': {}


### PR DESCRIPTION
Back when the `getSetCookie` workaround code was added in 2023, Astro used undici 5.x. Since Astro now uses undici v6.x, it seems like we can remove the workaround for `getSetCookies`.

Astro package.json (with undici 5) from the time the workaround was added to @keystatic/astro https://github.com/withastro/astro/blob/71743aeca723e215c0107ecf2e111fdcc8ec7e45/packages/astro/package.json

Astro package.json from today, using undici 7.x:
https://github.com/withastro/astro/blob/main/packages/astro/package.json

And even Astro v4 (legacy) uses undici v6:
https://github.com/withastro/astro/blob/32b14f24cdd3cf2c963c97bca6099ef996f7aadf/packages/astro/package.json

Because undici 7 is now widely used across all Astro versions, it should be safe to make this change. Of course assuming people have somewhat updated Astro versions.

There is a small risk for a breaking change if someone were to update `@keystatic/astro` but not `astro`, so this might be worth treating as a major version bump of `@keystatic/astro` just to be sure.

---

Note: I didn't add a changeset yet, until we decide how to version this change.