### PR TITLE
fix(collection table): support conditional fields in columns schema

### DIFF
--- a/packages/keystatic/src/app/CollectionPage.tsx
+++ b/packages/keystatic/src/app/CollectionPage.tsx
@@ -570,6 +570,12 @@ function CollectionTable(
 
                     if (val == null) {
                       val = undefined;
+                    } else if (
+                      collection.schema[column].kind === 'conditional' &&
+                      typeof val === 'object' &&
+                      'discriminant' in val
+                    ) {
+                      val = val.discriminant + '';
                     } else {
                       val = val + '';
                     }

--- a/packages/keystatic/src/config.tsx
+++ b/packages/keystatic/src/config.tsx
@@ -1,7 +1,12 @@
 import { ColorScheme } from '@keystar/ui/types';
 import { ReactElement } from 'react';
 
-import { ComponentSchema, FormField, SlugFormField } from './form/api';
+import {
+  ComponentSchema,
+  ConditionalField,
+  FormField,
+  SlugFormField,
+} from './form/api';
 import type { Locale } from './app/l10n/locales';
 import { RepoConfig } from './app/repo-config';
 
@@ -189,6 +194,7 @@ export function collection<
             string | number | boolean | Date | null | undefined
           >
         | SlugFormField<any, any, any, string>
+        | ConditionalField<any, any>
         ? K & string
         : never;
     }[keyof Schema][];


### PR DESCRIPTION
## Summary

This PR fixes two issues when using `fields.conditional()` in collection `columns`:

1. Conditional fields were rejected by TypeScript when referenced in a collection's `columns` array.
2. Conditional field values were rendered as `[object Object]` in the collection list view.

## Changes

### TypeScript support

Updated the `collection()` column type definition to allow `ConditionalField` entries in addition to the previously supported field types.

### Runtime rendering

When rendering collection table values, conditional field values are now detected and their `discriminant` value is displayed instead of coercing the entire object to a string.

Before:
`[object Object]`

After:
`true` or `false`

(or the selected discriminant value for select-based conditional fields).

## Testing

Tested with conditional fields using:

- Checkbox discriminants (`true` / `false`)
- Select discriminants with multiple options

Verified that:

- Conditional fields can be added to `columns` without TypeScript errors.
- Collection list views render the selected discriminant value instead of `[object Object]`.
- Existing supported column types continue to behave as before.

## Implementation Notes

While investigating this issue, it became apparent that collection column rendering currently assumes that all column values have a scalar preview representation.

Conditional fields are one of the first structured field types where this assumption breaks. Their stored value is an object, which results in `[object Object]` being rendered when the value is coerced to a string.

For this fix, the conditional field's discriminant value is used as the column preview because it provides a meaningful scalar representation of the selected condition.

More generally, it may be safer for collection columns to explicitly support only scalar-like field types (and other field types that provide a well-defined preview value) rather than attempting to stringify arbitrary complex structures such as `object`, `image`, `file`, `markdoc`, or `mdx` fields.

A more comprehensive long-term solution could be a field-level preview resolver that allows each field type to define how it should be represented in collection columns. However, that appears to be a broader design change and is outside the scope of this PR.

## Related

Fixes #1396