### PR TITLE
feature: Replace `fast-glob` with `glob` from `node:fs/promises`

### DIFF
--- a/design-system/primitives/package.json
+++ b/design-system/primitives/package.json
@@ -17,7 +17,6 @@
     "@types/lodash": "^4.14.191",
     "color2k": "^2.0.2",
     "emery": "^1.4.1",
-    "fast-glob": "^3.2.12",
     "json5": "^2.2.1",
     "lodash": "^4.17.21",
     "prettier": "^3.0.3",

--- a/design-system/primitives/scripts/build.ts
+++ b/design-system/primitives/scripts/build.ts
@@ -1,4 +1,4 @@
-import glob from 'fast-glob';
+import { glob } from 'fs/promises';
 import fs from 'fs';
 import StyleDictionary from 'style-dictionary';
 
@@ -25,14 +25,18 @@ const build = ({
   });
 };
 
-build({
-  // bring themes to the top of the file, but dark must be after light
-  files: glob.sync('dist/css/**/*.css').sort((a, b) => {
-    if (a.includes('theme')) return -1;
-    if (b.includes('theme')) return 1;
-    if (a.includes('dark')) return 1;
-    if (b.includes('dark')) return -1;
-    return 0;
-  }),
-  destination: 'dist/keystar.css',
-});
+async function main() {
+  build({
+    // bring themes to the top of the file, but dark must be after light
+    files: (await Array.fromAsync(glob('dist/css/**/*.css'))).sort((a, b) => {
+      if (a.includes('theme')) return -1;
+      if (b.includes('theme')) return 1;
+      if (a.includes('dark')) return 1;
+      if (b.includes('dark')) return -1;
+      return 0;
+    }),
+    destination: 'dist/keystar.css',
+  });
+}
+
+main();

--- a/design-system/primitives/scripts/buildTokens.ts
+++ b/design-system/primitives/scripts/buildTokens.ts
@@ -1,4 +1,4 @@
-import glob from 'fast-glob';
+import { glob } from 'fs/promises';
 import type StyleDictionary from 'style-dictionary';
 
 import { KeystarStyleDictionary } from '../KeystarStyleDictionary';
@@ -36,9 +36,9 @@ const getStyleDictionaryConfig: StyleDictionaryConfigGenerator = (
   },
 });
 
-export const buildDesignTokens = (
+export const buildDesignTokens = async (
   buildOptions: ConfigGeneratorOptions
-): void => {
+): Promise<void> => {
   // buildFigma(buildOptions);
 
   /** -----------------------------------
@@ -68,7 +68,7 @@ export const buildDesignTokens = (
   /** -----------------------------------
    * Size tokens
    * ----------------------------------- */
-  const sizeFiles = glob.sync('tokens/size/*');
+  const sizeFiles = await Array.fromAsync(glob('tokens/size/*'));
   for (const file of sizeFiles) {
     KeystarStyleDictionary.extend(
       getStyleDictionaryConfig(
@@ -95,7 +95,7 @@ export const buildDesignTokens = (
   /** -----------------------------------
    * JavaScript token schema
    * ----------------------------------- */
-  const allFiles = glob.sync('tokens/**/*.json5');
+  const allFiles = await Array.fromAsync(glob('tokens/**/*.json5'));
   KeystarStyleDictionary.extend(
     getStyleDictionaryConfig(
       `tokenSchema`,

--- a/packages/keystatic/package.json
+++ b/packages/keystatic/package.json
@@ -199,7 +199,6 @@
     "@types/signal-exit": "^3.0.1",
     "@vitest/pretty-format": "^3.0.5",
     "eslint": "^8.18.0",
-    "fast-glob": "^3.2.12",
     "jest-diff": "^29.0.1",
     "outdent": "^0.8.0",
     "prismjs": "^1.29.0",

--- a/packages/keystatic/test/test-utils.ts
+++ b/packages/keystatic/test/test-utils.ts
@@ -2,7 +2,6 @@ import path from 'path';
 import fs from 'fs/promises';
 import nonPromiseFs from 'fs';
 import outdent from 'outdent';
-import fastGlob from 'fast-glob';
 import onExit from 'signal-exit';
 import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
@@ -66,7 +65,7 @@ expect.addSnapshotSerializer({
 const dirPrintingSymbol = Symbol('dir printing symbol');
 
 export async function getFiles(dir: string, glob: string[] = ['**']) {
-  const files = await fastGlob(glob, { cwd: dir });
+  const files = await Array.fromAsync(fs.glob(glob, { cwd: dir }));
   const filesObj: Record<string, string> = {
     [dirPrintingSymbol]: true,
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,9 +595,6 @@ importers:
       emery:
         specifier: ^1.4.1
         version: 1.4.2
-      fast-glob:
-        specifier: ^3.2.12
-        version: 3.3.1
       json5:
         specifier: ^2.2.1
         version: 2.2.3
@@ -1364,9 +1361,6 @@ importers:
       eslint:
         specifier: ^8.18.0
         version: 8.48.0
-      fast-glob:
-        specifier: ^3.2.12
-        version: 3.3.1
       jest-diff:
         specifier: ^29.0.1
         version: 29.6.4
@@ -9035,10 +9029,6 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-glob@3.3.1:
-    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
-    engines: {node: '>=8.6.0'}
 
   fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
@@ -24826,14 +24816,6 @@ snapshots:
   fast-deep-equal@2.0.1: {}
 
   fast-deep-equal@3.1.3: {}
-
-  fast-glob@3.3.1:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.5
 
   fast-glob@3.3.2:
     dependencies:


### PR DESCRIPTION
This only affects development and testing environments, and works well with Node.js 24.

All tests pass both before and after the change.

The output when building `design-system/primitives` seems OK as well.

Fix #1495 

This change would be even better when paired with #1491 