### PR TITLE
Update to minimatch@10

### DIFF
--- a/.changeset/nasty-peaches-confess.md
+++ b/.changeset/nasty-peaches-confess.md
@@ -1,0 +1,5 @@
+---
+'@keystatic/core': patch
+---
+
+Update to minimatch@10

--- a/packages/keystatic/package.json
+++ b/packages/keystatic/package.json
@@ -151,7 +151,7 @@
     "micromark-extension-gfm-strikethrough": "^2.0.0",
     "micromark-extension-gfm-table": "^2.0.0",
     "micromark-extension-mdxjs": "^3.0.0",
-    "minimatch": "^9.0.3",
+    "minimatch": "^10.2.6",
     "partysocket": "^0.0.22",
     "prosemirror-commands": "^1.5.1",
     "prosemirror-history": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -944,8 +944,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       minimatch:
-        specifier: ^9.0.3
-        version: 9.0.3
+        specifier: ^10.2.6
+        version: 10.2.6
       partysocket:
         specifier: ^0.0.22
         version: 0.0.22


### PR DESCRIPTION
Closes #1568

Note this is not actually a security vulnerability since no untrusted globs are passed to minimatch, this is just convenient to get rid of the warning.