### PR TITLE
Fix pt-BR translations for `save` and git terms

### DIFF
--- a/.changeset/pt-br-translation-fixes.md
+++ b/.changeset/pt-br-translation-fixes.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Fix pt-BR (Brazilian Portuguese) translations: `save` said "Guardar" (European Portuguese) and the git terms were mistranslated as unrelated words

--- a/packages/keystatic/src/app/l10n/pt-BR/branchName/index.json
+++ b/packages/keystatic/src/app/l10n/pt-BR/branchName/index.json
@@ -1,6 +1,6 @@
 {
   "key": "branchName",
-  "value": "Nome da filial",
+  "value": "Nome do branch",
   "notes": "",
   "type": "git-related"
 }

--- a/packages/keystatic/src/app/l10n/pt-BR/branches/index.json
+++ b/packages/keystatic/src/app/l10n/pt-BR/branches/index.json
@@ -1,6 +1,6 @@
 {
   "key": "branches",
-  "value": "Galhos",
+  "value": "Branches",
   "notes": "",
   "type": "git-related"
 }

--- a/packages/keystatic/src/app/l10n/pt-BR/createPullRequest/index.json
+++ b/packages/keystatic/src/app/l10n/pt-BR/createPullRequest/index.json
@@ -1,6 +1,6 @@
 {
   "key": "createPullRequest",
-  "value": "Criar solicitação pull",
+  "value": "Criar pull request",
   "notes": "",
   "type": "git-related"
 }

--- a/packages/keystatic/src/app/l10n/pt-BR/currentBranch/index.json
+++ b/packages/keystatic/src/app/l10n/pt-BR/currentBranch/index.json
@@ -1,6 +1,6 @@
 {
   "key": "currentBranch",
-  "value": "filial atual",
+  "value": "branch atual",
   "notes": "",
   "type": "git-related"
 }

--- a/packages/keystatic/src/app/l10n/pt-BR/defaultBranch/index.json
+++ b/packages/keystatic/src/app/l10n/pt-BR/defaultBranch/index.json
@@ -1,6 +1,6 @@
 {
   "key": "defaultBranch",
-  "value": "ramo padrão",
+  "value": "branch padrão",
   "notes": "",
   "type": "git-related"
 }

--- a/packages/keystatic/src/app/l10n/pt-BR/deleteBranch/index.json
+++ b/packages/keystatic/src/app/l10n/pt-BR/deleteBranch/index.json
@@ -1,6 +1,6 @@
 {
   "key": "deleteBranch",
-  "value": "Excluir ramificação",
+  "value": "Excluir branch",
   "notes": "",
   "type": "git-related"
 }

--- a/packages/keystatic/src/app/l10n/pt-BR/newBranch/index.json
+++ b/packages/keystatic/src/app/l10n/pt-BR/newBranch/index.json
@@ -1,6 +1,6 @@
 {
   "key": "newBranch",
-  "value": "Nova filial",
+  "value": "Novo branch",
   "notes": "",
   "type": "git-related"
 }

--- a/packages/keystatic/src/app/l10n/pt-BR/otherBranches/index.json
+++ b/packages/keystatic/src/app/l10n/pt-BR/otherBranches/index.json
@@ -1,6 +1,6 @@
 {
   "key": "otherBranches",
-  "value": "Outros ramos",
+  "value": "Outros branches",
   "notes": "",
   "type": "git-related"
 }

--- a/packages/keystatic/src/app/l10n/pt-BR/save/index.json
+++ b/packages/keystatic/src/app/l10n/pt-BR/save/index.json
@@ -1,6 +1,6 @@
 {
   "key": "save",
-  "value": "Guardar",
+  "value": "Salvar",
   "notes": "",
   "type": "global"
 }


### PR DESCRIPTION
The Brazilian Portuguese (`pt-BR`) strings look machine-translated, and a few land on words that mean something else entirely to a Brazilian reader. The most visible one is the primary action button.

| key | before | after | why |
|---|---|---|---|
| `save` | Guardar | Salvar | "Guardar" is European Portuguese. Brazilians say "Salvar", and this is the main action button in the editor. |
| `branches` | Galhos | Branches | "Galho" is a tree branch (the wooden kind). |
| `branchName` | Nome da filial | Nome do branch | "Filial" is a company branch office. |
| `currentBranch` | filial atual | branch atual | same |
| `newBranch` | Nova filial | Novo branch | same |
| `defaultBranch` | ramo padrão | branch padrão | "Ramo" is a field or line of work. |
| `otherBranches` | Outros ramos | Outros branches | same |
| `deleteBranch` | Excluir ramificação | Excluir branch | "Ramificação" is understandable but not what developers say. |
| `createPullRequest` | Criar solicitação pull | Criar pull request | "Solicitação pull" is a literal translation nobody uses. |

On the git vocabulary: Brazilian developers use the English terms ("branch", "pull request") in everyday speech, including in Portuguese-language documentation and tooling. Translating them produces text that is harder to follow than leaving them alone, which is why this PR keeps them in English rather than picking different Portuguese words.

Only the source JSON files under `packages/keystatic/src/app/l10n/pt-BR/` are changed, since `index.js` is generated at build time. A patch changeset is included.

For context on how this came up: I maintain two Keystatic Cloud panels used by non-technical clients in Brazil, and I am currently patching these strings locally. Happy to adjust any of the choices above.