### PR TITLE
Using github repo as User-Agent

### DIFF
--- a/packages/keystatic/src/reader/github.ts
+++ b/packages/keystatic/src/reader/github.ts
@@ -46,7 +46,10 @@ export function createGitHubReader<
     const res = await fetch(
       `https://api.github.com/repos/${opts.repo}/git/trees/${ref}?recursive=1`,
       {
-        headers: opts.token ? { Authorization: `Bearer ${opts.token}` } : {},
+        headers: {
+          'User-Agent': opts.repo,
+          ...(opts.token && { Authorization: `Bearer ${opts.token}` }),
+        },
         cache: 'no-store',
       }
     );


### PR DESCRIPTION
I tried to use keystatic github reader when deployed to Cloudflare but always got 403 error. Turned out, API call to github need a valid [User-Agent](https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2022-11-28#user-agent), but Cloudflare workers is not populate that by default like other runtime.

Fix: #1441