### PR TITLE
Storybook fix

### DIFF
--- a/design-system/docs/.storybook/main.js
+++ b/design-system/docs/.storybook/main.js
@@ -18,6 +18,16 @@ module.exports = {
     name: '@storybook/nextjs',
     options: {},
   },
+  webpackFinal: async config => ({
+    ...config,
+    resolve: {
+      ...config.resolve,
+      alias: {
+        ...(config.resolve?.alias ?? {}),
+        '@storybook/react-dom-shim': '@storybook/react-dom-shim/dist/react-18',
+      },
+    },
+  }),
   typescript: {
     reactDocgen: false,
   },


### PR DESCRIPTION
Shim to keep Storybook running while avoiding an upgrade. Our version of Storybook `7.x` isn't compatible with React `19.x`.