### PR TITLE
Fix typo in astro-images documentation

### DIFF
--- a/docs/src/content/pages/recipes/astro-images.mdoc
+++ b/docs/src/content/pages/recipes/astro-images.mdoc
@@ -62,7 +62,7 @@ As long as the image path stored is within the `src/assets` directory, Astro wil
 
 ## Images inside MDX or Markdoc fields
 
-Images uploaded via the [MDX](/docs/fields/mdx) of [Markdoc](/docs/fields/markdoc) fields can be configured the same way as standalone image fields via the `options` object:
+Images uploaded via the [MDX](/docs/fields/mdx) or [Markdoc](/docs/fields/markdoc) fields can be configured the same way as standalone image fields via the `options` object:
 
 ```ts 
 content: fields.mdx({


### PR DESCRIPTION
`or` not `of` in "Images uploaded via the [MDX](/docs/fields/mdx) of [Markdoc](/docs/fields/markdoc) fields...".