### PR TITLE
fix(astro): read Cloudflare env via cloudflare:workers, not removed locals.runtime.env

### DIFF
--- a/.changeset/proud-jars-fix.md
+++ b/.changeset/proud-jars-fix.md
@@ -1,0 +1,5 @@
+---
+"@keystatic/astro": patch
+---
+
+Fix GitHub-mode API routes crashing under `@astrojs/cloudflare` on Astro v6+ with `Astro.locals.runtime.env has been removed in Astro v6`. Reads Cloudflare's runtime env via a dynamic `cloudflare:workers` import instead, falling back to the previous `context.locals.runtime.env` shape for other adapters/older Astro versions.

--- a/packages/astro/src/api.tsx
+++ b/packages/astro/src/api.tsx
@@ -5,9 +5,37 @@ import {
 import type { APIContext } from 'astro';
 import { parseString } from 'set-cookie-parser';
 
+// `Astro.locals.runtime.env` was removed in Astro v6+; the platform now
+// recommends reading Cloudflare's runtime env via a dynamic
+// `cloudflare:workers` import instead. Falls back to the old
+// `context.locals.runtime.env` shape (still used by some other adapters/
+// older Astro versions) and finally to `undefined` so this stays adapter-
+// agnostic - this file isn't Cloudflare-specific.
+async function getCloudflareEnvVars(
+  context: APIContext
+): Promise<Record<string, string | undefined> | undefined> {
+  try {
+    // @ts-expect-error - 'cloudflare:workers' is only a valid specifier
+    // under the Cloudflare adapter; no ambient type for it here since this
+    // package isn't Cloudflare-specific.
+    const cf: any = await import(/* @vite-ignore */ 'cloudflare:workers');
+    if (cf?.env) return cf.env;
+  } catch {
+    // not running under a Cloudflare adapter that supports this import
+  }
+  try {
+    // Older Astro versions / other adapters may still expose this shape.
+    // On Astro v6+, `locals.runtime` throws when accessed if it's not
+    // actually present, so this has to be its own try/catch too.
+    return (context.locals as any)?.runtime?.env;
+  } catch {
+    return undefined;
+  }
+}
+
 export function makeHandler(_config: APIRouteConfig) {
   return async function keystaticAPIRoute(context: APIContext) {
-    const envVarsForCf = (context.locals as any)?.runtime?.env;
+    const envVarsForCf = await getCloudflareEnvVars(context);
     const handler = makeGenericAPIRouteHandler(
       {
         ..._config,


### PR DESCRIPTION
## Summary

Fixes #1554. GitHub-mode API routes (`/api/keystatic/github/*`) crash with a 500 under `@astrojs/cloudflare` on Astro 6+ — `Astro.locals.runtime.env` was removed, and `keystatic-astro-api.js` still reads it.

Confirmed the crash both in `astro dev` and a real deployed Cloudflare Worker (via `wrangler tail`), and confirmed this fix resolves it in both, on our own project (Astro 7.0.9, `@astrojs/cloudflare` 14.1.3, `wrangler` 4.110.0).

## What changed

`packages/astro/src/api.tsx` now reads the Cloudflare runtime env via a dynamic `cloudflare:workers` import — exactly what the removed API's own error message recommends — instead of `context.locals.runtime.env`. Falls back to the old shape (in its own try/catch, since that access itself throws on Astro v6+) for other adapters or older Astro versions, so the fix stays adapter-agnostic rather than hardcoding a Cloudflare-only assumption into a shared file.

Also flagged in the issue but not attempted here: the GitHub App creation wizard (`/keystatic` guided setup) has a separate, unrelated bug under this same adapter combo (`module is not defined`, React/workerd bundling) — didn't touch that in this PR, wanted to keep this one focused on the API crash.

## Test plan

- [x] Reproduced the original crash against our own deployed Worker via `wrangler tail`
- [x] Applied the equivalent fix locally via `patch-package` first, confirmed it resolves the crash (replaced with a clean "missing credentials" error, then a working OAuth redirect once credentials were set) both in `astro dev` and the real deployment
- [x] Ported the fix to this repo's actual TypeScript source (not just the compiled output) and isolated-checked it with `tsc` for syntax/type correctness
- [ ] Haven't run this repo's own test suite / full monorepo build — happy to address any feedback from CI

Added a changeset (patch bump for `@keystatic/astro`).