### PR TITLE
feat(editor): add support for mailto: and tel: links

### DIFF
--- a/.changeset/mailto-tel-links.md
+++ b/.changeset/mailto-tel-links.md
@@ -1,0 +1,7 @@
+---
+'@keystatic/core': patch
+---
+
+Add support for `mailto:` and `tel:` links in document and markdoc editors
+
+Previously, pasting `mailto:` or `tel:` links would not create a hyperlink because the URL validation only accepted `http://` and `https://` schemes. This change expands the URL pattern to include `mailto:` and `tel:` protocols, allowing users to create email and phone links by pasting.

--- a/packages/keystatic/src/form/fields/document/DocumentEditor/pasting/index.ts
+++ b/packages/keystatic/src/form/fields/document/DocumentEditor/pasting/index.ts
@@ -7,7 +7,7 @@ import { deserializeMarkdown } from './markdown';
 import { base64UrlEncode, base64UrlDecode } from '#base64';
 import { isBlock } from '../editor';
 
-const urlPattern = /https?:\/\//;
+const urlPattern = /^(https?:\/\/|mailto:|tel:)/;
 
 function insertFragmentButDifferent(editor: Editor, nodes: Descendant[]) {
   if (isBlock(nodes[0])) {

--- a/packages/keystatic/src/form/fields/document/DocumentEditor/pasting/links.test.tsx
+++ b/packages/keystatic/src/form/fields/document/DocumentEditor/pasting/links.test.tsx
@@ -131,3 +131,77 @@ test('pasting a url on a selection with a link inside replaces the selection wit
     </editor>
   `);
 });
+
+test('pasting a mailto: link on some text wraps the text with a link', () => {
+  const editor = makeEditor(
+    <editor>
+      <paragraph>
+        <text>
+          contact <anchor />
+          us
+          <focus /> here
+        </text>
+      </paragraph>
+    </editor>
+  );
+  pasteText(editor, 'mailto:hello@example.com');
+  expect(editor).toMatchInlineSnapshot(`
+    <editor>
+      <paragraph>
+        <text>
+          contact 
+        </text>
+        <link
+          @@isInline={true}
+          href="mailto:hello@example.com"
+        >
+          <text>
+            <anchor />
+            us
+            <focus />
+          </text>
+        </link>
+        <text>
+           here
+        </text>
+      </paragraph>
+    </editor>
+  `);
+});
+
+test('pasting a tel: link on some text wraps the text with a link', () => {
+  const editor = makeEditor(
+    <editor>
+      <paragraph>
+        <text>
+          call <anchor />
+          us
+          <focus /> now
+        </text>
+      </paragraph>
+    </editor>
+  );
+  pasteText(editor, 'tel:+1234567890');
+  expect(editor).toMatchInlineSnapshot(`
+    <editor>
+      <paragraph>
+        <text>
+          call 
+        </text>
+        <link
+          @@isInline={true}
+          href="tel:+1234567890"
+        >
+          <text>
+            <anchor />
+            us
+            <focus />
+          </text>
+        </link>
+        <text>
+           now
+        </text>
+      </paragraph>
+    </editor>
+  `);
+});

--- a/packages/keystatic/src/form/fields/markdoc/editor/links.tsx
+++ b/packages/keystatic/src/form/fields/markdoc/editor/links.tsx
@@ -7,7 +7,7 @@ function isValidURL(url: string) {
   return url === sanitizeUrl(url);
 }
 
-const urlPattern = /^https?:\/\//;
+const urlPattern = /^(https?:\/\/|mailto:|tel:)/;
 
 function rangeHasLink(
   $from: ResolvedPos,


### PR DESCRIPTION
Expand URL pattern in document and markdoc editors to accept mailto: and tel: protocols in addition to http:// and https://. This allows users to paste email addresses and phone numbers as hyperlinks.