### PR TITLE
fix(editor): add zIndex for editor popover

### DIFF
--- a/design-system/pkg/src/editor/EditorPopover.tsx
+++ b/design-system/pkg/src/editor/EditorPopover.tsx
@@ -225,6 +225,7 @@ export const DialogElement = forwardRef<
           minHeight: tokenSchema.size.element.regular,
           minWidth: tokenSchema.size.element.regular,
           outline: 0,
+          zIndex: 3
         }),
         props.className
       )}


### PR DESCRIPTION
The popover was rendered beneath the sticky editor toolbar because the toolbar uses `zIndex: 2` while the popover had no explicit stacking order.

Add `zIndex: 3` so the popover appears above the toolbar.

Fixes #1443