### PR TITLE
Remove optionality in react-aria/react-stately/@keystar/ui peer deps

### DIFF
--- a/.changeset/few-stingrays-shake.md
+++ b/.changeset/few-stingrays-shake.md
@@ -1,0 +1,6 @@
+---
+'@keystatic/core': patch
+'@keystar/ui': patch
+---
+
+Make `react-aria`, `react-stately` and `@keystar/ui` non-optional peer dependencies + normal dependencies instead of optional peer dependencies + normal dependencies to fix installing with pnpm

--- a/design-system/pkg/package.json
+++ b/design-system/pkg/package.json
@@ -1516,12 +1516,6 @@
   "peerDependenciesMeta": {
     "next": {
       "optional": true
-    },
-    "react-aria": {
-      "optional": true
-    },
-    "react-stately": {
-      "optional": true
     }
   },
   "imports": {

--- a/packages/keystatic/package.json
+++ b/packages/keystatic/package.json
@@ -210,17 +210,6 @@
     "react-dom": "^18.2.0 || ^19.0.0",
     "react-stately": "catalog:"
   },
-  "peerDependenciesMeta": {
-    "@keystar/ui": {
-      "optional": true
-    },
-    "react-aria": {
-      "optional": true
-    },
-    "react-stately": {
-      "optional": true
-    }
-  },
   "preconstruct": {
     "entrypoints": [
       "index.ts",


### PR DESCRIPTION
This should fix installing with pnpm which broke from #1557. These dependencies are still optional for consumers to install. It seems that pnpm unlike npm and yarn won't install dependencies specified in dependencies + optional peer dependencies so this makes them dependencies + non-optional peer dependencies which works correctly.