### PR TITLE
Add `files` to `@keystar/ui` `package.json`

### DIFF
--- a/design-system/pkg/package.json
+++ b/design-system/pkg/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/Thinkmill/keystatic/",
     "directory": "design-system/pkg"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build-icons": "node build-icons.ts && cd ../.. && pnpm preconstruct fix"
   },


### PR DESCRIPTION
I think pnpm 11 changed how they pack since at least the `pkg.pr.new` tarballs don't have the dist files